### PR TITLE
 Fix the -write-* debug options in martinize2

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -25,6 +25,8 @@ import itertools
 import textwrap
 from pathlib import Path
 
+import networkx as nx
+
 import vermouth
 from vermouth.forcefield import FORCE_FIELDS
 from vermouth import DATA_PATH
@@ -73,13 +75,15 @@ def pdb_to_universal(system, delete_unknown=False,
     canonicalized.force_field = force_field
     vermouth.MakeBonds().run_system(canonicalized)
     if write_graph is not None:
-        vermouth.pdb.write_pdb(system, str(write_graph), omit_charges=True)
+        vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True)
     vermouth.RepairGraph(delete_unknown=delete_unknown).run_system(canonicalized)
     if write_repair is not None:
-        vermouth.pdb.write_pdb(system, str(write_repair), omit_charges=True)
+        vermouth.pdb.write_pdb(canonicalized, str(write_repair),
+                               omit_charges=True, omit_missing_pos=True)
     vermouth.CanonicalizeModifications().run_system(canonicalized)
     if write_canon is not None:
-        vermouth.pdb.write_pdb(system, str(write_canon), omit_charges=True)
+        vermouth.pdb.write_pdb(canonicalized, str(write_canon),
+                               omit_charges=True, omit_missing_pos=True)
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
     return canonicalized
 
@@ -285,10 +289,16 @@ def entry():
     debug_group.add_argument('-write-graph', type=Path, default=None,
                              help='Write the graph as PDB after the MakeBonds step.')
     debug_group.add_argument('-write-repair', type=Path, default=None,
-                             help='Write the graph as PDB after the RepairGraph step.')
+                             help=('Write the graph as PDB after the '
+                                   'RepairGraph step. The resulting file may '
+                                   'contain "nan" coordinates making it '
+                                   'unreadable by most softwares.'))
     debug_group.add_argument('-write-canon', type=Path, default=None,
                              help=('Write the graph as PDB after the '
-                                   'CanonicalizeModifications step.'))
+                                   'CanonicalizeModifications step. The '
+                                   'resulting file may contain "nan" '
+                                   'coordinates making it unreadable by most '
+                                   'softwares.'))
 
     args = parser.parse_args()
 

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -25,8 +25,6 @@ import itertools
 import textwrap
 from pathlib import Path
 
-import networkx as nx
-
 import vermouth
 from vermouth.forcefield import FORCE_FIELDS
 from vermouth import DATA_PATH

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -77,11 +77,11 @@ def pdb_to_universal(system, delete_unknown=False,
     vermouth.RepairGraph(delete_unknown=delete_unknown).run_system(canonicalized)
     if write_repair is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_repair),
-                               omit_charges=True, omit_missing_pos=True)
+                               omit_charges=True, nan_missing_pos=True)
     vermouth.CanonicalizeModifications().run_system(canonicalized)
     if write_canon is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_canon),
-                               omit_charges=True, omit_missing_pos=True)
+                               omit_charges=True, nan_missing_pos=True)
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
     return canonicalized
 

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -16,7 +16,6 @@
 Provides functions for reading and writing PDB files.
 """
 
-
 from functools import partial
 
 import numpy as np
@@ -107,10 +106,11 @@ def write_pdb_string(system, conect=True, omit_charges=True, omit_missing_pos=Fa
             resid = node['resid']
             insertion_code = get_not_none(node, 'insertioncode', '')
             try:
-                x, y, z = node['position'] * 10  # converting from nm to A  # pylint: disable=invalid-name
+                # converting from nm to A
+                x, y, z = node['position'] * 10  # pylint: disable=invalid-name
             except KeyError:
                 if omit_missing_pos:
-                    x = y = z = float('nan')
+                    x = y = z = float('nan')  # pylint: disable=invalid-name
                 else:
                     raise
             occupancy = get_not_none(node, 'occupancy', 1)
@@ -212,8 +212,6 @@ def do_conect(mol, conectlist):
                 dist = distance(mol.node[at0]['position'], mol.node[atom]['position'])
                 mol.add_edge(at0, atom, distance=dist)
 
-    return
-
 
 def read_pdb(file_name, exclude=('SOL',), ignh=False, model=0):
     """
@@ -258,7 +256,7 @@ def read_pdb(file_name, exclude=('SOL',), ignh=False, model=0):
             record = line[:6]
             if record == 'ENDMDL':
                 models.append(Molecule())
-            elif record == 'ATOM  ' or record == 'HETATM':
+            elif record in ('ATOM  ', 'HETATM'):
                 properties = {}
                 for name, type_, slice_ in zip(field_names, field_types, slices):
                     properties[name] = type_(line[slice_].strip())

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -50,7 +50,7 @@ def get_not_none(node, attr, default):
     return value
 
 
-def write_pdb_string(system, conect=True, omit_charges=True, omit_missing_pos=False):
+def write_pdb_string(system, conect=True, omit_charges=True, nan_missing_pos=False):
     """
     Describes `system` as a PDB formatted string. Will create CONECT records
     from the edges in the molecules in `system` iff `conect` is True.
@@ -64,7 +64,7 @@ def write_pdb_string(system, conect=True, omit_charges=True, omit_missing_pos=Fa
     omit_charges: bool
         Whether charges should be omitted. This is usually a good idea since
         the PDB format can only deal with integer charges.
-    omit_missing_pos: bool
+    nan_missing_pos: bool
         Wether the writing should fail if an atom does not have a position.
         When set to `True`, atoms without coordinates will be written
         with 'nan' as coordinates; this will cause the output file to be
@@ -109,7 +109,7 @@ def write_pdb_string(system, conect=True, omit_charges=True, omit_missing_pos=Fa
                 # converting from nm to A
                 x, y, z = node['position'] * 10  # pylint: disable=invalid-name
             except KeyError:
-                if omit_missing_pos:
+                if nan_missing_pos:
                     x = y = z = float('nan')  # pylint: disable=invalid-name
                 else:
                     raise
@@ -150,7 +150,7 @@ def write_pdb_string(system, conect=True, omit_charges=True, omit_missing_pos=Fa
     return '\n'.join(out)
 
 
-def write_pdb(system, path, conect=True, omit_charges=True, omit_missing_pos=False):
+def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=False):
     """
     Writes `system` to `path` as a PDB formatted string.
 
@@ -165,7 +165,7 @@ def write_pdb(system, path, conect=True, omit_charges=True, omit_missing_pos=Fal
     omit_charges: bool
         Whether charges should be omitted. This is usually a good idea since
         the PDB format can only deal with integer charges.
-    omit_missing_pos: bool
+    nan_missing_pos: bool
         Wether the writing should fail if an atom does not have a position.
         When set to `True`, atoms without coordinates will be written
         with 'nan' as coordinates; this will cause the output file to be
@@ -177,7 +177,7 @@ def write_pdb(system, path, conect=True, omit_charges=True, omit_missing_pos=Fal
     :func:write_pdb_string
     """
     with open(path, 'w') as out:
-        out.write(write_pdb_string(system, conect, omit_charges, omit_missing_pos))
+        out.write(write_pdb_string(system, conect, omit_charges, nan_missing_pos))
 
 
 def do_conect(mol, conectlist):

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -66,7 +66,7 @@ def write_pdb_string(system, conect=True, omit_charges=True, omit_missing_pos=Fa
         the PDB format can only deal with integer charges.
     omit_missing_pos: bool
         Wether the writing should fail if an atom does not have a position.
-        When set to :bool:`True`, atoms without coordinates will be written
+        When set to `True`, atoms without coordinates will be written
         with 'nan' as coordinates; this will cause the output file to be
         *invalid* for most uses.
         for most use.
@@ -167,7 +167,7 @@ def write_pdb(system, path, conect=True, omit_charges=True, omit_missing_pos=Fal
         the PDB format can only deal with integer charges.
     omit_missing_pos: bool
         Wether the writing should fail if an atom does not have a position.
-        When set to :bool:`True`, atoms without coordinates will be written
+        When set to `True`, atoms without coordinates will be written
         with 'nan' as coordinates; this will cause the output file to be
         *invalid* for most uses.
         for most use.

--- a/vermouth/tests/gmx/test_gro.py
+++ b/vermouth/tests/gmx/test_gro.py
@@ -281,7 +281,7 @@ def filter_molecule(molecule, exclude, ignh):
     Remove nodes from a graph based on some criteria.
 
     Nodes are removed if their resname matches one from
-    the `exclude` argument, or of `ighn` is :bool:`True` and the node is a
+    the `exclude` argument, or of `ighn` is `True` and the node is a
     hydrogen.
 
     The atoms are renumbered after the filtered atoms are removed. This will
@@ -295,7 +295,7 @@ def filter_molecule(molecule, exclude, ignh):
     exclude: list
         List of residue name to exclude.
     ighn: bool
-        If :bool:`True`, the hydrogens are excluded.
+        If `True`, the hydrogens are excluded.
     """
     to_remove = []
     exclusions = [('resname', value) for value in exclude]

--- a/vermouth/tests/pdb/test_write_pdb.py
+++ b/vermouth/tests/pdb/test_write_pdb.py
@@ -114,7 +114,7 @@ END
 def test_write_failure_missing_pos(missing_pos_system):
     """
     Make sure the writing fails when coordinates are missing and
-    `omit_missing_pos` is not set. (Shall be :bool:`False` by default.)
+    `omit_missing_pos` is not set. (Shall be `False` by default.)
     """
     with pytest.raises(KeyError):
         pdb.write_pdb_string(missing_pos_system)
@@ -123,7 +123,7 @@ def test_write_failure_missing_pos(missing_pos_system):
 def test_write_success_missing_pos(missing_pos_system):
     """
     Make sure the writing succeed when coordinates are missing and
-    `omit_missing_pos` is :bool:`True`.
+    `omit_missing_pos` is `True`.
     """
     pdb_found = pdb.write_pdb_string(
         missing_pos_system,

--- a/vermouth/tests/pdb/test_write_pdb.py
+++ b/vermouth/tests/pdb/test_write_pdb.py
@@ -114,7 +114,7 @@ END
 def test_write_failure_missing_pos(missing_pos_system):
     """
     Make sure the writing fails when coordinates are missing and
-    `omit_missing_pos` is not set. (Shall be `False` by default.)
+    `nan_missing_pos` is not set. (Shall be `False` by default.)
     """
     with pytest.raises(KeyError):
         pdb.write_pdb_string(missing_pos_system)
@@ -123,13 +123,13 @@ def test_write_failure_missing_pos(missing_pos_system):
 def test_write_success_missing_pos(missing_pos_system):
     """
     Make sure the writing succeed when coordinates are missing and
-    `omit_missing_pos` is `True`.
+    `nan_missing_pos` is `True`.
     """
     pdb_found = pdb.write_pdb_string(
         missing_pos_system,
         conect=False,
         omit_charges=False,
-        omit_missing_pos=True,  # Argument of interest!
+        nan_missing_pos=True,  # Argument of interest!
     )
     expected = '''
 ATOM      1 A    A       1      10.000  20.000 -30.000  1.00  0.00          A   

--- a/vermouth/tests/pdb/test_write_pdb.py
+++ b/vermouth/tests/pdb/test_write_pdb.py
@@ -20,12 +20,31 @@ Unittests for the PDB writer.
 
 import numpy as np
 import networkx as nx
+
+import pytest
+
 import vermouth
 from vermouth.molecule import Molecule
 from vermouth.pdb import pdb
 
 
-def test_conect():
+@pytest.fixture
+def dummy_system():
+    """
+    Build a system with 3 dummy molecules.
+
+    All nodes have the following attributes:
+
+    * `atomname`
+    * `resname`
+    * `resid`
+    * `chain` set to `''`
+    * `element` set to the value of `atomname`
+    * `positions`
+
+    Some nodes have a `charge` attribute set to an integer charge. The
+    molecules are connected.
+    """
     nodes = (
              {'atomname': 'A', 'resname': 'A', 'resid': 1, },
              {'atomname': 'B', 'resname': 'A', 'resid': 1, 'charge': -1},
@@ -48,7 +67,26 @@ def test_conect():
                  for component in nx.connected_components(graph)]
     system = vermouth.system.System()
     system.molecules = molecules
-    pdb_found = pdb.write_pdb_string(system, conect=True, omit_charges=False)
+    return system
+
+
+@pytest.fixture
+def missing_pos_system(dummy_system):
+    """
+    Build a system of dummy molecules with some nodes lacking a `position`
+    attribute.
+    """
+    for node in dummy_system.molecules[1].nodes.values():
+        del node['position']
+    return dummy_system
+
+
+def test_conect(dummy_system):
+    """
+    Test that the CONECT record is written as expected. Test also that the
+    overall format is correct.
+    """
+    pdb_found = pdb.write_pdb_string(dummy_system, conect=True, omit_charges=False)
     expected = '''
 ATOM      1 A    A       1      10.000  20.000 -30.000  1.00  0.00          A   
 ATOM      2 B    A       1      10.000  20.000 -30.000  1.00  0.00          B 1-
@@ -65,6 +103,43 @@ CONECT    1    2
 CONECT    4    5
 CONECT    7    8
 CONECT    8    9   10
+END
+'''
+    assert pdb_found.strip() == expected.strip()
+
+
+def test_write_failure_missing_pos(missing_pos_system):
+    """
+    Make sure the writing fails when coordinates are missing and
+    `omit_missing_pos` is not set. (Shall be :bool:`False` by default.)
+    """
+    with pytest.raises(KeyError):
+        pdb.write_pdb_string(missing_pos_system)
+
+
+def test_write_success_missing_pos(missing_pos_system):
+    """
+    Make sure the writing succeed when coordinates are missing and
+    `omit_missing_pos` is :bool:`True`.
+    """
+    pdb_found = pdb.write_pdb_string(
+        missing_pos_system,
+        conect=False,
+        omit_charges=False,
+        omit_missing_pos=True,  # Argument of interest!
+    )
+    expected = '''
+ATOM      1 A    A       1      10.000  20.000 -30.000  1.00  0.00          A   
+ATOM      2 B    A       1      10.000  20.000 -30.000  1.00  0.00          B 1-
+TER       3      A       1 
+ATOM      4 C    A       2         nan     nan     nan  1.00  0.00          C 1+
+ATOM      5 D    A       3         nan     nan     nan  1.00  0.00          D   
+TER       6      A       3 
+ATOM      7 E    A       4      10.000  20.000 -30.000  1.00  0.00          E   
+ATOM      8 F    B       4      10.000  20.000 -30.000  1.00  0.00          F   
+ATOM      9 G    B       4      10.000  20.000 -30.000  1.00  0.00          G   
+ATOM     10 H    B       4      10.000  20.000 -30.000  1.00  0.00          H   
+TER      11      B       4 
 END
 '''
     assert pdb_found.strip() == expected.strip()

--- a/vermouth/tests/pdb/test_write_pdb.py
+++ b/vermouth/tests/pdb/test_write_pdb.py
@@ -17,6 +17,9 @@
 Unittests for the PDB writer.
 """
 
+# Pylint is wrongly complaining about fixtures.
+# pylint: disable=redefined-outer-name
+
 
 import numpy as np
 import networkx as nx
@@ -46,15 +49,15 @@ def dummy_system():
     molecules are connected.
     """
     nodes = (
-             {'atomname': 'A', 'resname': 'A', 'resid': 1, },
-             {'atomname': 'B', 'resname': 'A', 'resid': 1, 'charge': -1},
-             {'atomname': 'C', 'resname': 'A', 'resid': 2, 'charge': 1},
-             {'atomname': 'D', 'resname': 'A', 'resid': 3, },
-             {'atomname': 'E', 'resname': 'A', 'resid': 4, },
-             {'atomname': 'F', 'resname': 'B', 'resid': 4, },
-             {'atomname': 'G', 'resname': 'B', 'resid': 4, },
-             {'atomname': 'H', 'resname': 'B', 'resid': 4, },
-            )
+        {'atomname': 'A', 'resname': 'A', 'resid': 1, },
+        {'atomname': 'B', 'resname': 'A', 'resid': 1, 'charge': -1},
+        {'atomname': 'C', 'resname': 'A', 'resid': 2, 'charge': 1},
+        {'atomname': 'D', 'resname': 'A', 'resid': 3, },
+        {'atomname': 'E', 'resname': 'A', 'resid': 4, },
+        {'atomname': 'F', 'resname': 'B', 'resid': 4, },
+        {'atomname': 'G', 'resname': 'B', 'resid': 4, },
+        {'atomname': 'H', 'resname': 'B', 'resid': 4, },
+    )
     edges = [(0, 1), (2, 3), (4, 5), (5, 6), (5, 7)]
     graph = nx.Graph()
     for idx, node in enumerate(nodes):


### PR DESCRIPTION
The -write-* options allow to write the state of the system as a PDB
file at various stages of the workflow. Though, the wrong system was
wtitten. Also, some stages lack coordinates for some atoms which was
causing issues. This commit adds the `omit_missing_pos` argument to the
PDB writer that allows to write nan when the coordinates are missing.