### PR TITLE
Make PDB reader more loose

### DIFF
--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -135,7 +135,7 @@ def read_pdb(file_name, exclude=('SOL',), ignh=False, model=0):
     conect = []
     idx = 0
     
-    field_widths = (-6, 5, -1, 4, 1, 3, -1, 1, 4, 1, -3, 8, 8, 8, 6, 6, -10, 2, 2)
+    field_widths = (-6, 5, -1, 4, 1, 4, 1, 4, 1, -3, 8, 8, 8, 6, 6, -10, 2, 2)
     field_types = (int, str, str, str, str, int, str, float, float, float, float, float, str, str)
     field_names = ('atomid', 'atomname', 'altloc', 'resname', 'chain', 'resid',
                    'insertion_code', 'x', 'y', 'z', 'occupancy', 'temp_factor',


### PR DESCRIPTION
Allow the resname to be 4 characters by reading the empty column after the resname as part of the resname. This does not affect well formatted PDB file as that column is not assigned to any type of data in the PDB standard, but it allows to read PDB files that make use of that empty column, such as those from the ATB.

This is a common variation around the PDB format, and it is supported at least by pymol and VMD.

Note that the writing is not modified, so 4 chars resnames are still truncated at writing to write valid PDB files.