### PR TITLE
Add a version number using pbr

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -41,6 +41,8 @@ import operator
 import textwrap
 import functools
 
+VERSION = 'martinize with vermouth {}'.format(vermouth.__version__)
+
 
 def read_system(path):
     """
@@ -155,7 +157,11 @@ def write_gmx_topology(system, top_path, deduplicate=True):
 
 
 def entry():
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('-V', '--version', action='version', version=VERSION)
+
     file_group = parser.add_argument_group('Input and output files')
     file_group.add_argument('-f', dest='inpath', required=True, type=Path,
                             help='Input file (PDB|GRO)')

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ keywords = martini MD martinize
 packages = find:
 setup-requires =
     setuptools >= 30.3.0
+    pbr
 install-requires =  # ?? requires-dist?
     pbr
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 setup-requires =
     setuptools >= 30.3.0
 install-requires =  # ?? requires-dist?
+    pbr
     numpy
     networkx ~= 2.0
     matplotlib  # See issue #23

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     package_data={'': package_files('vermouth/data')
                   + package_files('vermouth/tests/data'),},
     scripts=['bin/martinize2', ],
-    setup_requires=['setuptools>=30.3.0', 'pbr'],
     pbr=True,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     package_data={'': package_files('vermouth/data')
                   + package_files('vermouth/tests/data'),},
     scripts=['bin/martinize2', ],
-    setup_requires=['setuptools>=30.3.0']
+    setup_requires=['setuptools>=30.3.0', 'pbr'],
+    pbr=True,
 )
 

--- a/vermouth/__init__.py
+++ b/vermouth/__init__.py
@@ -30,4 +30,8 @@ else:
     DATA_PATH = pkg_resources.resource_filename('vermouth', 'data')
     del pkg_resources
 
+import pbr.version
+__version__ = pbr.version.VersionInfo('vermouth').release_string()
+del pbr
+
 from .vermouth import *

--- a/vermouth/tests/test_version.py
+++ b/vermouth/tests/test_version.py
@@ -1,0 +1,19 @@
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.import pytest
+
+import vermouth
+
+
+def test_version():
+    assert isinstance(vermouth.__version__, str)


### PR DESCRIPTION
Creates the `vermouth.__version__` attribute. Also adds `--version` to martinize2.

We will have to pay attention to our commit messages, though: https://docs.openstack.org/pbr/latest/user/features.html#version

The following strings are recognized in commit messages:
* feature
* api-break
* deprecation
* bugfix

When prefixes with `Sem-Ver: ` in the commit message, they can trigger a bump in the version number.


Fixes #66 