### PR TITLE
Add more options to martinize2

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -35,6 +35,7 @@ from vermouth.map_input import read_mapping_directory
 import itertools
 import operator
 import textwrap
+import functools
 
 
 def read_system(path):
@@ -180,6 +181,9 @@ def entry():
                         help='Elastic bond decay power p')
     parser.add_argument('-em', dest='rb_minimum_force', type=float, default=0,
                         help='Remove elastic bonds with force constant lower than this')
+    parser.add_argument('-eb', dest='rb_selection',
+                        type=lambda x: x.split(','), default=None,
+                        help='Comma separated list of bead names for elastic bonds')
     parser.add_argument('-nt', dest='neutral_terminii',
                         action='store_true', default=False,
                         help='Set neutral termini (charged is default)')
@@ -226,6 +230,14 @@ def entry():
 
     # Apply a rubber band elastic network is required.
     if args.elastic:
+        if args.rb_selection is not None:
+            selector = functools.partial(
+                selectors.proto_select_attribute_in,
+                attribute='atomname',
+                values=args.rb_selection,
+            )
+        else:
+            selector = selectors.select_backbone
         rubber_band_processor = vermouth.ApplyRubberBand(
             lower_bound=args.rb_lower_bound,
             upper_bound=args.rb_upper_bound,
@@ -233,6 +245,7 @@ def entry():
             decay_power=args.rb_decay_power,
             base_constant=args.rb_force_constant,
             minimum_force=args.rb_minimum_force,
+            selector=selector,
         )
         rubber_band_processor.run_system(system)
 

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -150,52 +150,58 @@ def write_gmx_topology(system, top_path, deduplicate=True):
 
 
 def entry():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-f', dest='inpath', required=True, type=Path,
-                        help='Input file (PDB|GRO)')
-    parser.add_argument('-x', dest='outpath', required=True, type=Path,
-                        help='Output coarse grained structure (PDB)')
-    parser.add_argument('-o', dest='top_path', type=Path,
-                        help='Output topology (TOP)')
-    parser.add_argument('-p', dest='posres', type=lambda x: x.lower(),
-                        choices=('none', 'all', 'backbone'), default='none',
-                        help='Output position restraints (None/All/Backbone) (default: None)')
-    parser.add_argument('-pf', dest='posres_fc', type=float, default=1000,
-                        help='Position restraints force constant (default: 1000 kJ/mol/nm^2)')
-    parser.add_argument('-ff', dest='to_ff', default='martini22',
-                        help='Which forcefield to use')
-    parser.add_argument('-dssp', nargs='?', const='dssp',
-                        help='DSSP executable for determining structure')
-    parser.add_argument('-ed', dest='extdih', action='store_true', default=False,
-                        help='Use dihedrals for extended regions rather than elastic bonds') 
-    parser.add_argument('-collagen', action='store_true', default=False,
-                        help='Use collagen parameters')
-    parser.add_argument('-elastic', action='store_true', default=False,
-                        help='Write elastic bonds')
-    parser.add_argument('-ef', dest='rb_force_constant', type=float, default=500,
-                        help='Elastic bond force constant Fc in kJ/mol/nm^2')
-    parser.add_argument('-el', dest='rb_lower_bound', type=float, default=0.5,
-                        help='Elastic bond lower cutoff: F = Fc if rij < lo')
-    parser.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9,
-                        help='Elastic bond upper cutoff: F = 0  if rij > up')
-    parser.add_argument('-ea', dest='rb_decay_factor', type=float, default=0,
-                        help='Elastic bond decay factor a')
-    parser.add_argument('-ep', dest='rb_decay_power', type=float, default=0,
-                        help='Elastic bond decay power p')
-    parser.add_argument('-em', dest='rb_minimum_force', type=float, default=0,
-                        help='Remove elastic bonds with force constant lower than this')
-    parser.add_argument('-eb', dest='rb_selection',
-                        type=lambda x: x.split(','), default=None,
-                        help='Comma separated list of bead names for elastic bonds')
-    parser.add_argument('-nt', dest='neutral_terminii',
-                        action='store_true', default=False,
-                        help='Set neutral termini (charged is default)')
-    parser.add_argument('-merge', dest='merge_chains',
-                        type=lambda x: x.split(','), action='append',
-                        help='Merge chains: e.g. -merge A,B,C (+)')
-    parser.add_argument('-sep', dest='deduplicate_itp',
-                        action='store_false', default=True,
-                        help='Write separate topologies for identical chains')
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    file_group = parser.add_argument_group('Input and output files')
+    file_group.add_argument('-f', dest='inpath', required=True, type=Path,
+                            help='Input file (PDB|GRO)')
+    file_group.add_argument('-x', dest='outpath', required=True, type=Path,
+                            help='Output coarse grained structure (PDB)')
+    file_group.add_argument('-o', dest='top_path', type=Path,
+                            help='Output topology (TOP)')
+    file_group.add_argument('-sep', dest='keep_duplicate_itp',
+                            action='store_true', default=False,
+                            help='Write separate topologies for identical chains')
+    file_group.add_argument('-merge', dest='merge_chains',
+                            type=lambda x: x.split(','), action='append',
+                            help='Merge chains: e.g. -merge A,B,C (+)')
+    ff_group = parser.add_argument_group('Force field selection')
+    ff_group.add_argument('-ff', dest='to_ff', default='martini22',
+                          help='Which forcefield to use')
+    posres_group = parser.add_argument_group('Position restraints')
+    posres_group.add_argument('-p', dest='posres', type=lambda x: x.lower(),
+                              choices=('none', 'all', 'backbone'), default='none',
+                              help='Output position restraints (none/all/backbone)')
+    posres_group.add_argument('-pf', dest='posres_fc', type=float, default=1000,
+                              help='Position restraints force constant in kJ/mol/nm^2')
+    secstruct_group = parser.add_argument_group('Secondary structure handling')
+    secstruct_group.add_argument('-dssp', nargs='?', const='dssp',
+                                 help='DSSP executable for determining structure')
+    secstruct_group.add_argument('-ed', dest='extdih', action='store_true', default=False,
+                                 help='Use dihedrals for extended regions rather than elastic bonds')
+    secstruct_group.add_argument('-collagen', action='store_true', default=False,
+                                 help='Use collagen parameters')
+    rb_group = parser.add_argument_group('Protein elastic network')
+    rb_group.add_argument('-elastic', action='store_true', default=False,
+                          help='Write elastic bonds')
+    rb_group.add_argument('-ef', dest='rb_force_constant', type=float, default=500,
+                          help='Elastic bond force constant Fc in kJ/mol/nm^2')
+    rb_group.add_argument('-el', dest='rb_lower_bound', type=float, default=0.5,
+                          help='Elastic bond lower cutoff: F = Fc if rij < lo')
+    rb_group.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9,
+                          help='Elastic bond upper cutoff: F = 0  if rij > up')
+    rb_group.add_argument('-ea', dest='rb_decay_factor', type=float, default=0,
+                          help='Elastic bond decay factor a')
+    rb_group.add_argument('-ep', dest='rb_decay_power', type=float, default=0,
+                          help='Elastic bond decay power p')
+    rb_group.add_argument('-em', dest='rb_minimum_force', type=float, default=0,
+                          help='Remove elastic bonds with force constant lower than this')
+    rb_group.add_argument('-eb', dest='rb_selection',
+                          type=lambda x: x.split(','), default=None,
+                          help='Comma separated list of bead names for elastic bonds')
+    prot_group = parser.add_argument_group('Protein description')
+    prot_group.add_argument('-nt', dest='neutral_terminii',
+                            action='store_true', default=False,
+                            help='Set neutral termini (charged is default)')
     args = parser.parse_args()
 
     known_force_fields = vermouth.forcefield.find_force_fields(
@@ -271,7 +277,8 @@ def entry():
     vermouth.pdb.write_pdb(system, str(args.outpath))
 
     if args.top_path is not None:
-        write_gmx_topology(system, args.top_path, deduplicate=args.deduplicate_itp)
+        write_gmx_topology(system, args.top_path,
+                           deduplicate=not args.keep_duplicate_itp)
 
 
 if __name__ == '__main__':

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -151,7 +151,7 @@ def entry():
     parser.add_argument('-x', dest='outpath', required=True, type=Path)
     parser.add_argument('-o', dest='top_path', type=Path)
     parser.add_argument('-p', dest='posres', type=lambda x: x.lower(),
-                        choices=('none', 'all', 'backbone'), default='None')
+                        choices=('none', 'all', 'backbone'), default='none')
     parser.add_argument('-pf', dest='posres_fc', type=float, default=500)
     parser.add_argument('-ff', dest='to_ff', default='martini22')
     parser.add_argument('-dssp', nargs='?', const='dssp')
@@ -166,6 +166,8 @@ def entry():
     parser.add_argument('-em', dest='rb_minimum_force', type=float, default=0)
     parser.add_argument('-nt', dest='neutral_terminii',
                         action='store_true', default=False)
+    parser.add_argument('-merge', dest='merge_chains',
+                        type=lambda x: x.split(','), action='append')
     args = parser.parse_args()
 
     known_force_fields = vermouth.forcefield.find_force_fields(
@@ -229,6 +231,10 @@ def entry():
     for molecule in system.molecules:
         for atom in molecule.nodes.values():
             atom['element'] = atom.get('cgsecstruct', 'X')
+
+    if args.merge_chains:
+        for chain_set in args.merge_chains:
+            vermouth.MergeChains(chain_set).run_system(system)
 
     # Write a PDB file.
     vermouth.pdb.write_pdb(system, str(args.outpath))

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -147,27 +147,45 @@ def write_gmx_topology(system, top_path):
 
 def entry():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', dest='inpath', required=True, type=Path)
-    parser.add_argument('-x', dest='outpath', required=True, type=Path)
-    parser.add_argument('-o', dest='top_path', type=Path)
+    parser.add_argument('-f', dest='inpath', required=True, type=Path,
+                        help='Input file (PDB|GRO)')
+    parser.add_argument('-x', dest='outpath', required=True, type=Path,
+                        help='Output coarse grained structure (PDB)')
+    parser.add_argument('-o', dest='top_path', type=Path,
+                        help='Output topology (TOP)')
     parser.add_argument('-p', dest='posres', type=lambda x: x.lower(),
-                        choices=('none', 'all', 'backbone'), default='none')
-    parser.add_argument('-pf', dest='posres_fc', type=float, default=500)
-    parser.add_argument('-ff', dest='to_ff', default='martini22')
-    parser.add_argument('-dssp', nargs='?', const='dssp')
-    parser.add_argument('-ed', dest='extdih', action='store_true', default=False) 
-    parser.add_argument('-collagen', action='store_true', default=False)
-    parser.add_argument('-elastic', action='store_true', default=False)
-    parser.add_argument('-ef', dest='rb_force_constant', type=float, default=500)
-    parser.add_argument('-el', dest='rb_lower_bound', type=float, default=0.5)
-    parser.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9)
-    parser.add_argument('-ea', dest='rb_decay_factor', type=float, default=0)
-    parser.add_argument('-ep', dest='rb_decay_power', type=float, default=0)
-    parser.add_argument('-em', dest='rb_minimum_force', type=float, default=0)
+                        choices=('none', 'all', 'backbone'), default='none',
+                        help='Output position restraints (None/All/Backbone) (default: None)')
+    parser.add_argument('-pf', dest='posres_fc', type=float, default=1000,
+                        help='Position restraints force constant (default: 1000 kJ/mol/nm^2)')
+    parser.add_argument('-ff', dest='to_ff', default='martini22',
+                        help='Which forcefield to use')
+    parser.add_argument('-dssp', nargs='?', const='dssp',
+                        help='DSSP executable for determining structure')
+    parser.add_argument('-ed', dest='extdih', action='store_true', default=False,
+                        help='Use dihedrals for extended regions rather than elastic bonds') 
+    parser.add_argument('-collagen', action='store_true', default=False,
+                        help='Use collagen parameters')
+    parser.add_argument('-elastic', action='store_true', default=False,
+                        help='Write elastic bonds')
+    parser.add_argument('-ef', dest='rb_force_constant', type=float, default=500,
+                        help='Elastic bond force constant Fc in kJ/mol/nm^2')
+    parser.add_argument('-el', dest='rb_lower_bound', type=float, default=0.5,
+                        help='Elastic bond lower cutoff: F = Fc if rij < lo')
+    parser.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9,
+                        help='Elastic bond upper cutoff: F = 0  if rij > up')
+    parser.add_argument('-ea', dest='rb_decay_factor', type=float, default=0,
+                        help='Elastic bond decay factor a')
+    parser.add_argument('-ep', dest='rb_decay_power', type=float, default=0,
+                        help='Elastic bond decay power p')
+    parser.add_argument('-em', dest='rb_minimum_force', type=float, default=0,
+                        help='Remove elastic bonds with force constant lower than this')
     parser.add_argument('-nt', dest='neutral_terminii',
-                        action='store_true', default=False)
+                        action='store_true', default=False,
+                        help='Set neutral termini (charged is default)')
     parser.add_argument('-merge', dest='merge_chains',
-                        type=lambda x: x.split(','), action='append')
+                        type=lambda x: x.split(','), action='append',
+                        help='Merge chains: e.g. -merge A,B,C (+)')
     args = parser.parse_args()
 
     known_force_fields = vermouth.forcefield.find_force_fields(

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -164,6 +164,8 @@ def entry():
     parser.add_argument('-ea', dest='rb_decay_factor', type=float, default=0)
     parser.add_argument('-ep', dest='rb_decay_power', type=float, default=0)
     parser.add_argument('-em', dest='rb_minimum_force', type=float, default=0)
+    parser.add_argument('-nt', dest='neutral_terminii',
+                        action='store_true', default=False)
     args = parser.parse_args()
 
     known_force_fields = vermouth.forcefield.find_force_fields(
@@ -192,6 +194,7 @@ def entry():
         AnnotateResidues(attribute='cgsecstruct', sequence='F',
                          molecule_selector=selectors.is_protein).run_system(system)
     vermouth.SetMoleculeMeta(extdih=args.extdih).run_system(system)
+    vermouth.SetMoleculeMeta(neutral_terminii=args.neutral_terminii).run_system(system)
 
     # Run martinize on the system.
     system = martinize(

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -149,6 +149,7 @@ def entry():
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', dest='inpath', required=True, type=Path)
     parser.add_argument('-x', dest='outpath', required=True, type=Path)
+    parser.add_argument('-o', dest='top_path', type=Path)
     parser.add_argument('-p', dest='posres',
                         choices=('None', 'All', 'Backbone'), default='None')
     parser.add_argument('-pf', dest='posres_fc', type=float, default=500)
@@ -229,7 +230,8 @@ def entry():
     # Write a PDB file.
     vermouth.pdb.write_pdb(system, str(args.outpath))
 
-    write_gmx_topology(system, Path('topol.top'))
+    if args.top_path is not None:
+        write_gmx_topology(system, args.top_path)
 
 
 if __name__ == '__main__':

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -225,13 +225,7 @@ def entry():
         node_selector = node_selectors[args.posres]
         vermouth.ApplyPosres(node_selector, args.posres_fc).run_system(system)
 
-    # For demonstration purpose, write the secondary structure assignation
-    # instead of the element.
-    # TODO: remove this code for production
-    for molecule in system.molecules:
-        for atom in molecule.nodes.values():
-            atom['element'] = atom.get('cgsecstruct', 'X')
-
+    # Merge chains if required.
     if args.merge_chains:
         for chain_set in args.merge_chains:
             vermouth.MergeChains(chain_set).run_system(system)

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -150,8 +150,8 @@ def entry():
     parser.add_argument('-f', dest='inpath', required=True, type=Path)
     parser.add_argument('-x', dest='outpath', required=True, type=Path)
     parser.add_argument('-o', dest='top_path', type=Path)
-    parser.add_argument('-p', dest='posres',
-                        choices=('None', 'All', 'Backbone'), default='None')
+    parser.add_argument('-p', dest='posres', type=lambda x: x.lower(),
+                        choices=('none', 'all', 'backbone'), default='None')
     parser.add_argument('-pf', dest='posres_fc', type=float, default=500)
     parser.add_argument('-ff', dest='to_ff', default='martini22')
     parser.add_argument('-dssp', nargs='?', const='dssp')
@@ -217,9 +217,9 @@ def entry():
         rubber_band_processor.run_system(system)
 
     # Apply position restraints if required.
-    if args.posres != 'None':
-        node_selectors = {'All': selectors.select_all,
-                          'Backbone': selectors.select_backbone}
+    if args.posres != 'none':
+        node_selectors = {'all': selectors.select_all,
+                          'backbone': selectors.select_backbone}
         node_selector = node_selectors[args.posres]
         vermouth.ApplyPosres(node_selector, args.posres_fc).run_system(system)
 

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -84,19 +84,22 @@ def martinize(system, mappings, to_ff, delete_unknown=False):
     return system
 
 
-def write_gmx_topology(system, top_path):
+def write_gmx_topology(system, top_path, deduplicate=True):
     if not system.molecules:
         raise ValueError('No molecule in the system. Nothing to write.')
-    # Deduplicate the moleculetypes in order to write each molecule ITP only
-    # once.
-    molecule_types = [[system.molecules[0], [system.molecules[0]]], ]
-    for molecule in system.molecules[1:]:
-        for molecule_type, share_moltype in molecule_types:
-            if molecule.share_moltype_with(molecule_type):
-                share_moltype.append(molecule)
-                break
-        else:  # no break
-            molecule_types.append([molecule, [molecule, ]])
+    if deduplicate:
+        # Deduplicate the moleculetypes in order to write each molecule ITP only
+        # once.
+        molecule_types = [[system.molecules[0], [system.molecules[0]]], ]
+        for molecule in system.molecules[1:]:
+            for molecule_type, share_moltype in molecule_types:
+                if molecule.share_moltype_with(molecule_type):
+                    share_moltype.append(molecule)
+                    break
+            else:  # no break
+                molecule_types.append([molecule, [molecule, ]])
+    else:
+        molecule_types = [[molecule, [molecule, ]] for molecule in system.molecules]
     # Write the ITP files for the moleculetypes.
     for molidx, (molecule_type, _) in enumerate(molecule_types):
         molecule_type.moltype = 'molecule_{}'.format(molidx)
@@ -190,6 +193,9 @@ def entry():
     parser.add_argument('-merge', dest='merge_chains',
                         type=lambda x: x.split(','), action='append',
                         help='Merge chains: e.g. -merge A,B,C (+)')
+    parser.add_argument('-sep', dest='deduplicate_itp',
+                        action='store_false', default=True,
+                        help='Write separate topologies for identical chains')
     args = parser.parse_args()
 
     known_force_fields = vermouth.forcefield.find_force_fields(
@@ -265,7 +271,7 @@ def entry():
     vermouth.pdb.write_pdb(system, str(args.outpath))
 
     if args.top_path is not None:
-        write_gmx_topology(system, args.top_path)
+        write_gmx_topology(system, args.top_path, deduplicate=args.deduplicate_itp)
 
 
 if __name__ == '__main__':

--- a/vermouth/data/force_fields/martini22/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22/aminoacids.ff
@@ -825,12 +825,16 @@ BB +++BB 1 0.970 2500
 
 ;; Protein terminii. These links should be applied last.
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
 BB -BB
 
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -863,6 +863,8 @@ BB +++BB 1 0.970 2500
 ;; Protein terminii. These links should be applied last.
 [ link ]
 resname $protein_resnames
+[ molmeta ]
+neutral_terminii not(true)
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -870,6 +872,8 @@ BB -BB
 
 [ link ]
 resname $protein_resnames
+[ molmeta ]
+neutral_terminii not(true)
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -681,12 +681,5 @@ def read_ff(lines, force_field):
     for link in links:
         link.make_edges_from_interactions()
 
-    # For debug purpose, we add a comment to the link interactions so
-    # they can be easily identified in the output topology.
-    for link in links:
-        for interactions in link.interactions.values():
-            for interaction in interactions:
-                interaction.meta['comment'] = 'Link'
-
     force_field.blocks.update(blocks)
     force_field.links.extend(links)

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -264,6 +264,7 @@ class Molecule(nx.Graph):
         self._force_field = kwargs.pop('force_field', None)
         super().__init__(*args, **kwargs)
         self.interactions = defaultdict(list)
+        self.nrexcl = None
 
     @property
     def force_field(self):
@@ -372,6 +373,12 @@ class Molecule(nx.Graph):
             raise ValueError(
                 'Cannot merge molecules with different force fields.'
             )
+        if self.nrexcl != molecule.nrexcl:
+            raise ValueError(
+                'Cannot merge molecules with different nrexcl. '
+                'This molecule has nrexcl={}, while the other has nrexcl={}.'
+                .format(self.nrexcl, molecule.nrexcl)
+            )
         if len(self.nodes()):
             # We assume that the last id is always the largest.
             last_node_idx = max(self) 
@@ -395,7 +402,7 @@ class Molecule(nx.Graph):
         for name, interactions in molecule.interactions.items():
             for interaction in interactions:
                 atoms = tuple(correspondence[atom] for atom in interaction.atoms)
-                self.add_interaction(name, atoms, interaction.parameters)
+                self.add_interaction(name, atoms, interaction.parameters, interaction.meta)
 
         for edge in molecule.edges:
             self.add_edge(*(correspondence[node] for node in edge))

--- a/vermouth/processors/__init__.py
+++ b/vermouth/processors/__init__.py
@@ -33,3 +33,4 @@ from .set_molecule_meta import SetMoleculeMeta
 from .locate_charge_dummies import LocateChargeDummies
 from .attach_mass import AttachMass
 from .apply_rubber_band import ApplyRubberBand
+from .merge_chains import MergeChains

--- a/vermouth/processors/apply_posres.py
+++ b/vermouth/processors/apply_posres.py
@@ -15,25 +15,32 @@
 from .processor import Processor
 
 
-def apply_posres(molecule, selector, force_constant, functype=1):
+def apply_posres(molecule, selector, force_constant, functype=1, ifdef='POSRES'):
     for key, node in molecule.nodes.items():
         if selector(node):
             parameters = [functype, ] + [force_constant, ] * 3
-            molecule.add_interaction('position_restraints', (key, ), parameters)
+            if ifdef is not None:
+                meta = {'ifdef': ifdef}
+            else:
+                meta = {}
+            molecule.add_interaction('position_restraints',
+                                     (key, ), parameters, meta)
     return molecule
 
 
 class ApplyPosres(Processor):
-    def __init__(self, selector, force_constant, functype=1):
+    def __init__(self, selector, force_constant, functype=1, ifdef='POSRES'):
         super().__init__()
         self.selector = selector
         self.force_constant = force_constant
         self.functype = functype
+        self.ifdef = ifdef
 
     def run_molecule(self, molecule):
         return apply_posres(
             molecule,
             self.selector,
             self.force_constant,
-            functype=self.functype
+            functype=self.functype,
+            ifdef=self.ifdef,
         )

--- a/vermouth/processors/merge_chains.py
+++ b/vermouth/processors/merge_chains.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Merge molecules by chain.
+"""
+
+from ..molecule import Molecule
+from ..processors.processor import Processor
+
+
+def merge_chains(system, chains):
+    """
+    Merge molecules with the given chains as a single molecule.
+
+    Molecules are merged into the resulting molecule if their chain is in the
+    list of chains to merge. The resulting molecule is not connected.
+
+    If a molecule comprises multiple chains, then it is merged only if all the
+    chains it comprises are part of the selection.
+
+    The meta variable are not conserved in the process.
+
+    The input system is modified in-place.
+
+    Parameters
+    ----------
+    system: vermouth.System
+        The system to modify.
+    chains: list of str
+        A container of chain identifier.
+    """
+    chains = set(chains)
+    merged = Molecule()
+    merged._force_field = system.force_field
+    has_merged = False
+    new_molecules = []
+    for molecule in system.molecules:
+        molecule_chains = set(node.get('chain') for node in molecule.nodes.values())
+        if molecule_chains.issubset(chains):
+            if not has_merged:
+                merged.nrexcl = molecule.nrexcl
+                new_molecules.append(merged)
+            merged.merge_molecule(molecule)
+            has_merged = True
+        else:
+            new_molecules.append(molecule)
+
+    system.molecules = new_molecules
+
+
+class MergeChains(Processor):
+    name = 'MergeChains'
+
+    def __init__(self, chains):
+        self.chains = chains
+
+    def run_system(self, system):
+        merge_chains(system, self.chains)

--- a/vermouth/selectors.py
+++ b/vermouth/selectors.py
@@ -75,6 +75,39 @@ def selector_has_position(atom):
     return position is not None and np.all(np.isfinite(position))
 
 
+def proto_select_attribute_in(node, attribute, values):
+    """
+    Return True if the given attribute of the node is in a list of values.
+
+    To be used as a selector, the function must be wrapped in a way that it can
+    be called without the need to explicitly specify the 'attribute' and
+    'values' arguments. This can be done using :fun:`functools.partial`:
+
+    >>> # select an atom if its name is in a given list
+    >>> to_keep = ['BB', 'SC1']
+    >>> select_name_in = functools.partial(
+    ...     proto_select_attribute_in,
+    ...     attribute='atomname',
+    ...     values=to_keep
+    ... )
+    >>> select_name_in(node)
+
+    Parameters
+    ----------
+    node: dict
+        The atom/node to consider.
+    attribute: str
+        The key to look at in the node.
+    values: list
+        The values the node attribute can take for the node to be selected.
+
+    Returns
+    -------
+    bool
+    """
+    return node.get(attribute) in values
+
+
 def filter_minimal(molecule, selector):
     """
     Yield the atom keys that match the selector.


### PR DESCRIPTION
With this PR, the help of martinize2 looks like this:

```
usage: martinize2 [-h] -f INPATH -x OUTPATH [-o TOP_PATH] [-sep]
                  [-merge MERGE_CHAINS] [-ff TO_FF] [-p {none,all,backbone}]
                  [-pf POSRES_FC] [-dssp [DSSP]] [-ed] [-collagen] [-elastic]
                  [-ef RB_FORCE_CONSTANT] [-el RB_LOWER_BOUND]
                  [-eu RB_UPPER_BOUND] [-ea RB_DECAY_FACTOR]
                  [-ep RB_DECAY_POWER] [-em RB_MINIMUM_FORCE]
                  [-eb RB_SELECTION] [-nt]

optional arguments:
  -h, --help            show this help message and exit

Input and output files:
  -f INPATH             Input file (PDB|GRO) (default: None)
  -x OUTPATH            Output coarse grained structure (PDB) (default: None)
  -o TOP_PATH           Output topology (TOP) (default: None)
  -sep                  Write separate topologies for identical chains
                        (default: False)
  -merge MERGE_CHAINS   Merge chains: e.g. -merge A,B,C (+) (default: None)

Force field selection:
  -ff TO_FF             Which forcefield to use (default: martini22)

Position restraints:
  -p {none,all,backbone}
                        Output position restraints (none/all/backbone)
                        (default: none)
  -pf POSRES_FC         Position restraints force constant in kJ/mol/nm^2
                        (default: 1000)

Secondary structure handling:
  -dssp [DSSP]          DSSP executable for determining structure (default:
                        None)
  -ed                   Use dihedrals for extended regions rather than elastic
                        bonds (default: False)
  -collagen             Use collagen parameters (default: False)

Protein elastic network:
  -elastic              Write elastic bonds (default: False)
  -ef RB_FORCE_CONSTANT
                        Elastic bond force constant Fc in kJ/mol/nm^2
                        (default: 500)
  -el RB_LOWER_BOUND    Elastic bond lower cutoff: F = Fc if rij < lo
                        (default: 0.5)
  -eu RB_UPPER_BOUND    Elastic bond upper cutoff: F = 0 if rij > up (default:
                        0.9)
  -ea RB_DECAY_FACTOR   Elastic bond decay factor a (default: 0)
  -ep RB_DECAY_POWER    Elastic bond decay power p (default: 0)
  -em RB_MINIMUM_FORCE  Remove elastic bonds with force constant lower than
                        this (default: 0)
  -eb RB_SELECTION      Comma separated list of bead names for elastic bonds
                        (default: None)

Protein description:
  -nt                   Set neutral termini (charged is default) (default:
                        False)
```