### PR TITLE
Update deprecated option for sphinx 1.8.0

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -180,7 +180,12 @@ apidoc_separate_modules = True
 apidoc_excluded_paths = ['tests', 'redistributed']
 
 autoclass_content = 'both'
-autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance']
+#autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance']
+autodoc_default_options = {
+    'members': None,
+    'undoc-members': None,
+    'show-inheritance': None,
+}
 
 # -- Options for intersphinx extension ---------------------------------------
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx >= 1.8.0
 sphinxcontrib-apidoc
 pbr
 setuptools >= 30.3.0


### PR DESCRIPTION
Set 1.8.0 as the minimum version for sphinx.