### PR TITLE
Add support for Martini 2.2 P

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -71,10 +71,13 @@ def read_mapping(path):
         The mapping. The keys of the dictionary are the atom names in
         the origin force field; the values are lists of atom names in the
         destination force field, the origin atom is assigned to.
+    extra: list
+        Unmapped atoms to be added.
     """
-    from_ff = ['universal', ]
-    to_ff = ['martini22', ]
+    from_ff = []
+    to_ff = []
     mapping = {}
+    extra = []
     
     with open(str(path)) as infile:
         for line_number, line in enumerate(infile, start=1):
@@ -90,8 +93,21 @@ def read_mapping(path):
             elif context == 'atoms':
                 _, from_atom, *to_atoms = line.split()
                 mapping[(0, from_atom)] = [(0, to_atom) for to_atom in to_atoms]
+            elif context in ['from', 'mapping']:
+                from_ff.extend(cleaned.split())
+            elif context == 'to':
+                to_ff.append(cleaned)
+            elif context == 'extra':
+                extra.extend(cleaned.split())
 
-    return name, from_ff, to_ff, mapping
+    # If not specified in the file, we assume the mapping is for
+    # universal -> martini22
+    if not from_ff:
+        from_ff = ['universal', ]
+    if not to_ff:
+        to_ff = ['martini22', ]
+
+    return name, from_ff, to_ff, mapping, extra
 
 
 def read_mapping_directory(directory):
@@ -121,12 +137,12 @@ def read_mapping_directory(directory):
     directory = Path(directory)
     mappings = {}
     for path in directory.glob('**/*.map'):
-        name, all_from_ff, all_to_ff, mapping = read_mapping(path)
+        name, all_from_ff, all_to_ff, mapping, extra = read_mapping(path)
         for from_ff in all_from_ff:
             mappings[from_ff] = mappings.get(from_ff, {})
             for to_ff in all_to_ff:
                 mappings[from_ff][to_ff] = mappings[from_ff].get(to_ff, {})
-                mappings[from_ff][to_ff][name] = mapping
+                mappings[from_ff][to_ff][name] = (mapping, extra)
     return mappings
 
 
@@ -167,9 +183,10 @@ def martinize(system, mappings, to_ff, delete_unknown=False):
     vermouth.DoMapping(mappings=mappings,
                        to_ff=to_ff,
                        delete_unknown=delete_unknown).run_system(system)
-    vermouth.DoAverageBead().run_system(system)
+    vermouth.DoAverageBead(ignore_missing_graphs=True).run_system(system)
     vermouth.ApplyBlocks().run_system(system)
     vermouth.DoLinks().run_system(system)
+    vermouth.LocateChargeDummies().run_system(system)
     return system
 
 

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -1,0 +1,795 @@
+[ macros ]
+protein_resnames "GLY|ALA|CYS|VAL|LEU|ILE|MET|PRO|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
+
+;;; GLYCINE
+
+[ moleculetype ]
+; molname       nrexcl
+GLY                1			
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5   1     GLY    BB     1      0      
+
+
+;;; ALANINE
+
+[ moleculetype ]
+; molname       nrexcl
+ALA                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P4    1     ALA    BB     1      0     ; ALA slightly less polar 
+
+
+;;; CYSTEINE
+
+[ moleculetype ]
+; molname       nrexcl
+CYS                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5     1   CYS    BB     1      0
+ 2   C5     1   CYS    SC1    2      0     
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.31     7500        
+
+
+;;; VALINE
+
+[ moleculetype ]
+; molname       nrexcl
+VAL                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5   1     VAL     BB     1      0    
+ 2   C2   1     VAL     SC1    2      0    
+
+[constraints]
+;  i     j   funct   length  
+   1     2    1       0.265       
+
+
+;;; LEUCINE
+
+[ moleculetype ]
+; molname       nrexcl
+LEU                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5   1     LEU     BB     1      0    
+ 2   C1   1     LEU     SC1    2      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.33     7500    
+
+
+;;; ISOLEUCINE
+
+[ moleculetype ]
+; molname       nrexcl
+ILE                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5   1     ILE     BB     1      0    
+ 2   C1   1     ILE     SC1    2      0    
+
+[constraints]
+;  i     j   funct   length  
+   1     2    1       0.31       
+
+
+;;; METHIONINE
+
+[ moleculetype ]
+; molname       nrexcl
+MET                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5   1     MET     BB     1      0    
+ 2   C5   1     MET     SC1    2      0     
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.40     2500
+
+
+;;; PROLINE
+
+[ moleculetype ]
+; molname       nrexcl
+PRO                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P4   1     PRO     BB     1      0    
+ 2   C3   1     PRO     SC1    2      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+  1     2    1       0.30     7500
+
+
+;;; ASPARAGINE
+
+[ moleculetype ]
+; molname       nrexcl
+ASN                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge  mass
+ 1   P5    1     ASN     BB     1      0  72
+ 2   P5    1     ASN     SC1    2      0   0
+ 3   D     1     ASN     SC2    3  +0.46  36 {"charge_dummy": 0.14}
+ 4   D     1     ASN     SC3    4  -0.46  36 {"charge_dummy": 0.14}
+
+[virtual_sites2]
+; Site from       funct a
+   2     3    4   1     0.5
+
+[ edges ]
+SC2 SC1
+SC3 SC1 
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.32     5000
+
+[constraints]
+;  i     j   funct   length 
+   3     4    1       0.28   
+
+;;; GLUTAMINE
+
+[ moleculetype ]
+; molname       nrexcl
+GLN                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge  mass
+ 1   P5    1     GLN     BB     1      0  72
+ 2   P4    1     GLN     SC1    2      0   0
+ 3   D     1     GLN     SC2    3  +0.46  36 {"charge_dummy": 0.14}
+ 4   D     1     GLN     SC3    4  -0.46  36 {"charge_dummy": 0.14}
+
+[virtual_sites2]
+; Site from       funct a
+   2     3    4   1     0.5
+
+[ edges ]
+SC2 SC1
+SC3 SC1 
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.40     5000     
+
+[constraints]
+;  i     j   funct   length 
+   3     4    1       0.28   
+
+;;; ASPARTATE
+
+[ moleculetype ]
+; molname       nrexcl
+ASP                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge  mass
+ 1   P5     1     ASP     BB     1     0  72
+ 2   Qa     1     ASP     SC1    2  -1.0  36
+ 3   D      1     ASP     SC2    3  -1.0  36 {"charge_dummy": 0.11}
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.32     7500
+
+[constraints]
+;  i     j   funct   length 
+   2     3    1       0.11   
+
+;;; ASPARTATE - NEUTRAL FORM
+
+[ moleculetype ]
+; molname       nrexcl
+ASP0               1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5     1     ASP0    BB     1      0    
+ 2   P3     1     ASP0    SC1    2      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.32     7500
+
+
+;;; GLUTAMATE
+
+[ moleculetype ]
+; molname       nrexcl
+GLU                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge mass
+ 1   P5     1     GLU     BB     1     0 72
+ 2   Qa     1     GLU     SC1    2  -1.0 36 
+ 3   D      1     GLU     SC2    3  -1.0 36  {"charge_dummy": 0.11}
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.40     5000     
+
+[constraints]
+;  i     j   funct   length 
+   2     3    1       0.11   
+
+
+;;; GLUTAMATE - NEUTRAl FORM
+
+[ moleculetype ]
+; molname       nrexcl
+GLU0               1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5     1     GLU0    BB     1      0    
+ 2   P1     1     GLU0    SC1    2      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.40     5000    
+
+;;; THREONINE
+
+[ moleculetype ]
+; molname       nrexcl
+THR                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5     1     THR     BB     1      0    72
+2   Nda    1     THR     SC1    2      0    0
+3   D      1     THR     SC2    3  +0.31    36 {"charge_dummy": 0.14}
+4   D      1     THR     SC3    4  -0.31    36 {"charge_dummy": 0.14}
+
+[virtual_sites2]
+; Site from       funct a
+   2     3    4   1     0.5
+
+[ edges ]
+SC2 SC1
+SC3 SC1 
+
+[ bonds ]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length force.c.
+   1     2    1       0.26  9000
+
+[constraints]
+;  i     j   funct   length 
+   3     4    1       0.28   
+
+;;; SERINE
+
+[ moleculetype ]
+; molname       nrexcl
+SER                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge  mass
+1   P5     1    SER     BB     1      0   72
+2   P1     1    SER     SC1    2      0    0
+3   D      1    SER     SC2    3  +0.40   36 {"charge_dummy": 0.14}
+4   D      1    SER     SC3    4  -0.40   36 {"charge_dummy": 0.14}
+
+[virtual_sites2]
+; Site from       funct a
+   2     3    4   1     0.5
+
+[ edges ]
+SC2 SC1
+SC3 SC1 
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.25     7500
+
+[constraints]
+;  i     j   funct   length 
+   3     4    1       0.28   
+
+;;; LYSINE 
+
+[ moleculetype ]
+; molname       nrexcl
+LYS                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge mass
+ 1   P5    1     LYS     BB     1      0 72
+ 2   C3    1     LYS     SC1    2      0 72 
+ 3   Qd    1     LYS     SC2    3      0 36
+ 4   D     1     LYS     SC3    4    1.0 36 {"charge_dummy": 0.11}
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.33     5000      
+   2     3    1       0.28     5000  
+
+[constraints]
+;  i     j   funct   length 
+   3     4    1       0.11   
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   180.000    25.0      
+
+
+;;; LYSINE - NEUTRAL FORM
+
+[ moleculetype ]
+; molname       nrexcl
+LYS0               1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1   P5    1     LYS     BB     1      0    
+ 2   C3    1     LYS     SC1    2      0    
+ 3   P1    1     LYS     SC2    3      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.33     5000      
+   2     3    1       0.28     5000  
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   180.000    25.0      
+
+
+;;; ARGININE 
+
+[ moleculetype ]
+; molname       nrexcl
+ARG                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge  mass
+1   P5     1     ARG     BB     1      0  72  
+2   N0     1     ARG     SC1    2      0  72
+3   Qd     1     ARG     SC2    3      0  36
+4   D      1     ARG     SC3    4    1.0  36 {"charge_dummy": 0.11}
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.33     5000   
+   2     3    1       0.34     5000  
+
+[constraints]
+;  i     j   funct   length 
+   3     4    1       0.11   
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   180.000    25.0      
+
+
+;; ARGININE - NEUTRAL FORM
+
+[ moleculetype ]
+; molname       nrexcl
+ARG0               1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5     1     ARG0    BB     1      0    
+2   N0     1     ARG0    SC1    2      0    
+3   P4     1     ARG0    SC2    3      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.33     5000       
+   2     3    1       0.34     5000     
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   180.000    25.0      
+
+
+;;; HISTIDINE 
+
+[ moleculetype ]
+;molname       nrexcl
+HIS                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5     1     HIS     BB     1      0    
+2   SC4    1     HIS     SC1    2    0    ; three side chains in triangle
+3   SP1    1     HIS     SC2    3    0    ; configuration, mimicking
+4   SP1    1     HIS     SC3    4    0    ; ring structure
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.32     7500 
+
+[constraints]
+;  i     j   funct   length  
+   2     3    1       0.27    
+   2     4    1       0.27   
+   3     4    1       0.27  
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   150.000   50.0  
+    1     2    4       2   150.000   50.0 
+
+[dihedrals]
+;  i     j    k    l   funct   angle  force.c.
+   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+
+;;; HISTIDINE, charged.
+
+[ moleculetype ]
+;molname       nrexcl
+HISH               1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5     1     HIS     BB     1    0    72
+2   SC4    1     HIS     SC1    2    0    72 ; three side chains in triangle
+3   SP1    1     HIS     SC2    3    0    72 ; configuration, mimicking
+4   SQd    1     HIS     SC3    4    0    36 ; ring structure
+5   D      1     HIS     SC4    5  1.0    36 {"charge_dummy": 0.11}
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.32     7500 
+
+[constraints]
+;  i     j   funct   length  
+   2     3    1       0.27    
+   2     4    1       0.27   
+   3     4    1       0.27  
+   4     5    1       0.11  
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   150.000   50.0  
+    1     2    4       2   150.000   50.0 
+
+[dihedrals]
+;  i     j    k    l   funct   angle  force.c.
+   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+
+
+;;; PHENYLALANINE
+
+[ moleculetype ]
+; molname       nrexcl
+PHE                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5     1     PHE     BB     1    0
+2   SC5    1     PHE     SC1    2    0    ; three side chains in triangle
+3   SC5    1     PHE     SC2    3    0    ; configuration, mimicking
+4   SC5    1     PHE     SC3    4    0    ; ring structure
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.31     7500 	
+
+[constraints]
+;  i     j   funct   length  
+   2     3    1       0.27     
+   2     4    1       0.27    
+   3     4    1       0.27   
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   150.000   50.0  
+    1     2    4       2   150.000   50.0 
+
+[dihedrals]
+;  i     j    k    l   funct   angle  force.c.
+   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+
+
+;;; TYROSINE
+
+[ moleculetype ]
+; molname       nrexcl
+TYR                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5     1     TYR     BB     1    0
+2   SC4    1     TYR     SC1    2    0  
+3   SC4    1     TYR     SC2    3    0 
+4   SP1    1     TYR     SC3    4    0  
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.32     5000 	
+
+[constraints]
+;  i     j   funct   length  
+   2     3    1       0.27     
+   2     4    1       0.27    
+   3     4    1       0.27   
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+    1     2    3       2   150.000   50.0  
+    1     2    4       2   150.000   50.0 
+
+[dihedrals]
+;  i     j    k    l   funct   angle  force.c.
+   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+
+
+;;; TRYPTOPHAN
+
+[ moleculetype ]
+;molname       nrexcl
+TRP                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   P5       1     TRP     BB     1    0
+2   SC4      1     TRP     SC1    2    0    
+3   SNd      1     TRP     SC2    3    0
+4   SC5      1     TRP     SC3    4    0
+5   SC5      1     TRP     SC4    5    0
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+   1     2    1       0.30     5000 	
+
+[constraints]
+;  i     j   funct   length  
+   2     3    1       0.27     
+   3     4    1       0.27    
+   2     4    1       0.27   
+   3     5    1       0.27    
+   4     5    1       0.27   
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+   1     2    3       2   210.000   50.0 
+   1     2    4       2   90.000    50.0  
+
+[dihedrals]
+;  i     j    k    l   funct   angle  force.c.
+   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+   2     3    5    4       2    0.0    200.0    ; to keep plane fixed
+
+
+;;; Links
+
+;; Links for COIL. We apply them first as coil is the default.
+[ link ]
+resname $protein_resnames
+[ bonds ]
+BB +BB 1 0.350 1250 {"group": "Backbone bonds"}
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB +BB 2 119.2 150 {"group": "BBB angles"}
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB  BB  SC1  2 100 25 {"group": "BBS angles"}
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+#meta {"group": "First SBB"}
+SC1 BB +BB 2 100 25
+[ non-edges ]
+BB -BB
+
+;; Links for the different secondary structures.
+;; Set the bead type as a function of the secondary structures.
+;; We first replace for all amino acids, including for PRO and ALA that are
+;; special.
+[ link ]
+resname $protein_resnames
+[ atoms ]
+BB {"cgsecstruct": "T|3|E", "replace": {"atype": "Nda"}}
+
+[ link ]
+resname $protein_resnames
+[ atoms ]
+BB {"cgsecstruct": "2", "replace": {"atype": "Na"}}
+
+[ link ]
+resname $protein_resnames
+[ atoms ]
+BB {"cgsecstruct": "1", "replace": {"atype": "Nd"}}
+
+[ link ]
+resname $protein_resnames
+[ atoms ]
+BB {"cgsecstruct": "H|F", "replace": {"atype": "N0"}}
+
+;; Fix bead types for ALA and PRO.
+[ link ]
+resname "ALA|PRO|HYP"
+[ atoms ]
+BB {"cgsecstruct": "S", "replace": {"atype": "P4"}}
+
+[ link ]
+resname "ALA|PRO|HYP"
+[ atoms ]
+BB {"cgsecstruct": "T|3|2|1|E", "replace": {"atype": "N0"}}
+
+[ link ]
+resname "ALA|PRO|HYP"
+[ atoms ]
+BB {"cgsecstruct": "H|F", "replace": {"atype": "C5"}}
+
+[ link ]
+resname "PRO"
+[ atoms ]
+BB {"cgsecstruct": "2", "replace": {"atype": "Na"}}
+
+;; Setup the bonds. We only define those that are different from coil.
+[ link ]
+resname $protein_resnames
+cgsecstruct "H|1|2|3"
+[ constraints ]
+BB +BB 1 0.310 
+[ !bonds ]
+BB +BB
+
+;; Setup the angles. We only define those that are different from coil.
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB {"cgsecstruct": "H|1|2|3"} +BB 2 96 700
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB {"cgsecstruct": "S"} +BB 2 130 20
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB {"cgsecstruct": "T"} +BB 2 100 20
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB {"cgsecstruct": "E"} +BB 2 134 25
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB {"cgsecstruct": "F"} +BB 2 119.2 150
+
+[ link ]
+resname "PRO|HYP"
+[ angles ]
+-BB BB {"cgsecstruct": "H|1|2|3"} +BB 2 98 100
+
+[ link ]
+resname "PRO|HYP"
+[ angles ]
+-BB BB {"cgsecstruct": "S"} +BB 2 130 25
+
+[ link ]
+resname "PRO|HYP"
+[ angles ]
+-BB BB {"cgsecstruct": "T"} +BB 2 100 25
+
+[ link ]
+resname "PRO|HYP"
+[ angles ]
+-BB BB {"cgsecstruct": "E"} +BB 2 134 25
+
+;; Backbone dihedrals.
+[ link ]
+resname $protein_resnames
+cgsecstruct "H|1|2|3"
+[ dihedrals ]
+-BB BB +BB ++BB 1 -120 400 1
+
+[ link ]
+resname $protein_resnames
+cgsecstruct "F"
+[ dihedrals ]
+-BB BB  +BB ++BB 1 90.7 100 1
+
+;; Local elastic network to stabilize extented regions of proteins.
+[ link ]
+resname $protein_resnames
+cgsecstruct "E"
+[ edges ]
+BB +BB
++BB ++BB
+++BB +++BB
+[ bonds ]
+BB ++BB 1 0.640 2500 {"group": "Short elastic bonds for extended regions", "edge": false}
++BB +++BB 1 0.640 2500 {"group": "Short elastic bonds for extended regions", "edge": false}
+BB +++BB 1 0.970 2500 {"group": "Long elastic bonds for extended regions", "edge": false}
+
+; Use dihedrals rather than an elastic network for extended regions of proteins.
+[ link ]
+resname $protein_resnames
+cgsecstruct "E"
+[ molmeta ]
+extdih true
+[ dihedrals ]
+-BB BB +BB ++BB 1 0 10 1
+
+[ link ]
+resname $protein_resnames
+cgsecstruct "E"
+[ molmeta ]
+extdih true
+[ edges ]
+BB +BB
++BB ++BB
+++BB +++BB
+[ !bonds ]
+BB ++BB 1 0.640 2500
++BB +++BB 1 0.640 2500
+BB +++BB 1 0.970 2500
+
+;; Protein terminii. These links should be applied last.
+[ link ]
+[ atoms ]
+BB {"replace": {"atype": "Qd", "charge": 1}}
+[ non-edges ]
+BB -BB
+
+[ link ]
+[ atoms ]
+BB {"replace": {"atype": "Qa", "charge": -1}}
+[ non-edges ]
+BB +BB
+

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -1,5 +1,6 @@
 [ macros ]
-protein_resnames "GLY|ALA|CYS|VAL|LEU|ILE|MET|PRO|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
+protein_resnames "GLY|ALA|CYS|VAL|LEU|ILE|MET|PRO|HYP|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
+protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
 
 ;;; GLYCINE
 
@@ -132,17 +133,17 @@ ASN                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge  mass
  1   P5    1     ASN     BB     1      0  72
- 2   P5    1     ASN     SC1    2      0   0
- 3   D     1     ASN     SC2    3  +0.46  36 {"charge_dummy": 0.14}
- 4   D     1     ASN     SC3    4  -0.46  36 {"charge_dummy": 0.14}
+ 2   Nda   1     ASN     SC1    2      0   0
+ 3   D     1     ASN     SCP    3  +0.46  36 {"charge_dummy": 0.14}
+ 4   D     1     ASN     SCN    4  -0.46  36 {"charge_dummy": 0.14}
 
 [virtual_sites2]
 ; Site from       funct a
    2     3    4   1     0.5
 
 [ edges ]
-SC2 SC1
-SC3 SC1 
+SCP SC1
+SCN SC1 
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -162,17 +163,17 @@ GLN                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge  mass
  1   P5    1     GLN     BB     1      0  72
- 2   P4    1     GLN     SC1    2      0   0
- 3   D     1     GLN     SC2    3  +0.46  36 {"charge_dummy": 0.14}
- 4   D     1     GLN     SC3    4  -0.46  36 {"charge_dummy": 0.14}
+ 2   Nda   1     GLN     SC1    2      0   0
+ 3   D     1     GLN     SCP    3  +0.42  36 {"charge_dummy": 0.14}
+ 4   D     1     GLN     SCN    4  -0.42  36 {"charge_dummy": 0.14}
 
 [virtual_sites2]
 ; Site from       funct a
    2     3    4   1     0.5
 
 [ edges ]
-SC2 SC1
-SC3 SC1 
+SCP SC1
+SCN SC1 
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -192,8 +193,8 @@ ASP                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge  mass
  1   P5     1     ASP     BB     1     0  72
- 2   Qa     1     ASP     SC1    2  -1.0  36
- 3   D      1     ASP     SC2    3  -1.0  36 {"charge_dummy": 0.11}
+ 2   Qa     1     ASP     SC1    2     0  36
+ 3   D      1     ASP     SCN    3  -1.0  36 {"charge_dummy": 0.11}
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -230,8 +231,8 @@ GLU                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge mass
  1   P5     1     GLU     BB     1     0 72
- 2   Qa     1     GLU     SC1    2  -1.0 36 
- 3   D      1     GLU     SC2    3  -1.0 36  {"charge_dummy": 0.11}
+ 2   Qa     1     GLU     SC1    2     0 36 
+ 3   D      1     GLU     SCN    3  -1.0 36  {"charge_dummy": 0.11}
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -268,17 +269,17 @@ THR                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
 1   P5     1     THR     BB     1      0    72
-2   Nda    1     THR     SC1    2      0    0
-3   D      1     THR     SC2    3  +0.31    36 {"charge_dummy": 0.14}
-4   D      1     THR     SC3    4  -0.31    36 {"charge_dummy": 0.14}
+2   N0     1     THR     SC1    2      0    0
+3   D      1     THR     SCP    3  +0.36    36 {"charge_dummy": 0.14}
+4   D      1     THR     SCN    4  -0.36    36 {"charge_dummy": 0.14}
 
 [virtual_sites2]
 ; Site from       funct a
    2     3    4   1     0.5
 
 [ edges ]
-SC2 SC1
-SC3 SC1 
+SCP SC1
+SCN SC1 
 
 [ bonds ]
 #meta {"group": "Side chain bonds"}
@@ -298,17 +299,17 @@ SER                1
 [ atoms ]
 ;id type resnr residu atom cgnr   charge  mass
 1   P5     1    SER     BB     1      0   72
-2   P1     1    SER     SC1    2      0    0
-3   D      1    SER     SC2    3  +0.40   36 {"charge_dummy": 0.14}
-4   D      1    SER     SC3    4  -0.40   36 {"charge_dummy": 0.14}
+2   N0     1    SER     SC1    2      0    0
+3   D      1    SER     SCP    3  +0.40   36 {"charge_dummy": 0.14}
+4   D      1    SER     SCN    4  -0.40   36 {"charge_dummy": 0.14}
 
 [virtual_sites2]
 ; Site from       funct a
    2     3    4   1     0.5
 
 [ edges ]
-SC2 SC1
-SC3 SC1 
+SCP SC1
+SCN SC1 
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -330,7 +331,7 @@ LYS                1
  1   P5    1     LYS     BB     1      0 72
  2   C3    1     LYS     SC1    2      0 72 
  3   Qd    1     LYS     SC2    3      0 36
- 4   D     1     LYS     SC3    4    1.0 36 {"charge_dummy": 0.11}
+ 4   D     1     LYS     SCP    4    1.0 36 {"charge_dummy": 0.11}
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -346,7 +347,6 @@ LYS                1
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
     1     2    3       2   180.000    25.0      
-
 
 ;;; LYSINE - NEUTRAL FORM
 
@@ -383,7 +383,7 @@ ARG                1
 1   P5     1     ARG     BB     1      0  72  
 2   N0     1     ARG     SC1    2      0  72
 3   Qd     1     ARG     SC2    3      0  36
-4   D      1     ARG     SC3    4    1.0  36 {"charge_dummy": 0.11}
+4   D      1     ARG     SCP    4    1.0  36 {"charge_dummy": 0.11}
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -471,7 +471,7 @@ HISH               1
 2   SC4    1     HIS     SC1    2    0    72 ; three side chains in triangle
 3   SP1    1     HIS     SC2    3    0    72 ; configuration, mimicking
 4   SQd    1     HIS     SC3    4    0    36 ; ring structure
-5   D      1     HIS     SC4    5  1.0    36 {"charge_dummy": 0.11}
+5   D      1     HIS     SCP    5  1.0    36 {"charge_dummy": 0.11}
 
 [bonds]
 #meta {"group": "Side chain bonds"}
@@ -613,10 +613,6 @@ resname $protein_resnames
 [ bonds ]
 BB +BB 1 0.350 1250 {"group": "Backbone bonds"}
 
-[ link ]
-resname $protein_resnames
-[ angles ]
--BB BB +BB 2 119.2 150 {"group": "BBB angles"}
 
 [ link ]
 resname $protein_resnames
@@ -676,60 +672,144 @@ resname "PRO"
 [ atoms ]
 BB {"cgsecstruct": "2", "replace": {"atype": "Na"}}
 
-;; Setup the bonds. We only define those that are different from coil.
+;; Setup the bonds. We only have the bonds assuming everything is coil.
+;; We always select the lowest force constant when the two residues involved
+;; are assigned different secondary structures.
+;; Bonds/constraints between different secondary structures have the average
+;; length.
 [ link ]
 resname $protein_resnames
-cgsecstruct "H|1|2|3"
+[ bonds ]
+BB +BB 1 0.3375 1250
+[ patterns ]
+BB +BB {"cgsecstruct": "F"}
+BB {"cgsecstruct": "F"} +BB
+
+[ link ]
+resname $protein_resnames
+cgsecstruct "F"
+[ bonds ]
+BB +BB 1 0.365 1250
+
+[ link ]
+resname $protein_resnames
 [ constraints ]
 BB +BB 1 0.310 
 [ !bonds ]
 BB +BB
+[ patterns ]
+BB {"cgsecstruct": "H|1|2|3"} +BB
+BB +BB {"cgsecstruct": "H|1|2|3"}
+
+[ link ]
+resname $protein_resnames
+[ constraints ]
+BB +BB 1 0.33
+[ !bonds ]
+BB +BB
+[ patterns ]
+BB {"cgsecstruct": "H|1|2|3"} +BB {"cgsecstruct": "S|C|T|E"}
+BB {"cgsecstruct": "S|C|T|E"} +BB {"cgsecstruct": "H|1|2|3"}
+
+[ link ]
+resname $protein_resnames
+[ constraints ]
+BB +BB 1 0.3375
+[ !bonds ]
+BB +BB
+[ patterns ]
+BB {"cgsecstruct": "H|1|2|3"} +BB {"cgsecstruct": "F"}
+BB {"cgsecstruct": "F"} +BB {"cgsecstruct": "H|1|2|3"}
 
 ;; Setup the angles. We only define those that are different from coil.
+;; When there is more than one secondary structure involved, we take the
+;; angle with the lowest force constant, then the lowest angle.
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "H|1|2|3"} +BB 2 96 700
-
-[ link ]
-resname $protein_resnames
-[ angles ]
--BB BB {"cgsecstruct": "S"} +BB 2 130 20
-
-[ link ]
-resname $protein_resnames
-[ angles ]
--BB BB {"cgsecstruct": "T"} +BB 2 100 20
+-BB BB +BB 2 96 700 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "H|1|2|3"} +BB 
+-BB {"cgsecstruct": "H|1|2|3"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "H|1|2|3"}
 
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "E"} +BB 2 134 25
+-BB BB {"cgsecstruct": "E"} +BB 2 134 25 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "E"} +BB 
+-BB {"cgsecstruct": "E"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "E"}
 
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "F"} +BB 2 119.2 150
+-BB BB {"cgsecstruct": "S"} +BB 2 130 20 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "S"} +BB 
+-BB {"cgsecstruct": "S"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "S"}
 
 [ link ]
-resname "PRO|HYP"
+resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "H|1|2|3"} +BB 2 98 100
+-BB BB {"cgsecstruct": "F"} +BB 2 119.2 150 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "F"} +BB 
+-BB {"cgsecstruct": "F"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "F"}
 
 [ link ]
-resname "PRO|HYP"
 [ angles ]
--BB BB {"cgsecstruct": "S"} +BB 2 130 25
+-BB BB +BB 2 98 100 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"} +BB 
+-BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"}
 
 [ link ]
-resname "PRO|HYP"
 [ angles ]
--BB BB {"cgsecstruct": "T"} +BB 2 100 25
+-BB BB +BB 2 134 25 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "E", "resname": "PRO|HYP"} +BB 
+-BB {"cgsecstruct": "E", "resname": "PRO|HYP"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "E", "resname": "PRO|HYP"}
 
 [ link ]
-resname "PRO|HYP"
+resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "E"} +BB 2 134 25
+-BB BB +BB 2 130 25 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "S"} +BB 
+-BB {"cgsecstruct": "S"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "S"}
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB +BB 2 127 25 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "C"} +BB 
+-BB {"cgsecstruct": "C"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "C"}
+-BB {"cgsecstruct": null} BB {"cgsecstruct": null} +BB {"cgsecstruct": null}
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB +BB 2 100 25 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "T"} +BB 
+-BB {"cgsecstruct": "T"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "T"}
+
+
+; If there is a helical proline *at the middle* of the angle, then it takes
+; over.
+[ link ]
+[ angles ]
+-BB BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"} +BB 2 98 100 {"group": "BBB angles"}
 
 ;; Backbone dihedrals.
 [ link ]
@@ -782,14 +862,21 @@ BB +++BB 1 0.970 2500
 
 ;; Protein terminii. These links should be applied last.
 [ link ]
+resname $protein_resnames
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
 BB -BB
 
 [ link ]
+resname $protein_resnames
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]
 BB +BB
 
+; Exclusions between the charged terminii and the charge dummies
+[ link ]
+resname $protein_resnames
+[ exclusions ]
+BB {"atype": "Qd|Qa"} * {"atomname": "SCP|SCN"}

--- a/vermouth/data/mappings/ala.charmm36.map
+++ b/vermouth/data/mappings/ala.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 ALA
 

--- a/vermouth/data/mappings/arg.charmm36.map
+++ b/vermouth/data/mappings/arg.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 ARG
 

--- a/vermouth/data/mappings/arg.charmm36.martini22p.map
+++ b/vermouth/data/mappings/arg.charmm36.martini22p.map
@@ -16,14 +16,13 @@
 universal
 
 [to]
-martini22
 martini22p
 
 [ molecule ]
-TRP
+ARG
 
 [ martini ]
-BB SC1 SC2 SC3 SC4
+BB SC1 SC2
 
 [ mapping ]
 charmm27 charmm36
@@ -33,41 +32,52 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB
-    6   HB1   SC1 BB
-    7   HB2   SC1 BB
-    8    CG   SC1 SC1 SC1 SC1 SC3 SC3
-    9   CD1   SC1 
-   10   HD1   SC1
-   11   NE1   SC2 SC1
-   12   HE1   SC2
-   13   CE2   SC2 SC2 SC3 
-   14   CD2   SC3 SC3 SC2
-   15   CE3   SC3 SC3 SC4
-   16   HE3   SC3
-   17   CZ3   SC4 SC4 SC3
-   18   HZ3   SC4 
-   19   CZ2   SC2 SC2 SC4
-   20   HZ2   SC2 
-   21   CH2   SC4 SC4 SC2 
-   22   HH2   SC4
+    5    CB   SC1  BB BB
+    6   HB1   SC1  BB BB
+    7   HB2   SC1  BB BB
+    8    CG   SC1 SC1 BB
+    9   HG1   SC1 SC1 BB
+   10   HG2   SC1 SC1 BB
+   11    CD   SC1 
+   12   HD1   SC1
+   13   HD2   SC1
+   14    NE   SC2 SC1
+   15    HE   SC2 SC1
+   16    CZ   SC2
+   17   NH1   SC2
+   18  HH11   SC2
+   19  HH12   SC2
+   20   NH2   SC2
+   21  HH21   SC2
+   22  HH22   SC2
    23     C    BB
    24     O    BB
 
-[ trans ]
-CB  CG  CD2 CE2  
-HD1 CD1 NE1 CE2
-HE1 NE1 CD1 CG
-HE3 CE3 CD2 CE2
-HZ2 CZ2 CE2 CD2
-HZ3 CZ3 CE3 CD2
-HH2 CH2 CZ3 CE3
-
 [ chiral ]
-  CB     CA    N    C  
+  CB     CA    N    C
   HB1    CA    N    C
   HB2    CA    N    C
-
 [ chiral ]
-  HA     CA    N    CB    C ; L-Trp
-; HA     CA    N    C    CB ; D-Trp
+  HA     CA    N    CB    C ; L-Arg
+; HA     CA    N    C    CB ; D-Arg
+
+
+; The cis/trans are added to ensure proper
+; splitting of the guanidinium group
+
+[ trans ]
+; Because of the use of normalized vectors, this makes sense:
+  NH1    CZ    NE    HE
+
+[ out ]
+  NH2    CZ    NE    NH1
+  NH1    CZ    NE    NH2
+
+[ out ]
+ HH11    NH1   CZ   HH12
+ HH12    NH1   CZ   HH11
+ HH21    NH2   CZ   HH22
+ HH22    NH2   CZ   HH21
+
+[ extra ]
+SC3

--- a/vermouth/data/mappings/arg.charmm36.martini22p.map
+++ b/vermouth/data/mappings/arg.charmm36.martini22p.map
@@ -80,4 +80,4 @@ charmm27 charmm36
  HH22    NH2   CZ   HH21
 
 [ extra ]
-SC3
+SCP

--- a/vermouth/data/mappings/asn.charmm36.map
+++ b/vermouth/data/mappings/asn.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 ASN
 

--- a/vermouth/data/mappings/asn.charmm36.martini22p.map
+++ b/vermouth/data/mappings/asn.charmm36.martini22p.map
@@ -16,10 +16,10 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
-THR
+ASN
 
 [ martini ]
 BB SC1
@@ -32,30 +32,25 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB BB 
-    6    HB   SC1 BB BB
-    7   OG1   SC1 SC1 BB
-    8   HG1   SC1
-    9   CG2   SC1 
-   10   HG21  SC1 
-   11   HG22  SC1 
-   12   HG23  SC1 
+    5    CB   SC1 BB BB
+    6   HB1   SC1 BB BB
+    7   HB2   SC1 BB BB
+    8    CG   SC1 SC1 BB
+    9   OD1   SC1
+   10   ND2   SC1
+   11  HD21   SC1
+   12  HD22   SC1
    13     C    BB
    14     O    BB
 
 [ chiral ]
   CB     CA    N    C
-  HB     CA    N    C
+  HB1    CA    N    C
+  HB2    CA    N    C
 
 [ chiral ]
-  HA     CA    N    CB    C ; L-Thr
-; HA     CA    N    C    CB ; D-Thr
+  HA     CA    N    CB    C ; L-Asn
+; HA     CA    N    C    CB ; D-Asn
 
-[ out ] 
-OG1 CB CG2 CA
-[ trans ]
-HG1 OG1 CB CA
-
-[ chiral ]
-  HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
-; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+[ extra ]
+SC2 SC3

--- a/vermouth/data/mappings/asn.charmm36.martini22p.map
+++ b/vermouth/data/mappings/asn.charmm36.martini22p.map
@@ -53,4 +53,4 @@ charmm27 charmm36
 ; HA     CA    N    C    CB ; D-Asn
 
 [ extra ]
-SC2 SC3
+SCP SCN

--- a/vermouth/data/mappings/asp.charmm36.map
+++ b/vermouth/data/mappings/asp.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 ASP
 

--- a/vermouth/data/mappings/asp.charmm36.martini22p.map
+++ b/vermouth/data/mappings/asp.charmm36.martini22p.map
@@ -52,4 +52,4 @@ charmm27 charmm36
 ; HA     CA    N    C    CB ; D-Asp
 
 [ extra ]
-SC2
+SCN

--- a/vermouth/data/mappings/asp.charmm36.martini22p.map
+++ b/vermouth/data/mappings/asp.charmm36.martini22p.map
@@ -16,10 +16,10 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
-THR
+ASP
 
 [ martini ]
 BB SC1
@@ -32,30 +32,24 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB BB 
-    6    HB   SC1 BB BB
-    7   OG1   SC1 SC1 BB
-    8   HG1   SC1
-    9   CG2   SC1 
-   10   HG21  SC1 
-   11   HG22  SC1 
-   12   HG23  SC1 
-   13     C    BB
-   14     O    BB
+    5    CB   SC1 BB BB
+    6   HB1   SC1 BB BB
+    7   HB2   SC1 BB BB
+    8    CG   SC1 SC1 BB
+    9   OD1   SC1
+   10   OD2   SC1
+   11   HD2   SC1
+   12     C    BB
+   13     O    BB
 
 [ chiral ]
   CB     CA    N    C
-  HB     CA    N    C
+  HB1    CA    N    C
+  HB2    CA    N    C
 
 [ chiral ]
-  HA     CA    N    CB    C ; L-Thr
-; HA     CA    N    C    CB ; D-Thr
+  HA     CA    N    CB    C ; L-Asp
+; HA     CA    N    C    CB ; D-Asp
 
-[ out ] 
-OG1 CB CG2 CA
-[ trans ]
-HG1 OG1 CB CA
-
-[ chiral ]
-  HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
-; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+[ extra ]
+SC2

--- a/vermouth/data/mappings/chol.charmm36.map
+++ b/vermouth/data/mappings/chol.charmm36.map
@@ -11,6 +11,12 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
+[from]
+universal
+
+[to]
+martini22
+martini22p
 
 ; latest revision Kri 12.3.2013
 [ molecule ]

--- a/vermouth/data/mappings/cys.charmm36.map
+++ b/vermouth/data/mappings/cys.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 CYS
 

--- a/vermouth/data/mappings/dmpc.charmm36.map
+++ b/vermouth/data/mappings/dmpc.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; Mapping file created 24/11/2015 by Kri
 
 [ molecule ]

--- a/vermouth/data/mappings/dopc.charmm36.map
+++ b/vermouth/data/mappings/dopc.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; Mapping file created 15/03/2013 by Kri
 
 [ molecule ]

--- a/vermouth/data/mappings/dppc.charmm36.map
+++ b/vermouth/data/mappings/dppc.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; Mapping file created 28/02/2013 by Kri
 
 [ molecule ]

--- a/vermouth/data/mappings/dppg.charmm36.map
+++ b/vermouth/data/mappings/dppg.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; Created by Jagannath Mondal
 
 [ molecule ]

--- a/vermouth/data/mappings/gln.charmm36.map
+++ b/vermouth/data/mappings/gln.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 GLN
 

--- a/vermouth/data/mappings/gln.charmm36.martini22p.map
+++ b/vermouth/data/mappings/gln.charmm36.martini22p.map
@@ -56,4 +56,4 @@ charmm27 charmm36
 ; HA     CA    N    C    CB ; D-Gln
 
 [ extra ]
-SC2 SC3
+SCP SCN

--- a/vermouth/data/mappings/gln.charmm36.martini22p.map
+++ b/vermouth/data/mappings/gln.charmm36.martini22p.map
@@ -16,10 +16,10 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
-THR
+GLN
 
 [ martini ]
 BB SC1
@@ -32,30 +32,28 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB BB 
-    6    HB   SC1 BB BB
-    7   OG1   SC1 SC1 BB
-    8   HG1   SC1
-    9   CG2   SC1 
-   10   HG21  SC1 
-   11   HG22  SC1 
-   12   HG23  SC1 
-   13     C    BB
-   14     O    BB
+    5    CB   SC1 BB BB
+    6   HB1   SC1 BB BB
+    7   HB2   SC1 BB BB
+    8    CG   SC1 SC1 BB
+    9   HG1   SC1 SC1 BB
+   10   HG2   SC1 SC1 BB
+   11    CD   SC1 
+   12   OE1   SC1
+   13   NE2   SC1
+   14  HE21   SC1
+   15  HE22   SC1
+   16     C    BB
+   17     O    BB
 
 [ chiral ]
   CB     CA    N    C
-  HB     CA    N    C
+  HB1    CA    N    C
+  HB2    CA    N    C
 
 [ chiral ]
-  HA     CA    N    CB    C ; L-Thr
-; HA     CA    N    C    CB ; D-Thr
+  HA     CA    N    CB    C ; L-Gln
+; HA     CA    N    C    CB ; D-Gln
 
-[ out ] 
-OG1 CB CG2 CA
-[ trans ]
-HG1 OG1 CB CA
-
-[ chiral ]
-  HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
-; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+[ extra ]
+SC2 SC3

--- a/vermouth/data/mappings/glu.charmm36.map
+++ b/vermouth/data/mappings/glu.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 GLU
 

--- a/vermouth/data/mappings/glu.charmm36.martini22p.map
+++ b/vermouth/data/mappings/glu.charmm36.martini22p.map
@@ -16,10 +16,10 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
-THR
+GLU
 
 [ martini ]
 BB SC1
@@ -32,30 +32,27 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB BB 
-    6    HB   SC1 BB BB
-    7   OG1   SC1 SC1 BB
-    8   HG1   SC1
-    9   CG2   SC1 
-   10   HG21  SC1 
-   11   HG22  SC1 
-   12   HG23  SC1 
-   13     C    BB
-   14     O    BB
+    5    CB   SC1 BB BB
+    6   HB1   SC1 BB BB
+    7   HB2   SC1 BB BB
+    8    CG   SC1 SC1 BB
+    9   HG1   SC1 SC1 BB
+   10   HG2   SC1 SC1 BB
+   11    CD   SC1
+   12   OE1   SC1
+   13   OE2   SC1
+   14   HE2   SC1
+   15     C    BB
+   16     O    BB
 
 [ chiral ]
   CB     CA    N    C
-  HB     CA    N    C
+  HB1    CA    N    C
+  HB2    CA    N    C
 
 [ chiral ]
-  HA     CA    N    CB    C ; L-Thr
-; HA     CA    N    C    CB ; D-Thr
+  HA     CA    N    CB    C ; L-Glu
+; HA     CA    N    C    CB ; D-Glu
 
-[ out ] 
-OG1 CB CG2 CA
-[ trans ]
-HG1 OG1 CB CA
-
-[ chiral ]
-  HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
-; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+[ extra ]
+SC2

--- a/vermouth/data/mappings/glu.charmm36.martini22p.map
+++ b/vermouth/data/mappings/glu.charmm36.martini22p.map
@@ -55,4 +55,4 @@ charmm27 charmm36
 ; HA     CA    N    C    CB ; D-Glu
 
 [ extra ]
-SC2
+SCN

--- a/vermouth/data/mappings/gly.charmm36.map
+++ b/vermouth/data/mappings/gly.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 GLY
 

--- a/vermouth/data/mappings/his.charmm36.map
+++ b/vermouth/data/mappings/his.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
 

--- a/vermouth/data/mappings/ile.charmm36.map
+++ b/vermouth/data/mappings/ile.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 ILE
 

--- a/vermouth/data/mappings/leu.charmm36.map
+++ b/vermouth/data/mappings/leu.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 LEU
 

--- a/vermouth/data/mappings/lys.charmm36.map
+++ b/vermouth/data/mappings/lys.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 LYS
 

--- a/vermouth/data/mappings/lys.charmm36.martini22p.map
+++ b/vermouth/data/mappings/lys.charmm36.martini22p.map
@@ -16,13 +16,13 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
-THR
+LYS
 
 [ martini ]
-BB SC1
+BB SC1 SC2
 
 [ mapping ]
 charmm27 charmm36
@@ -32,30 +32,33 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB BB 
-    6    HB   SC1 BB BB
-    7   OG1   SC1 SC1 BB
-    8   HG1   SC1
-    9   CG2   SC1 
-   10   HG21  SC1 
-   11   HG22  SC1 
-   12   HG23  SC1 
-   13     C    BB
-   14     O    BB
+    5    CB   SC1 BB BB
+    6   HB1   SC1 BB BB
+    7   HB2   SC1 BB BB
+    8    CG   SC1 SC1 BB
+    9   HG1   SC1 SC1 BB
+   10   HG2   SC1 SC1 BB
+   11    CD   SC1
+   12   HD1   SC1
+   13   HD2   SC1
+   14    CE   SC1 SC1 SC2
+   15   HE1   SC1 SC1 SC2
+   16   HE2   SC1 SC1 SC2
+   17    NZ   SC2 SC2 SC1 
+   18   HZ1   SC2
+   19   HZ2   SC2
+   20   HZ3   SC2
+   21     C    BB
+   22     O    BB
 
 [ chiral ]
   CB     CA    N    C
-  HB     CA    N    C
+  HB1    CA    N    C
+  HB2    CA    N    C
 
 [ chiral ]
-  HA     CA    N    CB    C ; L-Thr
-; HA     CA    N    C    CB ; D-Thr
+  HA     CA    N    CB    C ; L-Lys
+; HA     CA    N    C    CB ; D-Lys
 
-[ out ] 
-OG1 CB CG2 CA
-[ trans ]
-HG1 OG1 CB CA
-
-[ chiral ]
-  HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
-; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+[ extra ]
+SC3

--- a/vermouth/data/mappings/lys.charmm36.martini22p.map
+++ b/vermouth/data/mappings/lys.charmm36.martini22p.map
@@ -61,4 +61,4 @@ charmm27 charmm36
 ; HA     CA    N    C    CB ; D-Lys
 
 [ extra ]
-SC3
+SCP

--- a/vermouth/data/mappings/met.charmm36.map
+++ b/vermouth/data/mappings/met.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 MET
 

--- a/vermouth/data/mappings/phe.charmm36.map
+++ b/vermouth/data/mappings/phe.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 PHE
 

--- a/vermouth/data/mappings/popc.charmm36.map
+++ b/vermouth/data/mappings/popc.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; latest revision TAW 20160213
 [ molecule ]
 POPC

--- a/vermouth/data/mappings/pope.charmm36.map
+++ b/vermouth/data/mappings/pope.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; latest revision kri 15.3.2013
 [ molecule ]
 POPE

--- a/vermouth/data/mappings/popg.charmm36.map
+++ b/vermouth/data/mappings/popg.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 ; latest revision kri 15.3.2013
 [ molecule ]
 POPG

--- a/vermouth/data/mappings/pops.charmm36.map
+++ b/vermouth/data/mappings/pops.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 POPS
 

--- a/vermouth/data/mappings/pro.charmm36.map
+++ b/vermouth/data/mappings/pro.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 PRO
 

--- a/vermouth/data/mappings/ser.charmm36.map
+++ b/vermouth/data/mappings/ser.charmm36.map
@@ -12,6 +12,12 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+
 [ molecule ]
 SER
 

--- a/vermouth/data/mappings/ser.charmm36.martini22p.map
+++ b/vermouth/data/mappings/ser.charmm36.martini22p.map
@@ -16,10 +16,10 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
-THR
+SER
 
 [ martini ]
 BB SC1
@@ -32,30 +32,22 @@ charmm27 charmm36
     2    HN    BB
     3    CA    BB
     4    HA    BB
-    5    CB   SC1 BB BB 
-    6    HB   SC1 BB BB
-    7   OG1   SC1 SC1 BB
-    8   HG1   SC1
-    9   CG2   SC1 
-   10   HG21  SC1 
-   11   HG22  SC1 
-   12   HG23  SC1 
-   13     C    BB
-   14     O    BB
+    5    CB   SC1 BB BB
+    6   HB1   SC1 BB BB
+    7   HB2   SC1 BB BB
+    8    OG   SC1 SC1 BB
+    9   HG1   SC1
+   10     C    BB
+   11     O    BB
 
 [ chiral ]
   CB     CA    N    C
-  HB     CA    N    C
+  HB1    CA    N    C
+  HB2    CA    N    C
 
 [ chiral ]
-  HA     CA    N    CB    C ; L-Thr
-; HA     CA    N    C    CB ; D-Thr
+  HA     CA    N    CB    C ; L-Ser
+; HA     CA    N    C    CB ; D-Ser
 
-[ out ] 
-OG1 CB CG2 CA
-[ trans ]
-HG1 OG1 CB CA
-
-[ chiral ]
-  HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
-; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+[ extra ]
+SC2 SC3

--- a/vermouth/data/mappings/ser.charmm36.martini22p.map
+++ b/vermouth/data/mappings/ser.charmm36.martini22p.map
@@ -50,4 +50,4 @@ charmm27 charmm36
 ; HA     CA    N    C    CB ; D-Ser
 
 [ extra ]
-SC2 SC3
+SCP SCN

--- a/vermouth/data/mappings/thr.charmm36.martini22p.map
+++ b/vermouth/data/mappings/thr.charmm36.martini22p.map
@@ -16,7 +16,7 @@
 universal
 
 [to]
-martini22
+martini22p
 
 [ molecule ]
 THR
@@ -59,3 +59,6 @@ HG1 OG1 CB CA
 [ chiral ]
   HB  CB  CG2  OG1 CA  ; 3R stereoisomer (natural form)
 ; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
+
+[ extra ]
+SC2 SC3

--- a/vermouth/data/mappings/thr.charmm36.martini22p.map
+++ b/vermouth/data/mappings/thr.charmm36.martini22p.map
@@ -61,4 +61,4 @@ HG1 OG1 CB CA
 ; HB  CB  CG2  CA  CG1 ; 3S stereoisomer
 
 [ extra ]
-SC2 SC3
+SCP SCN

--- a/vermouth/data/mappings/tyr.charmm36.map
+++ b/vermouth/data/mappings/tyr.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 TYR
 

--- a/vermouth/data/mappings/val.charmm36.map
+++ b/vermouth/data/mappings/val.charmm36.map
@@ -12,6 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[from]
+universal
+
+[to]
+martini22
+martini22p
+
 [ molecule ]
 VAL
 

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -311,7 +311,7 @@ def _treat_atom_prefix(reference, attributes):
     if order_attribute < 0:
         prefix_symbol = '-'
     atom_name = reference[prefix_end:]
-    attributes['atomname'] = atom_name
+    attributes['atomname'] = attributes.get('atomname', atom_name)
     prefixed_reference = prefix_symbol * int(math.fabs(order_attribute)) + atom_name
 
     return prefixed_reference, atom_name, attributes
@@ -338,7 +338,6 @@ def _treat_link_interaction_atoms(atoms, context, section):
                                              value, context_atom[key]))
             context_atom.update(attributes)
         else:
-            attributes['atomname'] = atom_name
             context.add_node(prefixed_reference, **attributes)
 
 

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -411,7 +411,7 @@ def _parse_block_atom(tokens, context):
         attributes = {}
 
     # deque does not support slicing
-    first_six = (tokens.popleft() for i in range(6))
+    first_six = (tokens.popleft() for _ in range(6))
     _, atype, _, resname, name, charge_group = first_six
     atom = {
         'atomname': name,

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -406,6 +406,11 @@ def _base_parser(tokens, context, context_type, section, natoms=None, delete=Fal
 
 
 def _parse_block_atom(tokens, context):
+    if tokens[-1].startswith('{'):
+        attributes = _parse_atom_attributes(tokens.pop())
+    else:
+        attributes = {}
+
     # deque does not support slicing
     first_six = (tokens.popleft() for i in range(6))
     _, atype, _, resname, name, charge_group = first_six
@@ -420,7 +425,7 @@ def _parse_block_atom(tokens, context):
         atom['charge'] = float(tokens.popleft())
     if tokens:
         atom['mass'] = float(tokens.popleft())
-    context.add_atom(atom)
+    context.add_atom(dict(collections.ChainMap(attributes, atom)))
 
 
 def _parse_link_atom(tokens, context):
@@ -522,6 +527,7 @@ def read_ff(lines):
         'dihedrals': 4,
         'impropers': 4,
         'constraints': 2,
+        'virtual_sites2': 3,
     }
 
     macros = {}

--- a/vermouth/gmx/gro.py
+++ b/vermouth/gmx/gro.py
@@ -85,12 +85,10 @@ def read_gro(file_name, exclude=('SOL',), ignh=False):
 
             pos = (properties.pop('x'), properties.pop('y'), properties.pop('z'))
             properties['position'] = np.array(pos, dtype=float)
-            properties['position'] *= 10  # Convert nm to A
 
             if has_vel:
                 vel = (properties.pop('vx'), properties.pop('vy'), properties.pop('vz'))
                 properties['velocity'] = np.array(vel, dtype=float)
-                properties['velocity'] *= 10  # Convert nm to A
 
             molecule.add_node(idx, **properties)
             idx += 1
@@ -124,7 +122,7 @@ def write_gro(system, file_name, precision=7):
                 atomname = node['atomname']
                 resname = node['resname']
                 resid = node['resid']
-                x, y, z = node['position']/10  # A to nm
+                x, y, z = node['position']
 
                 line = formatter.format(format_string, resid, resname, atomname,
                                         atomid, x, y, z)

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -54,7 +54,7 @@ def write_pdb_string(system, conect=True):
             chain = node['chain']
             resid = node['resid']
             insertion_code = node.get('insertioncode', '')
-            x, y, z = node['position']
+            x, y, z = node['position'] * 10  # converting from nm to A
             occupancy = node.get('occupancy', 1)
             temp_factor = node.get('temp_factor', 0)
             element = node.get('element', first_alpha(atomname))
@@ -152,7 +152,8 @@ def read_pdb(file_name, exclude=('SOL',), ignh=False, model=0):
                     properties[name] = type_(line[slice_].strip())
 
                 pos = (properties.pop('x'), properties.pop('y'), properties.pop('z'))
-                properties['position'] = np.array(pos, dtype=float)
+                # Coordinates are read in Angstrom, but we want them in nm
+                properties['position'] = np.array(pos, dtype=float) / 10
 
                 if not properties['element']:
                     atomname = properties['atomname']

--- a/vermouth/processors/__init__.py
+++ b/vermouth/processors/__init__.py
@@ -30,3 +30,4 @@ from .apply_blocks import ApplyBlocks
 from .average_beads import DoAverageBead
 from .apply_posres import ApplyPosres
 from .set_molecule_meta import SetMoleculeMeta
+from .locate_charge_dummies import LocateChargeDummies

--- a/vermouth/processors/average_beads.py
+++ b/vermouth/processors/average_beads.py
@@ -26,6 +26,9 @@ def do_average_bead(molecule, ignore_missing_graphs=False):
         The molecule to update. The attribute :attr:`position` of the particles
         is updated on place. The nodes of the molecule must have an attribute
         :attr:`graph` that contains the subgraph of the initial molecule.
+    ignore_missing_graphs: bool
+        If `True`, skip the atoms that do not have a 'graph' attribute; else
+        fail if not all the atoms in the molecule have a 'graph' attribute.
     """
     # Make sure the molecule fullfill the requirements.
     missing = []
@@ -41,7 +44,7 @@ def do_average_bead(molecule, ignore_missing_graphs=False):
             positions = np.stack([
                 subnode['position']
                 for subnode in node['graph'].nodes().values()
-                if 'position' in subnode
+                if 'position' in subnode and subnode['position'] is not None
             ])
             node['position'] = positions.mean(axis=0)
 

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -45,7 +45,7 @@ class GraphMapping:
     #       of blocks and a mapping of {node_idx: [node_idx, ...], ...}
 
     # TODO: renumber output residues. Needs information about the entire system
-    #       or we need to at least garantue we run it all in order. Which we
+    #       or we need to at least the garanty we run it all in order. Which we
     #       can't unless we do run_system instead of run_molecule. We should
     #       maybe also move this class to a different file, but we'll see.
     def __init__(self, blocks_from, blocks_to, mapping, extra=()):

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -45,7 +45,7 @@ class GraphMapping:
     #       of blocks and a mapping of {node_idx: [node_idx, ...], ...}
 
     # TODO: renumber output residues. Needs information about the entire system
-    #       or we need to at least the garanty we run it all in order. Which we
+    #       or we need to at least the garantee we run it all in order. Which we
     #       can't unless we do run_system instead of run_molecule. We should
     #       maybe also move this class to a different file, but we'll see.
     def __init__(self, blocks_from, blocks_to, mapping, extra=()):

--- a/vermouth/processors/locate_charge_dummies.py
+++ b/vermouth/processors/locate_charge_dummies.py
@@ -21,6 +21,22 @@ DEFAULT_DUMMY_ATTRIBUTE = 'charge_dummy'
 
 
 def fibonacci_sphere(n_samples):
+    """
+    Place points near-evenly distributed on a sphere.
+
+    Use the Fibonacci sphere algorithm to place 'n_samples' points at the
+    surface of a sphere of radius 1, centered on the origin.
+
+    Parameters
+    ----------
+    n_samples: int
+        Number of points to place.
+
+    Returns
+    -------
+    np.ndarray
+        3D coordinates of the points.
+    """
     offset = 2 / n_samples
     increment = np.pi * (3 - np.sqrt(5))
     sample_idx = np.arange(n_samples)
@@ -33,8 +49,9 @@ def fibonacci_sphere(n_samples):
 
 
 def colinear_pair():
-    # We want to create a randomly oriented vector of norm 2, and center it on
-    # the origin.
+    """
+    Build two points on a line around the origin at a random orientation.
+    """
     vector = np.random.rand(3)
     vector /= np.linalg.norm(vector)
     vector *= 2
@@ -44,6 +61,32 @@ def colinear_pair():
 
 
 def find_anchor(molecule, node_key, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
+    """
+    Find the non-dummy bead to which a charge dummy is anchored.
+
+    Each charge dummy has to be attached to one non-dummy atom. This function
+    returns the node key for that non-dummy atom.
+
+    Parameters
+    ----------
+    molecule: vermouth.Molecule
+        The molecule to work on.
+    node_key:
+        The node key of the charge dummy.
+    attribute_tag: str
+        The name of the atom attribute used to describe charge dummies.
+
+    Returns
+    -------
+    anchor_key:
+        The node key of the anchor in the molecule graph.
+
+    Raises
+    ------
+    ValueError
+        Raised if there are no anchor, or more than one anchor, found. Raised
+        also if the charge dummy is not a charge dummy.
+    """
     dummy = molecule.nodes[node_key]
     if dummy.get(attribute_tag, None) is None:
         msg = 'Node "{}" is not a charge dummy. Check the "{}" node attribute.'
@@ -67,7 +110,26 @@ def find_anchor(molecule, node_key, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
 
 
 def locate_dummy(molecule, anchor_key, dummy_keys, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
+    """
+    Set the position of a group of charge dummies around anon-dummy anchor.
+
+    The molecule is modified in-place.
     
+    The charge dummies are placed at a distance to the anchor defined in nm by
+    their charge dummy attribute, the name of which is given in the
+    'attribute_tag' argument.
+
+    Parameters
+    ----------
+    molecule: vermouth.Molecule
+        The molecule to work on.
+    anchor_key:
+        The key of the non-dummy anchor all the charge dummies are connected to.
+    dummy_keys: iterable
+        A collection of atom keys for charge dummies to position.
+    attribute_tag: str
+        Name of the atom attribute that describe charge dummies.
+    """
     anchor_position = molecule.nodes[anchor_key].get('position')
     if anchor_position is None:
         msg = 'The anchor of the "{}" dummy ("{}") does not have a position.'
@@ -98,6 +160,23 @@ def locate_dummy(molecule, anchor_key, dummy_keys, attribute_tag=DEFAULT_DUMMY_A
 
 
 def locate_all_dummies(molecule, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
+    """
+    Set the position of all charge dummies of a molecule.
+
+    The molecule is modified in-place.
+    
+    The charge dummies are placed at a distance to the anchor defined in nm by
+    their charge dummy attribute, the name of which is given in the
+    'attribute_tag' argument.
+
+    Parameters
+    ----------
+    molecule: vermouth.Molecule
+        The molecule to work on.
+    attribute_tag: str
+        Name of the atom attribute that describe charge dummies.
+    """
+
     dummies = [
         (find_anchor(molecule, dummy_key, attribute_tag), dummy_key)
         for dummy_key in molecule.nodes

--- a/vermouth/processors/locate_charge_dummies.py
+++ b/vermouth/processors/locate_charge_dummies.py
@@ -64,12 +64,12 @@ def find_anchor(molecule, node_key, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
     """
     Find the non-dummy bead to which a charge dummy is anchored.
 
-    Each charge dummy has to be attached to one non-dummy atom. This function
-    returns the node key for that non-dummy atom.
+    Each charge dummy has to be attached to exactly one non-dummy atom. This
+    function returns the node key for that non-dummy atom.
 
     Parameters
     ----------
-    molecule: vermouth.Molecule
+    molecule: nx.Groph
         The molecule to work on.
     node_key:
         The node key of the charge dummy.
@@ -111,7 +111,7 @@ def find_anchor(molecule, node_key, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
 
 def locate_dummy(molecule, anchor_key, dummy_keys, attribute_tag=DEFAULT_DUMMY_ATTRIBUTE):
     """
-    Set the position of a group of charge dummies around anon-dummy anchor.
+    Set the position of a group of charge dummies around a non-dummy anchor.
 
     The molecule is modified in-place.
     

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -34,7 +34,7 @@ except ImportError:
     from ..redistributed.kdtree import KDTree
 
 
-COVALENT_RADII = {'H': 0.31, 'C': 0.76, 'N': 0.71, 'O': 0.66, 'S': 1.05}
+COVALENT_RADII = {'H': 0.031, 'C': 0.076, 'N': 0.071, 'O': 0.066, 'S': 0.105}
 #VALENCES = {'H': 1, 'C': 4, 'N': 3, 'O': 2, 'S': 6}
 
 


### PR DESCRIPTION
**This PR is based on top of #41. Wait until #41 is merged before merging this one.**

Fixes #47 

Martini 2.2P uses dummy beads to hold the charges. These beads are not
part of the mapping; therefore, they must be added to the mapping target
molecule without having underlying atoms, and there coordinates must be
constructed.
This commit:
* Adds an [ extra ] section in the mapping files to declare unmapped particles
* Adapt do_mapping to add the unmapped particles
* Adds the LocateChargeDummies that construct the coordinates of the
  dummies
* Adds the force field file for martini 2.2P

In addition, I added a [ from ] and a [ to ] sections to the mapping
files as a quick fix to specify what force field the files are for.

The AverageBeads processor can ignore beads that do not have an
underlying graph.