### PR TITLE
Molecule comparison

### DIFF
--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -393,6 +393,7 @@ class Molecule(nx.Graph):
         Molecule
         """
         subgraph = self.__class__()
+        subgraph.name = self.name
         subgraph.meta = copy.copy(self.meta)
         subgraph._force_field = self._force_field
         subgraph.nrexcl = self.nrexcl

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -1081,6 +1081,15 @@ class Link(Block):
         self._set_defaults(defaults)
         self._apply_to_all_nodes = {}
 
+    def __eq__(self, other):
+        return (super().__eq__(other)
+                and self.non_edges == other.non_edges
+                and self.removed_interactions == other.removed_interactions
+                and self.molecule_meta == other.molecule_meta
+                and self.patterns == other.patterns
+                and self.features == other.features
+                )
+
 
 def attributes_match(attributes, template_attributes, ignore_keys=()):
     """

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -323,14 +323,14 @@ class Molecule(nx.Graph):
     * the exclusion distance (nrexcl) are equal
     * the force fields are equal (but may be different instances)
     * the nodes are equal and in the same order
-    * the edges are the equals (but order is not accounted for)
+    * the edges are equal (but order is not accounted for)
     * the interactions are the same and in the same order within an interaction
       type
 
     When comparing molecules, the order of the nodes is considered as it
     determines in what order atoms will be written in the output. Same goes for
     the interactions within an interaction type. The order of edges is not
-    garantied anywhere in the code, and they are not written in the output.
+    garantied anywhere in the code, and they are not writen in the output.
     """
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.
@@ -1102,13 +1102,13 @@ class Link(Block):
     
     * the underlying molecules are equal
     * the names are equal
-    * the negative edges ("non-edges") are the equal regardless of order
+    * the negative edges ("non-edges") are equal regardless of order
     * the interactions to remove are the same and in the same order
     * the meta variables are equal
     * the pattern definitions are equal and in the same order
     * the features are equals regardless of order
 
-    A link does not match if any of the non-edges match on the target; there
+    A link does not match if any of the non-edges match the target; their
     order therefore is not important. Same goes for features that just need to
     be present or not. The order does matter however for interactions to remove
     as removing the interactions in a different order may lead to a different
@@ -1117,7 +1117,7 @@ class Link(Block):
     Parameters
     ----------
     incoming_graph_data:
-        Data to initialize graph. If None (default) an empty graph is created.
+        Data to initialize graph. If `None` (default) an empty graph is created.
     attr:
         Attributes to add to graph as key=value pairs.
     """
@@ -1156,7 +1156,7 @@ class Link(Block):
         those of this link. Returns `False` otherwise.
         """
         # A non-edge is a list of two elements: the key to a node in the graph
-        # that is used as achor, and a attribute dict that must match none of
+        # that is used as anchor, and a attribute dict that must match none of
         # the atoms connected to the anchor.
         # For the link to match, none of the non-edges must match. Therefore,
         # their order do not matter. Though, because the attribute dicts are

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -330,7 +330,7 @@ class Molecule(nx.Graph):
     When comparing molecules, the order of the nodes is considered as it
     determines in what order atoms will be written in the output. Same goes for
     the interactions within an interaction type. The order of edges is not
-    garanteed anywhere in the code, and they are not writen in the output.
+    guaranteed anywhere in the code, and they are not writen in the output.
     """
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -316,6 +316,14 @@ class Molecule(nx.Graph):
     """
     Represents a molecule as per a specific force field. Consists of atoms
     (nodes), bonds (edges) and interactions such as angle potentials.
+
+    Two molecules are equal if:
+
+    * the exclusion distance (nrexcl) are equal
+    * the force fields are equal (but may not be the same instances)
+    * the nodes are the equals and in the same order
+    * the edges are the same (but order is not accounted for)
+    * the interactions are the same and in the same order
     """
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.
@@ -796,6 +804,9 @@ class Block(Molecule):
     """
     Residue topology template
 
+    Two blocks are equal if the underlying molecules are equal, and if the bloc
+    names are equal.
+
     Parameters
     ----------
     incoming_graph_data:
@@ -1057,6 +1068,16 @@ class Link(Block):
     """
     Template link between two residues.
 
+    Two links are equal if:
+    
+    * the underlying molecules are equal
+    * the names are equal
+    * the negative edges ("non_edges") are the equal regardless of order
+    * the interactions to remove are the same and in the same order
+    * the meta variables are equals regardless of order
+    * the pattern definitions are equals and in the same order
+    * the features are equals regardless of order
+
     Parameters
     ----------
     incoming_graph_data:
@@ -1083,11 +1104,11 @@ class Link(Block):
 
     def __eq__(self, other):
         return (super().__eq__(other)
-                and self.non_edges == other.non_edges
+                and set(self.non_edges) == set(other.non_edges)
                 and self.removed_interactions == other.removed_interactions
                 and self.molecule_meta == other.molecule_meta
                 and self.patterns == other.patterns
-                and self.features == other.features
+                and set(self.features) == set(other.features)
                 )
 
 

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -663,7 +663,7 @@ class Molecule(nx.Graph):
     # TODO: Allow comparison of interactions betweem isomorphic molecules.
     def same_interactions(self, other):
         """
-        Returns :bool:`True` if the interactions are the same.
+        Returns `True` if the interactions are the same.
 
         To be equal, two interations must share the same node key references,
         the same interation parameters, and the same meta attributes.
@@ -685,7 +685,7 @@ class Molecule(nx.Graph):
     # instance, the assumed default for the `PTM_atom` attribute is False.
     def same_nodes(self, other, ignore_attr=()):
         """
-        Returns :bool:`True` if the nodes are the same and in the same order.
+        Returns `True` if the nodes are the same and in the same order.
 
         The equality criteria used for the attribute values are those of
         :func:`are_different`.

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -673,7 +673,7 @@ class Molecule(nx.Graph):
         """
         Returns `True` if the interactions are the same.
 
-        To be equal, two interations must share the same node key references,
+        To be equal, two interations must share the same node key reference,
         the same interaction parameters, and the same meta attributes. Empty
         interaction categories are ignored.
 
@@ -1192,7 +1192,7 @@ class Link(Block):
         those of this link. Returns `False` otherwise.
         """
         # A non-edge is a list of two elements: the key to a node in the graph
-        # that is used as anchor, and a attribute dict that must match none of
+        # that is used as anchor, and an attribute dict that must match none of
         # the atoms connected to the anchor.
         # For the link to match, none of the non-edges must match. Therefore,
         # their order do not matter. Though, because the attribute dicts are

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -673,7 +673,7 @@ class Molecule(nx.Graph):
         """
         Returns `True` if the interactions are the same.
 
-        To be equal, two interations must share the same node key reference,
+        To be equal, two interactions must share the same node key reference,
         the same interaction parameters, and the same meta attributes. Empty
         interaction categories are ignored.
 

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -330,7 +330,7 @@ class Molecule(nx.Graph):
     When comparing molecules, the order of the nodes is considered as it
     determines in what order atoms will be written in the output. Same goes for
     the interactions within an interaction type. The order of edges is not
-    garantied anywhere in the code, and they are not writen in the output.
+    garanteed anywhere in the code, and they are not writen in the output.
     """
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.
@@ -1179,14 +1179,14 @@ class Link(Block):
         # except for the fact that order free comparison of non hashable things
         # is a pain.
         return (super().__eq__(other)
-                and self._same_non_edges(other)
+                and self.same_non_edges(other)
                 and self.removed_interactions == other.removed_interactions
                 and self.molecule_meta == other.molecule_meta
                 and self.patterns == other.patterns
                 and set(self.features) == set(other.features)
                 )
 
-    def _same_non_edges(self, other):
+    def same_non_edges(self, other):
         """
         Returns `True` if all the non-edges of an `other` link are equal to
         those of this link. Returns `False` otherwise.
@@ -1213,8 +1213,8 @@ class Link(Block):
         # dicts of the other link that share the same anchor.
         sorted_self = sorted(self.non_edges, key=lambda x: x[0])
         sorted_other = sorted(other.non_edges, key=lambda x: x[0])
-        zipped = zip(itertools.groupby(sorted_self),
-                     itertools.groupby(sorted_other))
+        zipped = zip(itertools.groupby(sorted_self, key=lambda x: x[0]),
+                     itertools.groupby(sorted_other, key=lambda x: x[0]))
         for (key_self, attrs_self), (key_other, attrs_other) in zipped:
             if key_self != key_other:
                 return False

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -688,7 +688,7 @@ class Molecule(nx.Graph):
         Returns `True` if the nodes are the same and in the same order.
 
         The equality criteria used for the attribute values are those of
-        :func:`are_different`.
+        :func:`vermouth.utils.are_different`.
 
         Parameters
         ----------

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -596,7 +596,7 @@ def test_subgraph_edges(edges_between_molecule, edges_between_selections,
                             parameters=[
                                 'a',
                                 vermouth.molecule.ParamDistance(
-                                    ['A', 'C'], format_spec='.2f',
+                                    ['A', 'B'], format_spec='.2f',
                                 ),
                                 '200',
                             ],

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -1216,3 +1216,72 @@ def test_link_equal(link):
     link_copy = link.copy()
     assert link == link
     assert link is not link_copy
+
+
+@pytest.mark.parametrize('left, right, expected', (
+    (  # Equal edges, same order, same direction, same attributes
+        [
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+            (1, 3, {'foo': 'bar'}),
+        ],
+        [
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+            (1, 3, {'foo': 'bar'}),
+        ],
+        True,
+    ),
+    (  # Equal edges, but different order
+        [
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+            (1, 3, {'foo': 'bar'}),
+        ],
+        [
+            (1, 3, {'foo': 'bar'}),
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+        ],
+        True,
+    ),
+    (  # Equal edges, but different order and different direction
+        [
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+            (1, 3, {'foo': 'bar'}),
+        ],
+        [
+            (3, 1, {'foo': 'bar'}),
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+        ],
+        True,
+    ),
+    (  # Edges only differ by an attribute
+        [
+            (0, 1, {'a': 0, 'b': [2, 3]}),
+            (1, 3, {'foo': 'bar'}),
+        ],
+        [
+            (0, 1, {'a': 0, 'b': [2, 40]}),
+            (1, 3, {'foo': 'bar'}),
+        ],
+        False,
+    ),
+    (  # Edges are different
+        [
+            (0, 1, {'foo': 'bar'}),
+            (2, 3, {}),
+        ],
+        [
+            (5, 6, {'foo': 'bar'}),
+            (3, 4, {}),
+        ],
+        False,
+    ),
+))
+def test_same_edges(left, right, expected):
+    """
+    Compare edges between two molecules.
+    """
+    molecule_left = vermouth.molecule.Molecule()
+    molecule_left.add_edges_from(left)
+    molecule_right = vermouth.molecule.Molecule()
+    molecule_right.add_edges_from(right)
+    assert molecule_left.same_edges(molecule_right) == expected
+    assert molecule_right.same_edges(molecule_left) == expected

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -1015,10 +1015,7 @@ def parameter_effectors(draw):
     ]
     effector = draw(st.sampled_from(possible_effectors))
     n_keys = effector.n_keys_asked
-    keys = draw(st.lists(
-        st.text(min_size=1, max_size=4),
-        min_size=n_keys, max_size=n_keys,
-    ))
+    keys = [draw(st.text(min_size=1, max_size=4)) for _ in range(n_keys)]
     possible_formats = [None, '.2f', '3.0f']
     format_spec = draw(st.sampled_from(possible_formats))
 

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -917,7 +917,8 @@ def test_link_parameter_effector_equal(effector_class, format_spec):
 ))
 def test_link_parameter_effector_diff_format(effector_class, format_left, format_right):
     """
-    Test that LinkParameterEffector compare different if they have different format.
+    Test that two instances of LinkParameterEffector compare different if they
+    have different formats.
     """
     n_keys = effector_class.n_keys_asked
     left_keys = ['A{}'.format(idx) for idx in range(n_keys)]
@@ -1074,7 +1075,7 @@ def random_interaction(draw, graph, natoms=None,
 def interaction_collection(draw, graph,
                            interaction_class=Interaction, attrs=False):
     """
-    Strategy that builds a collection of interaction-like intances.
+    Strategy that builds a collection of interaction-like instances.
 
     The collection is a dictionary with any string as key, and a list of
     :class:`~vermouth.molecule.Interaction` or
@@ -1127,7 +1128,7 @@ def random_molecule(draw, molecule_class=Molecule):
     nrexcl = draw(st.one_of(st.none(), st.integers()))
     molecule = molecule_class(graph, meta=meta, nrexcl=nrexcl)
 
-    molecule.interations = draw(interaction_collection(molecule))
+    molecule.interactions = draw(interaction_collection(molecule))
     
     return molecule
 

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -875,7 +875,6 @@ def test_same_interactions(left, right, expected):
         ),
         False,
     ),
-
 ))
 def test_same_nodes(left, right, expected):
     left_mol = Molecule()
@@ -1185,7 +1184,8 @@ def random_link(draw):
         max_size=4,
     ))
     link.patterns = draw(st.lists(
-        st.tuples(st.text(min_size=1, max_size=3), attribute_dict()),
+        st.tuples(st.text(min_size=1, max_size=3), attribute_dict(max_size=2)),
+        max_size=3,
     ))
     link.features = set(draw(st.lists(st.text(max_size=4), max_size=4)))
     return link

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -1285,3 +1285,110 @@ def test_same_edges(left, right, expected):
     molecule_right.add_edges_from(right)
     assert molecule_left.same_edges(molecule_right) == expected
     assert molecule_right.same_edges(molecule_left) == expected
+
+
+@pytest.mark.parametrize('left, right, expected', (
+    (  # Identical non-edges
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        True,
+    ),
+    (  # Identical non-edges, but disordered
+        [
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+        ],
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        True,
+    ),
+
+    (  # Different number of non-edges
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('YY', {'klonk': 0}),
+        ],
+        False,
+    ),
+    (  # Same number of non-edges, but mismatched anchors
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        [
+            ('AA', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('BB', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        False,
+    ),
+    (  # Mismatch in an attribute
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        [
+            ('XX', {'foo': 'mismatch', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        False,
+    ),
+    (  # Mismatch in number of attributes, there is a shortcut in same_non_edges
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar'}),
+            ('YY', {}),
+        ],
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar', 'plop': 'else'}),
+            ('YY', {'klonk': 0}),
+        ],
+        False,
+    ),
+    (
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar'}),
+            ('XX', {'foo': 'no bar again'}),
+            ('YY', {}),
+        ],
+        [
+            ('XX', {'foo': 'bar', 'toto': [0, 1, 2]}),
+            ('XX', {'foo': 'no bar'}),
+            ('YY', {}),
+            ('YY', {'something': 'tadaam'}),
+        ],
+        False,
+    ),
+))
+def test_same_non_edges(left, right, expected):
+    """
+    Compare non-edges between two links.
+    """
+    link_left = vermouth.molecule.Link()
+    link_left.non_edges = left
+    link_right = vermouth.molecule.Link()
+    link_right.non_edges = right
+    assert link_left.same_non_edges(link_right) == expected
+    assert link_right.same_non_edges(link_left) == expected

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -956,14 +956,20 @@ def random_link(draw):
 
 @hypothesis.given(random_molecule())
 def test_molecule_equal(mol):
-    assert mol == mol
+    mol_copy = mol.copy()
+    assert mol == mol_copy
+    assert mol is not mol_copy
 
 
 @hypothesis.given(random_block())
 def test_block_equal(block):
-    assert block == block
+    block_copy = block.copy()
+    assert block == block_copy
+    assert block is not block_copy
 
 
 @hypothesis.given(random_link())
 def test_link_equal(link):
+    link_copy = link.copy()
     assert link == link
+    assert link is not link_copy

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -967,7 +967,7 @@ def test_link_parameter_effector_diff_class(left_class, right_class):
 
 
 @st.composite
-def attribute_dict(draw, min_size=0, max_size=None, max_depth=1, _recursive_depth=0):
+def attribute_dict(draw, min_size=0, max_size=None, max_depth=1):
     """
     Strategy that builds an attribute dictionary for meta or atoms.
 
@@ -992,8 +992,8 @@ def attribute_dict(draw, min_size=0, max_size=None, max_depth=1, _recursive_dept
     """
     keys = st.one_of(st.text(), st.integers(), st.none())
     bases = [st.none(), st.text(), st.integers(), st.floats()]
-    if _recursive_depth < max_depth:
-        bases.append(attribute_dict(max_size=1, _recursive_depth=_recursive_depth + 1))
+    if max_depth > 0:
+        bases.append(attribute_dict(max_size=1, max_depth=max_depth - 1))
     lists = st.lists(st.one_of(*bases), max_size=2)
     values = st.one_of(*bases, lists)
     return draw(st.dictionaries(keys, values, min_size=min_size, max_size=max_size))
@@ -1004,7 +1004,7 @@ def parameter_effectors(draw):
     """
     Strategy that builds a :class:`~vermouth.molecule.LinkParameterEffector`.
 
-    The strategy choose one possible parameter effector class, and creates an
+    The strategy chooses one possible parameter effector class, and creates an
     instance with random keys and format spec.
     """
     possible_effectors = [
@@ -1078,7 +1078,7 @@ def interaction_collection(draw, graph,
 
     The collection is a dictionary with any string as key, and a list of
     :class:`~vermouth.molecule.Interaction` or
-    :class:`~vermouth.molecule.Interaction`.
+    :class:`~vermouth.molecule.DeleteInteraction`.
 
     The parameters are passed to :func:`random_interaction`.
 

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -884,8 +884,8 @@ def test_link_parameter_effector_diff_class(left_class, right_class):
 def attribute_dict(draw, min_size=0, max_size=None):
     keys = st.one_of(st.text(), st.integers(), st.none())
     bases = (st.text(), st.integers(), st.floats(), st.none())
-    lists = st.lists(st.one_of(*bases, attribute_dict()))
-    values = st.one_of(*bases, lists, attribute_dict())
+    lists = st.lists(st.one_of(*bases, attribute_dict(max_size=1)), max_size=3)
+    values = st.one_of(*bases, lists, attribute_dict(max_size=1))
     return draw(st.dictionaries(keys, values, min_size=min_size, max_size=max_size))
 
 

--- a/vermouth/tests/test_utils.py
+++ b/vermouth/tests/test_utils.py
@@ -16,12 +16,30 @@
 Tests for the `test_utils.py` module.
 """
 
+import itertools
 import string
 import pytest
 from hypothesis import strategies, given, example
 import numpy as np
 from numpy.testing import assert_allclose
 from vermouth import utils
+
+DIFFERENCE_USE_CASE = (
+    '', [], 'a', 2, 3, True, False, None, float('nan'), float('inf'),
+    [True], [False], [True, False], [False, False], [None], [None, None],
+    [1.1, 1.1], [0.0, 1.1],
+    [float('nan'), float('inf')],
+    [float('inf'), float('nan')],
+    ['a', 'b'], 'ab',
+    np.array([1.2, 2.3, 4.5]),
+    np.array([[1.2, 2.3, 4.5], [5.6, 7.8, 8.9]]),
+    np.array([np.nan, np.inf, 3]),
+    [[6, 8], [9, 10, 11]],
+    {'a': 3, 2: 'tata'},
+    {'a': 3, 2: np.array([2, 3, 4])},
+    {'a': 4, 2: 'not tata'},
+)
+
 
 
 @pytest.mark.parametrize('iter_type', (list, tuple, iter, np.array))
@@ -168,3 +186,22 @@ def test_distance(vec_and_dist):
     """
     point1, point2, distance = vec_and_dist
     assert_allclose(utils.distance(point1, point2), distance)
+
+
+@pytest.mark.parametrize(
+    'left, right',
+    itertools.combinations(DIFFERENCE_USE_CASE, 2)
+)
+def test_are_different(left, right):
+    """
+    Test that :func:`are_different` identify different values.
+    """
+    assert utils.are_different(left, right)
+
+
+@pytest.mark.parametrize('left', DIFFERENCE_USE_CASE)
+def test_not_are_different(left):
+    """
+    Test that :func:`are_different` returns False for equal values.
+    """
+    assert not utils.are_different(left, left)

--- a/vermouth/tests/test_utils.py
+++ b/vermouth/tests/test_utils.py
@@ -38,7 +38,7 @@ DIFFERENCE_USE_CASE = (
     {'a': 3, 2: 'tata'},
     {'a': 3, 2: np.array([2, 3, 4])},
     {'a': 4, 2: 'not tata'},
-    -9223372036854775809,  # beyond and int64, can cause numpy to break
+    -9223372036854775809,  # beyond an int64, can cause numpy to break
 )
 
 

--- a/vermouth/tests/test_utils.py
+++ b/vermouth/tests/test_utils.py
@@ -38,6 +38,7 @@ DIFFERENCE_USE_CASE = (
     {'a': 3, 2: 'tata'},
     {'a': 3, 2: np.array([2, 3, 4])},
     {'a': 4, 2: 'not tata'},
+    -9223372036854775809,  # beyond and int64, can cause numpy to break
 )
 
 

--- a/vermouth/tests/test_utils.py
+++ b/vermouth/tests/test_utils.py
@@ -206,3 +206,17 @@ def test_not_are_different(left):
     Test that :func:`are_different` returns False for equal values.
     """
     assert not utils.are_different(left, left)
+
+
+@pytest.mark.parametrize('left, right, expected', (
+    (  # dict with different order
+        {-1: None, '0+': None},
+        {'0+': None, -1: None},
+        False,
+    ),
+))
+def test_are_different_custom(left, right, expected):
+    """
+    Test :func:`are_different` on handcrafted cases.
+    """
+    assert utils.are_different(left, right) == expected

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -127,3 +127,29 @@ def are_all_equal(iterable):
     iterator = iter(iterable)
     first = next(iterator, None)
     return all(item == first for item in iterator)
+
+
+def are_different(left, right):
+    """
+    Return True if two values are different from one another.
+
+    Values are considered different if they do not share the same type. In case
+    of numerical value, the comparison is done with :func:`numpy.isclose` to
+    account for rounding. In the context of this test, `nan` compares equal to
+    itself, which is not the default behavior.
+    """
+    if not isinstance(left, right.__class__):
+        return True
+
+    left = np.asarray(left)
+    right = np.asarray(right)
+
+    if left.shape != right.shape:
+        return True
+
+    # For numbers, we want an approximate comparison to account for rounding
+    # errors; it only works for numbers, though.
+    try:
+        return not np.all(np.isclose(left, right, equal_nan=True))
+    except TypeError:
+        return np.any(left != right)

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -155,8 +155,8 @@ def are_different(left, right):
     if left.__class__ != right.__class__:
         return True
     
-    # Because we now that `left` and `right` share the same type, we also now
-    # that is `left` is `None`, then `right` is also `None`, so `left` and
+    # Because we know that `left` and `right` share the same type, we also know
+    # that if `left` is `None`, then `right` is also `None`, so `left` and
     # `right` are NOT different. It is an easy and common case, so we treat it
     # early to avoid extra work.
     if left is None:

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -155,6 +155,10 @@ def are_different(left, right):
     if left.__class__ != right.__class__:
         return True
     
+    # Because we now that `left` and `right` share the same type, we also now
+    # that is `left` is `None`, then `right` is also `None`, so `left` and
+    # `right` are NOT different. It is an easy and common case, so we treat it
+    # early to avoid extra work.
     if left is None:
         return False
 

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -151,6 +151,10 @@ def are_different(left, right):
     of numerical value, the comparison is done with :func:`numpy.isclose` to
     account for rounding. In the context of this test, `nan` compares equal to
     itself, which is not the default behavior.
+
+    The order of mappings (dicts) is assumed to be irrelevant, so two
+    dictionaries are not different if the only difference is the order of the
+    keys.
     """
     if left.__class__ != right.__class__:
         return True
@@ -176,14 +180,11 @@ def are_different(left, right):
     filler = _Filler()
 
     if isinstance(left, collections.abc.Mapping):
-        zipped = itertools.zip_longest(left.items(), right.items(), fillvalue=filler)
-        return any(
-            item_left is filler
-            or item_right is filler
-            or are_different(item_left[0], item_right[0])  # keys
-            or are_different(item_left[1], item_right[1])  # values
-            for item_left, item_right in zipped
-        )
+        left_key_set = set(left.keys())
+        right_key_set = set(right.keys())
+        if left_key_set != right_key_set:
+            return True
+        return any(are_different(left[key], right[key]) for key in left_key_set)
 
     if isinstance(left, collections.abc.Iterable):
         zipped = itertools.zip_longest(left, right, fillvalue=filler)


### PR DESCRIPTION
Being able to compare instances of `Molecule`, `Block`, and `Link` is required in order to compare instances of `ForceField`, which is itself required to thoroughly  test `ffinput.py` and other modules.