### PR TITLE
Allow links to declare features

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -217,7 +217,7 @@ def entry():
                           help='Comma separated list of bead names for elastic bonds')
 
     prot_group = parser.add_argument_group('Protein description')
-    prot_group.add_argument('-nt', dest='neutral_terminii',
+    prot_group.add_argument('-nt', dest='neutral_termini',
                             action='store_true', default=False,
                             help='Set neutral termini (charged is default)')
     args = parser.parse_args()
@@ -279,11 +279,11 @@ def entry():
                         'angles for extended regions of proteins (-extdih).'
                         .format(target_ff.name))
     vermouth.SetMoleculeMeta(extdih=args.extdih).run_system(system)
-    if args.neutral_terminii and not target_ff.has_feature('neutral_terminii'):
+    if args.neutral_termini and not target_ff.has_feature('neutral_termini'):
         logging.warning('The force field "{}" does not have specific '
                         'parameters for neutral termini (-nt).'
                         .format(target_ff.name))
-    vermouth.SetMoleculeMeta(neutral_terminii=args.neutral_terminii).run_system(system)
+    vermouth.SetMoleculeMeta(neutral_termini=args.neutral_termini).run_system(system)
 
     # Run martinize on the system.
     system = martinize(

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -40,6 +40,7 @@ import itertools
 import operator
 import textwrap
 import functools
+import logging
 
 
 def read_system(path):
@@ -262,13 +263,26 @@ def entry():
     system = pdb_to_universal(system, delete_unknown=True,
                               force_field=known_force_fields[from_ff])
 
+    target_ff = known_force_fields[args.to_ff]
     if args.dssp is not None:
         AnnotateDSSP(executable=args.dssp, savedir='.').run_system(system)
         AnnotateMartiniSecondaryStructures().run_system(system)
     elif args.collagen:
+        if not target_ff.has_feature('collagen'):
+            logging.warning('The force field "{}" does not have specific '
+                            'parameters for collagen (-collagen).'
+                            .format(target_ff.name))
         AnnotateResidues(attribute='cgsecstruct', sequence='F',
                          molecule_selector=selectors.is_protein).run_system(system)
+    if args.extdih and not target_ff.has_feature('extdih'):
+        logging.warning('The force field "{}" does not define dihedral '
+                        'angles for extended regions of proteins (-extdih).'
+                        .format(target_ff.name))
     vermouth.SetMoleculeMeta(extdih=args.extdih).run_system(system)
+    if args.neutral_terminii and not target_ff.has_feature('neutral_terminii'):
+        logging.warning('The force field "{}" does not have specific '
+                        'parameters for neutral termini (-nt).'
+                        .format(target_ff.name))
     vermouth.SetMoleculeMeta(neutral_terminii=args.neutral_terminii).run_system(system)
 
     # Run martinize on the system.

--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -598,9 +598,9 @@ resname $protein_resnames
 ;; Protein terminii. These links should be applied last.
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -608,9 +608,9 @@ BB -BB
 
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -560,6 +560,8 @@ BB {"cgsecstruct": "1", "replace": {"atype": "Nd"}}
 resname $protein_resnames
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "N0"}}
+[ features ]
+collagen
 
 ;; Fix bead types for ALA and PRO.
 [ link ]
@@ -571,6 +573,8 @@ BB {"cgsecstruct": "T|3|2|1|E", "replace": {"atype": "N0"}}
 resname "ALA|PRO|HYP"
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "C5"}}
+[ features ]
+collagen
 
 [ link ]
 resname "PRO"
@@ -593,12 +597,20 @@ resname $protein_resnames
 
 ;; Protein terminii. These links should be applied last.
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
 BB -BB
 
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -598,9 +598,9 @@ resname $protein_resnames
 ;; Protein terminii. These links should be applied last.
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -608,9 +608,9 @@ BB -BB
 
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -560,6 +560,8 @@ BB {"cgsecstruct": "1", "replace": {"atype": "Nd"}}
 resname $protein_resnames
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "N0"}}
+[ features ]
+collagen
 
 ;; Fix bead types for ALA and PRO.
 [ link ]
@@ -571,6 +573,8 @@ BB {"cgsecstruct": "T|3|2|1|E", "replace": {"atype": "N0"}}
 resname "ALA|PRO|HYP"
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "C5"}}
+[ features ]
+collagen
 
 [ link ]
 resname "PRO"
@@ -593,12 +597,20 @@ resname $protein_resnames
 
 ;; Protein terminii. These links should be applied last.
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
 BB -BB
 
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -622,6 +622,8 @@ BB {"cgsecstruct": "1", "replace": {"atype": "Nd"}}
 resname $protein_resnames
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "N0"}}
+[ features ]
+collagen
 
 ;; Fix bead types for ALA and PRO.
 [ link ]
@@ -633,6 +635,8 @@ BB {"cgsecstruct": "T|3|2|1|E", "replace": {"atype": "N0"}}
 resname "ALA|PRO|HYP"
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "C5"}}
+[ features ]
+collagen
 
 [ link ]
 resname "PRO"
@@ -655,12 +659,20 @@ resname $protein_resnames
 
 ;; Protein terminii. These links should be applied last.
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
 BB -BB
 
 [ link ]
+[ molmeta ]
+neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -660,9 +660,9 @@ resname $protein_resnames
 ;; Protein terminii. These links should be applied last.
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -670,9 +670,9 @@ BB -BB
 
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/martini22/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22/aminoacids.ff
@@ -590,6 +590,8 @@ BB {"cgsecstruct": "1", "replace": {"atype": "Nd"}}
 
 [ link ]
 resname $protein_resnames
+[ features ]
+collagen
 [ atoms ]
 BB {"cgsecstruct": "H|F", "replace": {"atype": "N0"}}
 
@@ -630,6 +632,8 @@ BB {"cgsecstruct": "F"} +BB
 [ link ]
 resname $protein_resnames
 cgsecstruct "F"
+[ features ]
+collagen
 [ bonds ]
 BB +BB 1 0.365 1250
 
@@ -784,6 +788,8 @@ cgsecstruct "H|1|2|3"
 [ link ]
 resname $protein_resnames
 cgsecstruct "F"
+[ features ]
+collagen
 [ dihedrals ]
 -BB BB  +BB ++BB 1 90.7 100 1
 
@@ -806,6 +812,8 @@ resname $protein_resnames
 cgsecstruct "E"
 [ molmeta ]
 extdih true
+[ features ]
+extdih
 [ dihedrals ]
 -BB BB +BB ++BB 1 0 10 1
 
@@ -827,6 +835,8 @@ BB +++BB 1 0.970 2500
 [ link ]
 [ molmeta ]
 neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -835,6 +845,8 @@ BB -BB
 [ link ]
 [ molmeta ]
 neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/martini22/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22/aminoacids.ff
@@ -834,9 +834,9 @@ BB +++BB 1 0.970 2500
 ;; Protein terminii. These links should be applied last.
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -844,9 +844,9 @@ BB -BB
 
 [ link ]
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -684,12 +684,16 @@ BB +BB 1 0.3375 1250
 [ patterns ]
 BB +BB {"cgsecstruct": "F"}
 BB {"cgsecstruct": "F"} +BB
+[ features ]
+collagen
 
 [ link ]
 resname $protein_resnames
 cgsecstruct "F"
 [ bonds ]
 BB +BB 1 0.365 1250
+[ features ]
+collagen
 
 [ link ]
 resname $protein_resnames
@@ -759,6 +763,8 @@ resname $protein_resnames
 -BB BB {"cgsecstruct": "F"} +BB 
 -BB {"cgsecstruct": "F"} BB +BB 
 -BB  BB +BB {"cgsecstruct": "F"}
+[ features ]
+collagen
 
 [ link ]
 [ angles ]
@@ -823,6 +829,8 @@ resname $protein_resnames
 cgsecstruct "F"
 [ dihedrals ]
 -BB BB  +BB ++BB 1 90.7 100 1
+[ features ]
+collagen
 
 ;; Local elastic network to stabilize extented regions of proteins.
 [ link ]
@@ -843,6 +851,8 @@ resname $protein_resnames
 cgsecstruct "E"
 [ molmeta ]
 extdih true
+[ features ]
+extdih
 [ dihedrals ]
 -BB BB +BB ++BB 1 0 10 1
 
@@ -851,6 +861,8 @@ resname $protein_resnames
 cgsecstruct "E"
 [ molmeta ]
 extdih true
+[ features ]
+extdih
 [ edges ]
 BB +BB
 +BB ++BB
@@ -865,6 +877,8 @@ BB +++BB 1 0.970 2500
 resname $protein_resnames
 [ molmeta ]
 neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -874,6 +888,8 @@ BB -BB
 resname $protein_resnames
 [ molmeta ]
 neutral_terminii not(true)
+[ features ]
+neutral_terminii
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -876,9 +876,9 @@ BB +++BB 1 0.970 2500
 [ link ]
 resname $protein_resnames
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qd", "charge": 1}}
 [ non-edges ]
@@ -887,9 +887,9 @@ BB -BB
 [ link ]
 resname $protein_resnames
 [ molmeta ]
-neutral_terminii not(true)
+neutral_termini not(true)
 [ features ]
-neutral_terminii
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qa", "charge": -1}}
 [ non-edges ]

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -582,6 +582,12 @@ def _parse_variables(tokens, force_field):
     force_field.variables[key] = value
 
 
+def _parse_features(tokens, context, context_type):
+    if context_type != 'link':
+        raise IOError('The "features" section is only valid in links.')
+    context.features.extend(list(tokens))
+
+
 def read_ff(lines, force_field):
     interactions_natoms = {
         'bonds': 2,
@@ -650,6 +656,8 @@ def read_ff(lines, force_field):
                 _parse_edges(tokens, context, context_type, negate=False)
             elif section == 'patterns':
                 _parse_patterns(tokens, context, context_type)
+            elif section == 'features':
+                _parse_features(tokens, context, context_type)
             elif section == 'variables':
                 if context is not None:
                     raise IOError('The [variables] section must be defined '

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -40,6 +40,32 @@ class ForceField(object):
     @property
     def reference_graphs(self):
         return self.blocks
+
+    @property
+    def features(self):
+        """
+        List the features declared by the links.
+
+        Returns
+        -------
+        set
+        """
+        return set(feature for link in self.links for feature in link.features)
+
+    def has_feature(self, feature):
+        """
+        Test if a feature is declared by the links.
+
+        Parameters
+        ----------
+        feature: str
+            The name of the feature of interest.
+
+        Returns
+        -------
+        bool
+        """
+        return feature in self.features
         
 
 def find_force_fields(directory, force_fields=None):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -680,6 +680,7 @@ class Link(Block):
             'removed_interactions': {},
             'molecule_meta': {},
             'patterns': [],
+            'features': [],
         }
         self._set_defaults(defaults)
         self._apply_to_all_nodes = {}


### PR DESCRIPTION
With this PR, links can declare the feature they implement. This allow to check is the feature is available in a given force field. Martinize2 benefit from this feature by issuing a warning when a command line argument ask for a feature that is not declared.

This should avoid surprises for user, and ease the life of people who write force field files.