### PR TITLE
Allow to define a format for link parameter effectors

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -368,8 +368,12 @@ def _parse_interaction_parameters(tokens):
             except KeyError:
                 raise IOError('{} is not a known parameter effector.'
                               .format(effector_name))
+            if '|' in effector_param_str:
+                effector_param_str, effector_format = effector_param_str.split('|')
+            else:
+                effector_format = None
             effector_param = [elem.strip() for elem in effector_param_str.split(',')]
-            parameter = effector_class(effector_param)
+            parameter = effector_class(effector_param, format=effector_format)
         else:
             parameter = token
         parameters.append(parameter)

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -156,7 +156,7 @@ class LinkParameterEffector:
     """
     n_keys_asked = None
 
-    def __init__(self, keys):
+    def __init__(self, keys, format=None):
         """
         Parameters
         ----------
@@ -178,6 +178,7 @@ class LinkParameterEffector:
                 '{} were expected, but {} were provided.'
                 .format(self.__class__.name, self.n_keys_asked, len(keys))
             )
+        self.format = format
 
     def __call__(self, molecule, match):
         """
@@ -195,7 +196,10 @@ class LinkParameterEffector:
             The calculated parameter value.
         """
         keys = [match[key] for key in self.keys]
-        return self._apply(molecule, keys)
+        result = self._apply(molecule, keys)
+        if self.format is not None:
+            result = '{value:{format}}'.format(value=result, format=self.format)
+        return result
 
     def _apply(self, molecule, keys):
         """

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -144,6 +144,15 @@ class LinkParameterEffector:
     linking the link nodes with the molecule ones. The format of the dictionary
     is expected to be ``{link key: molecule key}``.
 
+    An instance can also have a format defined. If defined, that format will be
+    applied to the value computed by the :meth:`_apply` method causing the
+    output to be a string. The format is given as a 'format_spec' from the
+    python format string syntax. This format spec corresponds to what follows
+    the column the column in string templates. For instance, formating a
+    floating number to have 2 decimal places will be obtained by setting format
+    to `.2f`. If no format is defined, then the calculated value is not
+    modified.
+
     This is a base class; it needs to be subclassed. A subclass must define an
     :meth:`_apply` method that takes a molecule and a list of node keys from
     that molecule as arguments. This method is not called directly by the user,
@@ -164,6 +173,8 @@ class LinkParameterEffector:
             A list of node keys from the link. If the :attr:`n_keys_asked`
             class argument is set, the number of keys must correspond to the
             value of the attribute.
+        format: str
+            Format specification.
 
         Raises
         ------
@@ -193,7 +204,7 @@ class LinkParameterEffector:
         Returns
         -------
         value:
-            The calculated parameter value.
+            The calculated parameter value, formatted if required.
         """
         keys = [match[key] for key in self.keys]
         result = self._apply(molecule, keys)


### PR DESCRIPTION
Some force field interactions expect their parameters to be formatted in a specific way. For instance, the side chain dihedral correction expect the angle to be rounded to the integer. This PR adds the possibility to define a format to a link effector.

While I am fine with the way it is implemented in the `LinkParameterEffector` class, I am open to suggestion about the syntax in the ff file. For now, writing a link that defines a SC1-BB-BB-SC1 torsion looks like:

```
[ link ]
[ dihedrals ]
SC1 BB +BB +SC1 1 dihedral(SC1,BB,+BB,+SC1) 75 1
```

With the syntax introduce in this PR, it becomes possible to limit the dihedral to 2 decimal places for instance by writing:

```
[ link ]
[ dihedrals ]
SC1 BB +BB +SC1 1 dihedral(SC1,BB,+BB,+SC1|.2f) 75 1
```

This syntax has the benefit to be super easy to parse. The pipe character was chosen because it is already forbidden in atom names for other reasons. It works well enough, especially as a prototype. But it is not really satisfying.