### PR TITLE
Allow calculation of dihedral angles

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -29,7 +29,7 @@ from .molecule import (
     Block, Link,
     Interaction, DeleteInteraction,
     Choice, NotDefinedOrNot,
-    ParamDistance, ParamAngle,
+    ParamDistance, ParamAngle, ParamDihedral,
 )
 
 VALUE_PREDICATES = {
@@ -39,6 +39,7 @@ VALUE_PREDICATES = {
 PARAMETER_EFFECTORS = {
     'dist': ParamDistance,
     'angle': ParamAngle,
+    'dihedral': ParamDihedral,
 }
 
 

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -29,7 +29,7 @@ from .molecule import (
     Block, Link,
     Interaction, DeleteInteraction,
     Choice, NotDefinedOrNot,
-    ParamDistance, ParamAngle, ParamDihedral,
+    ParamDistance, ParamAngle, ParamDihedral, ParamDihedralLeft,
 )
 
 VALUE_PREDICATES = {
@@ -40,6 +40,7 @@ PARAMETER_EFFECTORS = {
     'dist': ParamDistance,
     'angle': ParamAngle,
     'dihedral': ParamDihedral,
+    'dihleft': ParamDihedralLeft,
 }
 
 

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -29,7 +29,7 @@ from .molecule import (
     Block, Link,
     Interaction, DeleteInteraction,
     Choice, NotDefinedOrNot,
-    ParamDistance, ParamAngle, ParamDihedral, ParamDihedralLeft,
+    ParamDistance, ParamAngle, ParamDihedral, ParamDihedralPhase,
 )
 
 VALUE_PREDICATES = {
@@ -40,7 +40,7 @@ PARAMETER_EFFECTORS = {
     'dist': ParamDistance,
     'angle': ParamAngle,
     'dihedral': ParamDihedral,
-    'dihleft': ParamDihedralLeft,
+    'dihphase': ParamDihedralPhase,
 }
 
 

--- a/vermouth/geometry.py
+++ b/vermouth/geometry.py
@@ -53,6 +53,8 @@ def dihedral(vectorAB, vectorBC, vectorCD):
              \
               C - D
     
+    The angle around the BC axis is returned with values between -pi and +pi.
+    The direction of the angle follows the right hand convention.
     """
     normalABC = np.cross(vectorAB, vectorBC)
     normalBCD = np.cross(vectorBC, vectorCD)
@@ -60,3 +62,20 @@ def dihedral(vectorAB, vectorBC, vectorCD):
     pcos = np.dot(normalABC, normalBCD)
     return np.arctan2(psin, pcos)
 
+
+def dihedral_left(vectorAB, vectorBC, vectorCD):
+    """
+    Calculate a dihedral angle in radians following the left hand convention.
+
+    See Also
+    --------
+    dihedral
+        Calculate a dihedral angle in the right hand convention.
+    """
+    angle = dihedral(vectorAB, vectorBC, vectorCD)
+    angle -= np.pi
+    if angle > np.pi:
+        angle -= 2 * np.pi
+    if angle < -np.pi:
+        angle += 2 * np.pi
+    return angle

--- a/vermouth/geometry.py
+++ b/vermouth/geometry.py
@@ -63,14 +63,14 @@ def dihedral(vectorAB, vectorBC, vectorCD):
     return np.arctan2(psin, pcos)
 
 
-def dihedral_left(vectorAB, vectorBC, vectorCD):
+def dihedral_phase(vectorAB, vectorBC, vectorCD):
     """
-    Calculate a dihedral angle in radians following the left hand convention.
+    Calculate a dihedral angle in radians with a -pi phase correction.
 
     See Also
     --------
     dihedral
-        Calculate a dihedral angle in the right hand convention.
+        Calculate a dihedral angle.
     """
     angle = dihedral(vectorAB, vectorBC, vectorCD)
     angle -= np.pi

--- a/vermouth/geometry.py
+++ b/vermouth/geometry.py
@@ -36,26 +36,28 @@ def angle(vectorBA, vectorBC):
     denominator = np.linalg.norm(vectorBA) * np.linalg.norm(vectorBC)
     cosine = nominator / denominator
     # Floating errors at the limits may cause issues.
-    if cosine > 1:
-        cosine = 1
-    elif cosine < -1:
-        cosine = -1
+    cosine = np.clip(cosine, -1, 1)
     return np.arccos(cosine)
 
 
-def dihedral(vectorAB, vectorBC, vectorCD):
+def dihedral(coordinates):
     """
-    Calculate the dihedral angle in radians formed by 3 vectors.
+    Calculate the dihedral angle in radians.
 
-    The function assumes the following situation:
+    Parameters
+    ----------
+    coordinates: np.ndarray
+        The coordinates of 4 points defining the dihedral angle. Each row
+        corresponds to a point, and each column to a dimension.
 
-        A - B
-             \
-              C - D
-    
-    The angle around the BC axis is returned with values between -pi and +pi.
-    The direction of the angle follows the right hand convention.
+    Returns
+    -------
+    float
+        The calculated angle between -pi and +pi.
     """
+    vectorAB = coordinates[1, :] - coordinates[0, :]
+    vectorBC = coordinates[2, :] - coordinates[1, :]
+    vectorCD = coordinates[3, :] - coordinates[2, :]
     normalABC = np.cross(vectorAB, vectorBC)
     normalBCD = np.cross(vectorBC, vectorCD)
     psin = np.dot(normalABC, vectorCD) * np.linalg.norm(vectorBC)
@@ -63,16 +65,27 @@ def dihedral(vectorAB, vectorBC, vectorCD):
     return np.arctan2(psin, pcos)
 
 
-def dihedral_phase(vectorAB, vectorBC, vectorCD):
+def dihedral_phase(coordinates):
     """
     Calculate a dihedral angle in radians with a -pi phase correction.
+
+    Parameters
+    ----------
+    coordinates: np.ndarray
+        The coordinates of 4 points defining the dihedral angle. Each row
+        corresponds to a point, and each column to a dimension.
+
+    Returns
+    -------
+    float
+        The calculated angle between -pi and +pi.
 
     See Also
     --------
     dihedral
         Calculate a dihedral angle.
     """
-    angle = dihedral(vectorAB, vectorBC, vectorCD)
+    angle = dihedral(coordinates)
     angle -= np.pi
     if angle > np.pi:
         angle -= 2 * np.pi

--- a/vermouth/geometry.py
+++ b/vermouth/geometry.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Geometric operations.
+"""
+
+import numpy as np
+
+
+def angle(vectorBA, vectorBC):
+    """
+    Calculate the angle in radians between two vectors.
+
+    The function assumes the following situation:
+
+          B
+         / \
+        A   C
+
+    It returns the angle between BA and BC.
+    """
+    nominator = np.dot(vectorBA, vectorBC)
+    denominator = np.linalg.norm(vectorBA) * np.linalg.norm(vectorBC)
+    cosine = nominator / denominator
+    # Floating errors at the limits may cause issues.
+    if cosine > 1:
+        cosine = 1
+    elif cosine < -1:
+        cosine = -1
+    return np.arccos(cosine)
+
+
+def dihedral(vectorAB, vectorBC, vectorCD):
+    """
+    Calculate the dihedral angle in radians formed by 3 vectors.
+
+    The function assumes the following situation:
+
+        A - B
+             \
+              C - D
+    
+    """
+    normalABC = np.cross(vectorAB, vectorBC)
+    normalBCD = np.cross(vectorBC, vectorCD)
+    psin = np.dot(normalABC, vectorCD) * np.linalg.norm(vectorBC)
+    pcos = np.dot(normalABC, normalBCD)
+    return np.arctan2(psin, pcos)
+

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -267,6 +267,20 @@ class ParamDihedral(LinkParameterEffector):
         return np.degrees(angle)
 
 
+class ParamDihedralLeft(LinkParameterEffector):
+    n_keys_asked = 4
+
+    def apply(self, molecule, keys):
+        # This will raise a ValueError if an atom is missing, or if an
+        # atom does not have position.
+        positions = np.stack([molecule.nodes[key]['position'] for key in keys])
+        vectorAB = positions[1, :] - positions[0, :]
+        vectorBC = positions[2, :] - positions[1, :]
+        vectorCD = positions[3, :] - positions[2, :]
+        angle = geometry.dihedral_left(vectorAB, vectorBC, vectorCD)
+        return np.degrees(angle)
+
+
 class Molecule(nx.Graph):
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -27,6 +27,7 @@ import networkx as nx
 import numpy as np
 
 from . import graph_utils
+from . import geometry
 
 
 Interaction = namedtuple('Interaction', 'atoms parameters meta')
@@ -248,10 +249,22 @@ class ParamAngle(LinkParameterEffector):
         positions = np.stack([molecule.nodes[key]['position'] for key in keys])
         vectorBA = positions[0, :] - positions[1, :]
         vectorBC = positions[2, :] - positions[1, :]
-        nominator = np.dot(vectorBA, vectorBC)
-        denominator = np.linalg.norm(vectorBA) * np.linalg.norm(vectorBC)
-        cosine = nominator / denominator
-        return np.degrees(np.arccos(cosine))
+        angle = geometry.angle(vectorBA, vectorBC)
+        return np.degrees(angle)
+
+
+class ParamDihedral(LinkParameterEffector):
+    n_keys_asked = 4
+
+    def apply(self, molecule, keys):
+        # This will raise a ValueError if an atom is missing, or if an
+        # atom does not have position.
+        positions = np.stack([molecule.nodes[key]['position'] for key in keys])
+        vectorAB = positions[1, :] - positions[0, :]
+        vectorBC = positions[2, :] - positions[1, :]
+        vectorCD = positions[3, :] - positions[2, :]
+        angle = geometry.dihedral(vectorAB, vectorBC, vectorCD)
+        return np.degrees(angle)
 
 
 class Molecule(nx.Graph):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -254,6 +254,9 @@ class ParamAngle(LinkParameterEffector):
 
 
 class ParamDihedral(LinkParameterEffector):
+    """
+    Calculate the dihedral angle in degrees defined by four nodes.
+    """
     n_keys_asked = 4
 
     def apply(self, molecule, keys):
@@ -268,6 +271,9 @@ class ParamDihedral(LinkParameterEffector):
 
 
 class ParamDihedralPhase(LinkParameterEffector):
+    """
+    Calculate the dihedral angle in degrees defined by four nodes shifted by -180 degrees.
+    """
     n_keys_asked = 4
 
     def apply(self, molecule, keys):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -259,7 +259,7 @@ class ParamDihedral(LinkParameterEffector):
     """
     n_keys_asked = 4
 
-    def apply(self, molecule, keys):
+    def _apply(self, molecule, keys):
         # This will raise a ValueError if an atom is missing, or if an
         # atom does not have position.
         positions = np.stack([molecule.nodes[key]['position'] for key in keys])
@@ -276,7 +276,7 @@ class ParamDihedralPhase(LinkParameterEffector):
     """
     n_keys_asked = 4
 
-    def apply(self, molecule, keys):
+    def _apply(self, molecule, keys):
         # This will raise a ValueError if an atom is missing, or if an
         # atom does not have position.
         positions = np.stack([molecule.nodes[key]['position'] for key in keys])

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -267,7 +267,7 @@ class ParamDihedral(LinkParameterEffector):
         return np.degrees(angle)
 
 
-class ParamDihedralLeft(LinkParameterEffector):
+class ParamDihedralPhase(LinkParameterEffector):
     n_keys_asked = 4
 
     def apply(self, molecule, keys):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -263,10 +263,7 @@ class ParamDihedral(LinkParameterEffector):
         # This will raise a ValueError if an atom is missing, or if an
         # atom does not have position.
         positions = np.stack([molecule.nodes[key]['position'] for key in keys])
-        vectorAB = positions[1, :] - positions[0, :]
-        vectorBC = positions[2, :] - positions[1, :]
-        vectorCD = positions[3, :] - positions[2, :]
-        angle = geometry.dihedral(vectorAB, vectorBC, vectorCD)
+        angle = geometry.dihedral(positions)
         return np.degrees(angle)
 
 
@@ -280,10 +277,7 @@ class ParamDihedralPhase(LinkParameterEffector):
         # This will raise a ValueError if an atom is missing, or if an
         # atom does not have position.
         positions = np.stack([molecule.nodes[key]['position'] for key in keys])
-        vectorAB = positions[1, :] - positions[0, :]
-        vectorBC = positions[2, :] - positions[1, :]
-        vectorCD = positions[3, :] - positions[2, :]
-        angle = geometry.dihedral_left(vectorAB, vectorBC, vectorCD)
+        angle = geometry.dihedral_left(positions)
         return np.degrees(angle)
 
 

--- a/vermouth/tests/test_geometry.py
+++ b/vermouth/tests/test_geometry.py
@@ -114,3 +114,16 @@ def test_dihedral(points, angle):
     vectorBC = points[2, :] - points[1, :]
     vectorCD = points[3, :] - points[2, :]
     assert np.allclose(geometry.dihedral(vectorAB, vectorBC, vectorCD), angle)
+
+
+@pytest.mark.parametrize('points, angle', _generate_test_dihedrals(10))
+def test_dihedral_phase(points, angle):
+    vectorAB = points[1, :] - points[0, :]
+    vectorBC = points[2, :] - points[1, :]
+    vectorCD = points[3, :] - points[2, :]
+    angle_phase = angle + np.pi
+    if angle_phase > np.pi:
+        angle_phase -= 2 * np.pi
+    if angle_phase < -np.pi:
+        angle_phase += 2 * np.pi
+    assert np.allclose(geometry.dihedral_phase(vectorAB, vectorBC, vectorCD), angle_phase)

--- a/vermouth/tests/test_geometry.py
+++ b/vermouth/tests/test_geometry.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the geometry module.
+"""
+
+import pytest
+import numpy as np
+from vermouth import geometry
+
+
+def _generate_test_angles(n_angles):
+    """
+    Gererate a series of coordinates of 3 points at a different angles.
+
+    Generate 'n_angles' structures with angles between 0 and pi with regular
+    angle spacing.
+
+    Parameters
+    ----------
+    n_angles: int
+        Number of structures to generate.
+
+    Yields
+    ------
+    coordinates: np.ndrarray
+        The coordinates of the points. Each row corresponds to a pointm and
+        each column corresponds to a dimension.
+    angle: float
+        The angle between the 3 points.
+    """
+    # The shift is arbitrary. Its purpose is to avoid having the angle centered
+    # at the origin as it may be a special case.
+    shift = np.array([1.1, -7.2, 9.1])
+    coordinates = np.array([
+        [2, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],  # Will be redifined
+    ]) + shift
+    # The distance of the 3rd point to the second one, also the radius in polar
+    # coordinates. The value is totally arbitrary, and it should not change the
+    # angle; but avoid setting the radius to 1 as it may hide normalization
+    # errors.
+    radius = 4.2
+    for angle in np.linspace(0, np.pi, num=n_angles):
+        coordinates[-1, 0] = radius * np.cos(angle) + shift[0]
+        coordinates[-1, 1] = radius * np.sin(angle) + shift[1]
+        yield coordinates.copy(), angle
+
+
+def _generate_test_dihedrals(n_angles):
+    """
+    Generate a series of coordinates for 4 points at different torsion angles.
+
+    Generate 'n_angles' structures with torsion angles between -pi and +pi
+    with regular angle spacing.
+
+    Parameters
+    ----------
+    n_angles: int
+        Number of structures to generate.
+
+    Yields
+    ------
+    coordinates: np.ndrarray
+        The coordinates of the points. Each row corresponds to a pointm and
+        each column corresponds to a dimension.
+    angle: float
+        The angle around the ais between the middle points.
+    """
+    # The shift is arbitrary. Its purpose is to avoid having the angle centered
+    # at the origin as it may be a special case.
+    shift = np.array([1.1, -7.2, 9.1])
+    coordinates = np.array([
+        [2, 0, 0],
+        [0, 0, 0],
+        [0, 0, 5],
+        [0, 0, 5],  # Will be redifined
+    ]) + shift
+    # The distance of the 3rd point to the second one, also the radius in polar
+    # coordinates. The value is totally arbitrary, and it should not change the
+    # angle; but avoid setting the radius to 1 as it may hide normalization
+    # errors.
+    radius = 4.2
+    for angle in np.linspace(-np.pi, +np.pi, num=n_angles):
+        coordinates[-1, 0] = radius * np.cos(angle) + shift[0]
+        coordinates[-1, 1] = radius * np.sin(angle) + shift[1]
+        yield coordinates.copy(), angle
+
+
+@pytest.mark.parametrize('points, angle', _generate_test_angles(10))
+def test_angle(points, angle):
+    vectorBA = points[0, :] - points[1, :]
+    vectorBC = points[2, :] - points[1, :]
+    assert np.allclose(geometry.angle(vectorBA, vectorBC), angle)
+
+
+@pytest.mark.parametrize('points, angle', _generate_test_dihedrals(10))
+def test_dihedral(points, angle):
+    vectorAB = points[1, :] - points[0, :]
+    vectorBC = points[2, :] - points[1, :]
+    vectorCD = points[3, :] - points[2, :]
+    assert np.allclose(geometry.dihedral(vectorAB, vectorBC, vectorCD), angle)


### PR DESCRIPTION
Add a function to calculate dihedral angles, but also dihedral angles shifted by -pi as used by scFix. The function also adds the corresponding link parameter effectors.

The function to calculate the angles is moved to the new `geometry.py` module that even has tests.