### PR TITLE
Add flexibility in the choice of the force fields

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -245,8 +245,6 @@ def entry():
         raise ValueError('No mapping known to go from "{}" to "{}".'
                          .format(from_ff, args.to_ff))
 
-    print(known_mappings['universal']['universal'])
-
     # Reading the input structure.
     # So far, we assume we only go from atomistic to martini. We want the
     # input structure to be a clean universal system.

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -167,6 +167,14 @@ def entry():
     ff_group = parser.add_argument_group('Force field selection')
     ff_group.add_argument('-ff', dest='to_ff', default='martini22',
                           help='Which forcefield to use')
+    ff_group.add_argument('-from', dest='from_ff', default='universal',
+                          help='Force field of the original structure.')
+    ff_group.add_argument('-ff-dir', dest='extra_ff_dir', action='append',
+                          type=Path, default=[],
+                          help='Additional repository for custom force fields.')
+    ff_group.add_argument('-map-dir', dest='extra_map_dir', action='append',
+                          type=Path, default=[],
+                          help='Additional repository for mapping files.')
     posres_group = parser.add_argument_group('Position restraints')
     posres_group.add_argument('-p', dest='posres', type=lambda x: x.lower(),
                               choices=('none', 'all', 'backbone'), default='none',
@@ -209,9 +217,27 @@ def entry():
     )
     known_mappings = read_mapping_directory(Path(DATA_PATH) / 'mappings')
 
-    from_ff = 'universal'
+    # Add user force fields and mappings
+    for directory in args.extra_ff_dir:
+        if not directory.is_dir():
+            raise ValueError('"{}" given to the -ff-dir option should be a directory.')
+        known_force_fields.update(vermouth.forcefield.find_force_fields(directory))
+    for directory in args.extra_map_dir:
+        if not directory.is_dir():
+            raise ValueError('"{}" given to the -map-dir option should be a directory.')
+        partial_mapping = read_mapping_directory(directory)
+        for origin, destinations in partial_mapping.items():
+            known_mappings[origin] = known_mappings.get(origin, {})
+            for destination, residues in destinations.items():
+                known_mappings[origin][destination] = known_mappings[origin].get(destination, {})
+                for residue, mapping in residues.items():
+                    known_mappings[origin][destination][residue] = mapping
+
+    from_ff = args.from_ff
     if args.to_ff not in known_force_fields:
         raise ValueError('Unknown force field "{}".'.format(args.to_ff))
+    if args.from_ff not in known_force_fields:
+        raise ValueError('Unknown force field "{}".'.format(args.from_ff))
     if from_ff not in known_mappings or args.to_ff not in known_mappings[from_ff]:
         raise ValueError('No mapping known to go from "{}" to "{}".'
                          .format(from_ff, args.to_ff))

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -61,12 +61,13 @@ def read_system(path):
     return system
 
 
-def pdb_to_universal(system, delete_unknown=False):
+def pdb_to_universal(system, delete_unknown=False,
+                     force_field=FORCE_FIELDS['universal']):
     """
     Convert a system read from the PDB to a clean canonical atomistic system.
     """
     canonicalized = system.copy()
-    canonicalized.force_field = FORCE_FIELDS['universal']
+    canonicalized.force_field = force_field
     vermouth.MakeBonds().run_system(canonicalized)
     vermouth.RepairGraph(delete_unknown=delete_unknown).run_system(canonicalized)
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
@@ -250,7 +251,8 @@ def entry():
     # input structure to be a clean universal system.
     # For now at least, we silently delete molecules with unknown blocks.
     system = read_system(args.inpath)
-    system = pdb_to_universal(system, delete_unknown=True)
+    system = pdb_to_universal(system, delete_unknown=True,
+                              force_field=known_force_fields[from_ff])
 
     if args.dssp is not None:
         AnnotateDSSP(executable=args.dssp, savedir='.').run_system(system)
@@ -302,12 +304,17 @@ def entry():
         for chain_set in args.merge_chains:
             vermouth.MergeChains(chain_set).run_system(system)
 
-    # Write a PDB file.
-    vermouth.pdb.write_pdb(system, str(args.outpath))
-
+    # Write the topology if requested
     if args.top_path is not None:
         write_gmx_topology(system, args.top_path,
                            deduplicate=not args.keep_duplicate_itp)
+
+    # Write a PDB file.
+    # Get rid of the charge, the PDB format is too primitive to actually write them.
+    for molecule in system.molecules:
+        for node in molecule.nodes.values():
+            del node['charge']
+    vermouth.pdb.write_pdb(system, str(args.outpath))
 
 
 if __name__ == '__main__':

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -313,7 +313,10 @@ def entry():
     # Get rid of the charge, the PDB format is too primitive to actually write them.
     for molecule in system.molecules:
         for node in molecule.nodes.values():
-            del node['charge']
+            try:
+                del node['charge']
+            except KeyError:
+                pass
     vermouth.pdb.write_pdb(system, str(args.outpath))
 
 

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -31,7 +31,11 @@ from vermouth.dssp.dssp import (
     AnnotateResidues,
 )
 from vermouth import selectors
-from vermouth.map_input import read_mapping_directory
+from vermouth.map_input import (
+    read_mapping_directory,
+    generate_all_self_mappings,
+    combine_mappings
+)
 import itertools
 import operator
 import textwrap
@@ -226,12 +230,11 @@ def entry():
         if not directory.is_dir():
             raise ValueError('"{}" given to the -map-dir option should be a directory.')
         partial_mapping = read_mapping_directory(directory)
-        for origin, destinations in partial_mapping.items():
-            known_mappings[origin] = known_mappings.get(origin, {})
-            for destination, residues in destinations.items():
-                known_mappings[origin][destination] = known_mappings[origin].get(destination, {})
-                for residue, mapping in residues.items():
-                    known_mappings[origin][destination][residue] = mapping
+        combine_mappings(known_mappings, partial_mapping)
+        
+    # Build self mappings
+    partial_mapping = generate_all_self_mappings(known_force_fields)
+    combine_mappings(known_mappings, partial_mapping)
 
     from_ff = args.from_ff
     if args.to_ff not in known_force_fields:
@@ -241,6 +244,8 @@ def entry():
     if from_ff not in known_mappings or args.to_ff not in known_mappings[from_ff]:
         raise ValueError('No mapping known to go from "{}" to "{}".'
                          .format(from_ff, args.to_ff))
+
+    print(known_mappings['universal']['universal'])
 
     # Reading the input structure.
     # So far, we assume we only go from atomistic to martini. We want the

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -226,7 +226,7 @@ def entry():
     for directory in args.extra_ff_dir:
         if not directory.is_dir():
             raise ValueError('"{}" given to the -ff-dir option should be a directory.')
-        known_force_fields.update(vermouth.forcefield.find_force_fields(directory))
+        vermouth.forcefield.find_force_fields(directory, known_force_fields)
     for directory in args.extra_map_dir:
         if not directory.is_dir():
             raise ValueError('"{}" given to the -map-dir option should be a directory.')

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -169,6 +169,7 @@ def entry():
     file_group.add_argument('-merge', dest='merge_chains',
                             type=lambda x: x.split(','), action='append',
                             help='Merge chains: e.g. -merge A,B,C (+)')
+
     ff_group = parser.add_argument_group('Force field selection')
     ff_group.add_argument('-ff', dest='to_ff', default='martini22',
                           help='Which forcefield to use')
@@ -180,6 +181,7 @@ def entry():
     ff_group.add_argument('-map-dir', dest='extra_map_dir', action='append',
                           type=Path, default=[],
                           help='Additional repository for mapping files.')
+
     posres_group = parser.add_argument_group('Position restraints')
     posres_group.add_argument('-p', dest='posres', type=lambda x: x.lower(),
                               choices=('none', 'all', 'backbone'), default='none',
@@ -193,6 +195,7 @@ def entry():
                                  help='Use dihedrals for extended regions rather than elastic bonds')
     secstruct_group.add_argument('-collagen', action='store_true', default=False,
                                  help='Use collagen parameters')
+
     rb_group = parser.add_argument_group('Protein elastic network')
     rb_group.add_argument('-elastic', action='store_true', default=False,
                           help='Write elastic bonds')
@@ -211,6 +214,7 @@ def entry():
     rb_group.add_argument('-eb', dest='rb_selection',
                           type=lambda x: x.split(','), default=None,
                           help='Comma separated list of bead names for elastic bonds')
+
     prot_group = parser.add_argument_group('Protein description')
     prot_group.add_argument('-nt', dest='neutral_terminii',
                             action='store_true', default=False,
@@ -224,13 +228,17 @@ def entry():
 
     # Add user force fields and mappings
     for directory in args.extra_ff_dir:
-        if not directory.is_dir():
-            raise ValueError('"{}" given to the -ff-dir option should be a directory.')
-        vermouth.forcefield.find_force_fields(directory, known_force_fields)
+        try:
+            vermouth.forcefield.find_force_fields(directory, known_force_fields)
+        except FileNotFoundError:
+            msg = '"{}" given to the -ff-dir option should be a directory.'
+            raise ValueError(msg.format(directory))
     for directory in args.extra_map_dir:
-        if not directory.is_dir():
-            raise ValueError('"{}" given to the -map-dir option should be a directory.')
-        partial_mapping = read_mapping_directory(directory)
+        try:
+            partial_mapping = read_mapping_directory(directory)
+        except NotADirectoryError:
+            msg = '"{}" given to the -map-dir option should be a directory.'
+            raise ValueError(msg.format(directory))
         combine_mappings(known_mappings, partial_mapping)
         
     # Build self mappings
@@ -310,14 +318,7 @@ def entry():
                            deduplicate=not args.keep_duplicate_itp)
 
     # Write a PDB file.
-    # Get rid of the charge, the PDB format is too primitive to actually write them.
-    for molecule in system.molecules:
-        for node in molecule.nodes.values():
-            try:
-                del node['charge']
-            except KeyError:
-                pass
-    vermouth.pdb.write_pdb(system, str(args.outpath))
+    vermouth.pdb.write_pdb(system, str(args.outpath), omit_charges=True)
 
 
 if __name__ == '__main__':

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -14,6 +14,7 @@
 
 import itertools
 from glob import glob
+from pathlib import Path
 import os
 from .gmx.rtp import read_rtp
 from .ffinput import read_ff
@@ -58,10 +59,14 @@ def find_force_fields(directory, force_fields=None):
         except StopIteration:
             pass
         else:
-            if name not in force_fields:
-                force_fields[name] = ForceField(path)
-            else:
-                force_fields[name].read_from(path)
+            try:
+                if name not in force_fields:
+                    force_fields[name] = ForceField(path)
+                else:
+                    force_fields[name].read_from(path)
+            except IOError:
+                msg = 'An error occured while reading the force field in  "{}".'
+                raise IOError(msg.format(path))
     return force_fields
 
 

--- a/vermouth/map_input.py
+++ b/vermouth/map_input.py
@@ -173,6 +173,8 @@ def read_mapping_directory(directory):
         A collection of mappings.
     """
     directory = Path(directory)
+    if not directory.is_dir():
+        raise NotADirectoryError('"{}" is not a directory.'.format(directory))
     mappings = collections.defaultdict(lambda: collections.defaultdict(dict))
     for path in directory.glob('**/*.map'):
         with open(path) as infile:

--- a/vermouth/map_input.py
+++ b/vermouth/map_input.py
@@ -191,7 +191,7 @@ def generate_self_mappings(blocks):
             for atom in block.nodes.values()
         }
         weights = {
-            atom['atomname']: {atom['atomname']: 1}
+            (0, atom['atomname']): {(0, atom['atomname']): 1}
             for atom in block.nodes.values()
         }
         extra = []

--- a/vermouth/map_input.py
+++ b/vermouth/map_input.py
@@ -182,3 +182,34 @@ def read_mapping_directory(directory):
             mappings[from_ff][to_ff] = dict(mappings[from_ff][to_ff])
     return dict(mappings)
 
+
+def generate_self_mappings(blocks):
+    mappings = {}
+    for name, block in blocks.items():
+        mapping = {
+            (0, atom['atomname']): [(0, atom['atomname'])]
+            for atom in block.nodes.values()
+        }
+        weights = {
+            atom['atomname']: {atom['atomname']: 1}
+            for atom in block.nodes.values()
+        }
+        extra = []
+        mappings[name] = (mapping, weights, extra)
+    return mappings
+
+
+def generate_all_self_mappings(force_fields):
+    mappings = collections.defaultdict(dict)
+    for name, force_field in force_fields.items():
+        mappings[name][name] = generate_self_mappings(force_field.blocks)
+    return mappings
+
+
+def combine_mappings(known_mappings, partial_mapping):
+    for origin, destinations in partial_mapping.items():
+        known_mappings[origin] = known_mappings.get(origin, {})
+        for destination, residues in destinations.items():
+            known_mappings[origin][destination] = known_mappings[origin].get(destination, {})
+            for residue, mapping in residues.items():
+                known_mappings[origin][destination][residue] = mapping

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -421,6 +421,13 @@ class Block(nx.Graph):
     """
     Residue topology template
 
+    Parameters
+    ----------
+    incoming_graph_data:
+        Data to initialize graph. If None (default) an empty graph is created.
+    attr:
+        Attributes to add to graph as key=value pairs.
+
     Attributes
     ----------
     name: str or None
@@ -445,10 +452,18 @@ class Block(nx.Graph):
     # ordered.
     node_dict_factory = OrderedDict
 
-    def __init__(self):
-        super(Block, self).__init__(self)
-        self.name = None
-        self.interactions = {}
+    def __init__(self, incoming_graph_data=None, **attr):
+        super(Block, self).__init__(incoming_graph_data, **attr)
+        # Arbitrary attributes can be set during the initialization. We need
+        # to set the default of some key attributes, but without overwritting
+        # what has been passed in the 'attr' argument.
+        defaults = {
+            'name': None,
+            'interactions': {},
+        }
+        for attribute, default_value in defaults.items():
+            if not hasattr(self, attribute):
+                setattr(self, attribute, default_value)
         self._apply_to_all_interactions = defaultdict(dict)
 
     def __repr__(self):
@@ -600,16 +615,31 @@ class Block(nx.Graph):
 class Link(Block):
     """
     Template link between two residues.
+
+    Parameters
+    ----------
+    incoming_graph_data:
+        Data to initialize graph. If None (default) an empty graph is created.
+    attr:
+        Attributes to add to graph as key=value pairs.
     """
     node_dict_factory = OrderedDict
 
-    def __init__(self):
-        super().__init__()
-        self.non_edges = []
-        self.removed_interactions = {}
+    def __init__(self, incoming_graph_data=None, **attr):
+        super().__init__(incoming_graph_data, **attr)
+        # Arbitrary attributes can be set during the initialization. We need
+        # to set the default of some key attributes, but without overwritting
+        # what has been passed in the 'attr' argument.
+        defaults = {
+            'non_edges': [],
+            'removed_interactions': {},
+            'molecule_meta': {},
+            'patterns': [],
+        }
+        for attribute, default_value in defaults.items():
+            if not hasattr(self, attribute):
+                setattr(self, attribute, default_value)
         self._apply_to_all_nodes = {}
-        self.molecule_meta = {}
-        self.patterns = []
 
 
 def attributes_match(attributes, template_attributes, ignore_keys=()):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -461,10 +461,13 @@ class Block(nx.Graph):
             'name': None,
             'interactions': {},
         }
+        self._set_defaults(defaults)
+        self._apply_to_all_interactions = defaultdict(dict)
+
+    def _set_defaults(self, defaults):
         for attribute, default_value in defaults.items():
             if not hasattr(self, attribute):
                 setattr(self, attribute, default_value)
-        self._apply_to_all_interactions = defaultdict(dict)
 
     def __repr__(self):
         name = self.name
@@ -636,9 +639,7 @@ class Link(Block):
             'molecule_meta': {},
             'patterns': [],
         }
-        for attribute, default_value in defaults.items():
-            if not hasattr(self, attribute):
-                setattr(self, attribute, default_value)
+        self._set_defaults(defaults)
         self._apply_to_all_nodes = {}
 
 

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -34,7 +34,7 @@ def get_not_none(node, attr, default):
     return value
 
 
-def write_pdb_string(system, conect=True):
+def write_pdb_string(system, conect=True, omit_charges=True):
     def keyfunc(graph, node_idx):
         # TODO add something like idx_in_residue
         return graph.node[node_idx]['chain'], graph.node[node_idx]['resid'], graph.node[node_idx]['resname']
@@ -66,7 +66,7 @@ def write_pdb_string(system, conect=True):
             temp_factor = get_not_none(node, 'temp_factor', 0)
             element = get_not_none(node, 'element', '')
             charge = get_not_none(node, 'charge', 0)
-            if charge:
+            if charge and not omit_charges:
                 charge = '{:+2d}'.format(int(charge))[::-1]
             else:
                 charge = ''
@@ -98,9 +98,9 @@ def write_pdb_string(system, conect=True):
     return '\n'.join(out)
 
 
-def write_pdb(system, path, conect=True):
+def write_pdb(system, path, conect=True, omit_charges=True):
     with open(path, 'w') as out:
-        out.write(write_pdb_string(system, conect))
+        out.write(write_pdb_string(system, conect, omit_charges))
 
 
 def do_conect(mol, conectlist):

--- a/vermouth/tests/test_map_input.py
+++ b/vermouth/tests/test_map_input.py
@@ -16,6 +16,7 @@
 
 import pytest
 import collections
+import vermouth
 import vermouth.map_input
 
 Reference = collections.namedtuple('Reference',
@@ -186,3 +187,38 @@ def test_read_mapping(case):
     assert to_ff == case.to_ff
     assert mapping == case.mapping
     assert extra == case.extra
+
+
+def test_generate_self_mapping():
+    # Build the input blocks
+    blocks = {
+        'A0': vermouth.molecule.Block([['AA', 'BBB'], ['BBB', 'CCCC']]),
+        'B1': vermouth.molecule.Block([['BBB', 'CCCC'], ['BBB', 'E']]),
+    }
+    for name, block in blocks.items():
+        block.name = name
+        for atomname, node in block.nodes.items():
+            node['atomname'] = atomname
+    # Build the expected output
+    ref_mappings = {
+        'A0': (
+            # mapping
+            {(0, 'AA'): [(0, 'AA')], (0, 'BBB'): [(0, 'BBB')], (0, 'CCCC'): [(0, 'CCCC')]},
+            # weights
+            {(0, 'AA'): {(0, 'AA'): 1}, (0, 'BBB'): {(0, 'BBB'): 1}, (0, 'CCCC'): {(0, 'CCCC'): 1}},
+            # extra
+            [],
+        ),
+        'B1': (
+            # mapping
+            {(0, 'BBB'): [(0, 'BBB')], (0, 'CCCC'): [(0, 'CCCC')], (0, 'E'): [(0, 'E')]},
+            # weights
+            {(0, 'BBB'): {(0, 'BBB'): 1}, (0, 'CCCC'): {(0, 'CCCC'): 1}, (0, 'E'): {(0, 'E'): 1}},
+            # extra
+            [],
+        ),
+    }
+    # Actually test
+    mappings = vermouth.map_input.generate_self_mappings(blocks)
+    assert mappings.keys() == ref_mappings.keys()
+    assert ref_mappings == mappings


### PR DESCRIPTION
This commit makes it possible for a user to go beyond the universal to martini transformation by making it possible to select a origin force field in addition to the target one. It also makes possible to use user defined force fields and mappings that are crucial when developing models.

In practice, the PR adds the following options to martinize2:
* `-from`: the name of the origin force field
* `-ff-dir`: the path to a directory containing force field directories
* `-map-dir`: the path to a directory containing mapping files

In addition to these options, the PR adds the ability to generate self mappings for a force field, which martinize2 makes now by default. This makes it possible to generate topologies from a structure without force field transformation.