### PR TITLE
 Read proper and improper dihedrals separatly

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -527,6 +527,7 @@ def read_ff(lines):
         'impropers': 4,
         'constraints': 2,
         'virtual_sites2': 3,
+        'pairs': 2,
     }
 
     macros = {}

--- a/vermouth/gmx/itp.py
+++ b/vermouth/gmx/itp.py
@@ -113,6 +113,14 @@ def write_molecule_itp(molecule, outfile):
 
     # Write the interactions
     for name, interactions in molecule.interactions.items():
+        # Do not write an empty section.
+        if not interactions:
+            continue
+        # Improper dihedral angles have their own section in the Molecule
+        # object to distinguish them from the proper dihedrals. Yet, they
+        # should be written under the [ dihedrals ] section of the ITP file.
+        if name == 'impropers':
+            name = 'dihedrals'
         outfile.write('[ {} ]\n'.format(name))
         interactions_group_sorted = sorted(
             interactions,


### PR DESCRIPTION
While proper dihedral angles can be used to set edges, improper ones cannot. Storing them separately makes things easier, also it allows to care about the difference only in places we know about the format: the reading of the ff file, and the writing of the itp file.

Creating edges for improper dihedral in blocks leads to erroneous graphs, and therefore erroneous results. Not creating them, however, makes the writing of links painstaking and error prone as you manually need to define the edges manually while you do not with the other common interaction types.

Improper dihedrals can also be written directly in the [ impropers ] section. However, not allowing them to live in the [ dihedrals ] one in counter intuitive for gromacs user and will break the assumption that a simple ITP file can serve as a force field file.