### PR TITLE
Add the -ss option to martinize2

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -249,13 +249,18 @@ def entry():
     posres_group.add_argument('-pf', dest='posres_fc', type=float, default=1000,
                               help='Position restraints force constant in kJ/mol/nm^2')
     secstruct_group = parser.add_argument_group('Secondary structure handling')
-    secstruct_group.add_argument('-dssp', nargs='?', const='dssp',
-                                 help='DSSP executable for determining structure')
+    secstruct_exclusion = secstruct_group.add_mutually_exclusive_group()
+    secstruct_exclusion.add_argument('-dssp', nargs='?', const='dssp',
+                                     help='DSSP executable for determining structure')
+    secstruct_exclusion.add_argument('-ss', dest='ss', type=lambda x: x.upper(),
+                                     metavar='SEQUENCE',
+                                     help=('Manually set the secondary '
+                                           'structure of the proteins.'))
+    secstruct_exclusion.add_argument('-collagen', action='store_true', default=False,
+                                     help='Use collagen parameters')
     secstruct_group.add_argument('-ed', dest='extdih', action='store_true', default=False,
                                  help=('Use dihedrals for extended regions '
                                        'rather than elastic bonds'))
-    secstruct_group.add_argument('-collagen', action='store_true', default=False,
-                                 help='Use collagen parameters')
 
     rb_group = parser.add_argument_group('Protein elastic network')
     rb_group.add_argument('-elastic', action='store_true', default=False,
@@ -351,6 +356,10 @@ def entry():
     target_ff = known_force_fields[args.to_ff]
     if args.dssp is not None:
         AnnotateDSSP(executable=args.dssp, savedir='.').run_system(system)
+        AnnotateMartiniSecondaryStructures().run_system(system)
+    elif args.ss is not None:
+        AnnotateResidues(attribute='secstruct', sequence=args.ss,
+                         molecule_selector=selectors.is_protein).run_system(system)
         AnnotateMartiniSecondaryStructures().run_system(system)
     elif args.collagen:
         if not target_ff.has_feature('collagen'):

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -29,6 +29,7 @@ import sys
 import vermouth
 from vermouth.forcefield import FORCE_FIELDS
 from vermouth import DATA_PATH
+from vermouth.dssp import dssp
 from vermouth.dssp.dssp import (
     AnnotateDSSP,
     AnnotateMartiniSecondaryStructures,
@@ -379,6 +380,12 @@ def entry():
                         .format(target_ff.name))
     vermouth.SetMoleculeMeta(neutral_termini=args.neutral_termini).run_system(system)
 
+    ss_sequence = list(itertools.chain(*(
+        dssp.sequence_from_residues(molecule, 'secstruct')
+        for molecule in system.molecules
+        if selectors.is_protein(molecule)
+    )))
+
     if args.cystein_bridge == 'none':
         vermouth.RemoveCysteinBridgeEdges().run_system(system)
     elif args.cystein_bridge != 'auto':
@@ -431,6 +438,13 @@ def entry():
         ' '.join(sys.argv),
         VERSION,
     ]
+    if None not in ss_sequence:
+        header += [
+            'The following sequence of secondary structure ',
+            'was used for the full system:',
+            ''.join(ss_sequence),
+        ]
+
     if args.top_path is not None:
         write_gmx_topology(system, args.top_path,
                            deduplicate=not args.keep_duplicate_itp,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -244,7 +244,7 @@ def entry():
                           help='Additional repository for mapping files.')
 
     posres_group = parser.add_argument_group('Position restraints')
-    posres_group.add_argument('-p', dest='posres', type=lambda x: x.lower(),
+    posres_group.add_argument('-p', dest='posres', type=str.lower,
                               choices=('none', 'all', 'backbone'), default='none',
                               help='Output position restraints (none/all/backbone)')
     posres_group.add_argument('-pf', dest='posres_fc', type=float, default=1000,
@@ -253,7 +253,7 @@ def entry():
     secstruct_exclusion = secstruct_group.add_mutually_exclusive_group()
     secstruct_exclusion.add_argument('-dssp', nargs='?', const='dssp',
                                      help='DSSP executable for determining structure')
-    secstruct_exclusion.add_argument('-ss', dest='ss', type=lambda x: x.upper(),
+    secstruct_exclusion.add_argument('-ss', dest='ss', type=str.upper,
                                      metavar='SEQUENCE',
                                      help=('Manually set the secondary '
                                            'structure of the proteins.'))

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -515,7 +515,7 @@ class AnnotateResidues(Processor):
         vermouth.system.System
         """
         # Test and adjust the length of the sequence. There are 3 valid scenarios:
-        # * the length of the sequence matchesthe number of residues in the
+        # * the length of the sequence matches the number of residues in the
         #   selection;
         # * all the molecules in the selection have the same number of residues
         #   and the sequence length matches the number of residue of one

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -473,7 +473,7 @@ class AnnotateResidues(Processor):
         Name of the node attribute to populate.
     sequence: collections.abc.Sequence
         Per-residue sequence.
-    molecule_selector: callable
+    molecule_selector: collections.abc.Callable
         Function that takes an instance of :class:`vermouth.molecule.Molecule`
         as argument and returns `True` if the molecule should be considered,
         else `False`.

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -170,7 +170,7 @@ class TestAnnotateResidues:
         found = self.sequence_from_system(multi_mol_system_regular, 'test')
         assert found == expected
 
-    def test_sigle_molecules_cycle_one(self, single_mol_system):
+    def test_single_molecules_cycle_one(self, single_mol_system):
         """
         One molecule and a one element sequence to repeat over all residues of
         the molecule.

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -30,6 +30,272 @@ SECSTRUCT_1BTA = list('CEEEEETTTCCSHHHHHHHHHHHHTCCTTCCCSHHHHHHHHTTT'
                       'SCSSEEEEEESTTHHHHTTTSSHHHHHHHHHHHHHTTCCEEEEEC')
 
 
+# TODO: The code is very repetitive. There may be a way to refactor it with
+# clever use of parametrize and fixtures.
+class TestAnnotateResidues:
+    """
+    Tests for the :class:`dssp.AnnotateResidues` processor.
+    """
+    @staticmethod
+    def build_molecule(nresidues):
+        """
+        Build a dummy molecule with the requested number of residues and 3
+        atoms per residue.
+        """
+        molecule = vermouth.molecule.Molecule()
+        residue_template = vermouth.molecule.Molecule()
+        residue_template.add_nodes_from(
+            (idx, {'chain':'', 'atomname':str(idx), 'resname': 'DUMMY', 'resid': 1})
+            for idx in range(3)
+        )
+        for _ in range(nresidues):
+            molecule.merge_molecule(residue_template)
+        return molecule
+
+    @staticmethod
+    def sequence_from_mol(molecule, attribute, default=None):
+        """
+        Extract the content of an attribute for each node of a molecule.
+        """
+        return [node.get(attribute, default) for node in molecule.nodes.values()]
+
+    def sequence_from_system(self, system, attribute, default=None):
+        """
+        Extract the content of an attribute for each node of a system.
+        """
+        return list(itertools.chain(*(
+            self.sequence_from_mol(molecule, attribute, default)
+            for molecule in system.molecules
+        )))
+
+    @pytest.mark.parametrize('nres', (0, 1, 3, 10))
+    def test_build_molecule(self, nres):
+        """
+        :meth:`build_molecule` and :meth:`sequence_from_mol` work as excpected.
+        """
+        expected_resid = list(itertools.chain(
+            *([idx + 1] * 3 for idx in range(nres))
+        ))
+        expected_atomname = ['0', '1', '2'] * nres
+        expected_chain = [''] * (nres * 3)
+        expected_resname = ['DUMMY'] * (nres * 3)
+        molecule = self.build_molecule(nres)
+        assert self.sequence_from_mol(molecule, 'resid') == expected_resid
+        assert self.sequence_from_mol(molecule, 'resname') == expected_resname
+        assert self.sequence_from_mol(molecule, 'chain') == expected_chain
+        assert self.sequence_from_mol(molecule, 'atomname') == expected_atomname
+
+    @pytest.fixture
+    def single_mol_system(self):
+        """
+        Build a system with a single molecule that count 5 residues of 3 atoms
+        each.
+        """
+        molecule = self.build_molecule(5)
+        system = vermouth.system.System()
+        system.molecules = [molecule]
+        return system
+
+    @pytest.fixture
+    def multi_mol_system_irregular(self):
+        """
+        Build a system with 3 molecules having 4, 5, and 6 residues,
+        respectively.
+        """
+        system = vermouth.system.System()
+        system.molecules = [self.build_molecule(nres) for nres in (4, 5, 6)]
+        return system
+
+    @pytest.fixture
+    def multi_mol_system_regular(self):
+        """
+        Build a system with 3 molecules having each 4 residues.
+        """
+        system = vermouth.system.System()
+        system.molecules = [self.build_molecule(4) for _ in range(3)]
+        return system
+
+    @pytest.mark.parametrize('sequence', (
+        'ABCDE',
+        ['A', 'B', 'C', 'D', 'E'],
+        range(5),
+    ))
+    def test_single_molecule(self, single_mol_system, sequence):
+        """
+        The simple case with a single molecule and a sequence of the right size
+        works as expected.
+        """
+        expected = list(itertools.chain(
+            *([element] * 3 for element in sequence)
+        ))
+        processor = dssp.AnnotateResidues('test', sequence)
+        processor.run_system(single_mol_system)
+        found = self.sequence_from_system(single_mol_system, 'test')
+        assert found == expected
+
+    @pytest.mark.parametrize('sequence', (
+        'ABCDEFGHIJKLMNO',
+        list('ABCDEFGHIJKLMNO'),
+        range(15),
+    ))
+    def test_multi_molecules_diff_sizes(self, multi_mol_system_irregular, sequence):
+        """
+        The case of many protein of various sizes and a sequence of the right
+        size works as expected.
+        """
+        expected = list(itertools.chain(
+            *([element] * 3 for element in sequence)
+        ))
+        processor = dssp.AnnotateResidues('test', sequence)
+        processor.run_system(multi_mol_system_irregular)
+        found = self.sequence_from_system(multi_mol_system_irregular, 'test')
+        assert found == expected
+
+    @pytest.mark.parametrize('sequence', (
+        'ABCD',
+        ['A', 'B', 'C', 'D'],
+        range(4),
+    ))
+    def test_multi_molecules_cycle(self, multi_mol_system_regular, sequence):
+        """
+        The case with multiple molecules with all the same size and one
+        sequence to repeat for each molecule works as expected.
+        """
+        expected = list(itertools.chain(
+            *([element] * 3 for element in sequence)
+        ))
+        expected = expected * 3
+        processor = dssp.AnnotateResidues('test', sequence)
+        processor.run_system(multi_mol_system_regular)
+        found = self.sequence_from_system(multi_mol_system_regular, 'test')
+        assert found == expected
+
+    def test_sigle_molecules_cycle_one(self, single_mol_system):
+        """
+        One molecule and a one element sequence to repeat over all residues of
+        the molecule.
+        """
+        sequence = 'A'
+        expected = [sequence] * (5 * 3)
+        processor = dssp.AnnotateResidues('test', sequence)
+        processor.run_system(single_mol_system)
+        found = self.sequence_from_system(single_mol_system, 'test')
+        assert found == expected
+
+
+    def test_multi_molecules_cycle_one(self, multi_mol_system_irregular):
+        """
+        Many molecules and a one element sequence to repeat.
+        """
+        sequence = 'A'
+        expected = [sequence] * (15 * 3)
+        processor = dssp.AnnotateResidues('test', sequence)
+        processor.run_system(multi_mol_system_irregular)
+        found = self.sequence_from_system(multi_mol_system_irregular, 'test')
+        assert found == expected
+
+    @staticmethod
+    @pytest.mark.parametrize('sequence', (
+        'ABC',  # Too short
+        'ABCD',  # Too short, match the length of the first molecule
+        'ABCDEFGHIFKLMNOPQRSTU',  # Too long
+        '',  # Empty
+    ))
+    def test_wrong_length(multi_mol_system_irregular, sequence):
+        """
+        Many molecule and a sequence that has the wrong length raises an error.
+        """
+        processor = dssp.AnnotateResidues('test', sequence)
+        with pytest.raises(ValueError):
+            processor.run_system(multi_mol_system_irregular)
+
+    @staticmethod
+    @pytest.mark.parametrize('sequence', (
+        'ABC',  # Too short
+        'ABCD',  # Too short, match the length of the first molecule
+        'ABCDEFGHIFKLMNOPQRSTU',  # Too long
+        '',  # Empty
+        'ABCDEFGHIJKLMNO',  # Length of all the molecules, without filter
+    ))
+    def test_wrong_length_with_filter(multi_mol_system_irregular, sequence):
+        """
+        Many molecules and a sequence that has the wrong length because of a
+        molecule selector.
+        """
+        # We exclude the second molecule. The filter excludes it based on the
+        # number of nodes, which is 15 because it has 5 residues with 3 nodes
+        # each.
+        processor = dssp.AnnotateResidues(
+            'test', sequence,
+            molecule_selector=lambda mol: len(mol.nodes) != (5 * 3),
+        )
+        with pytest.raises(ValueError):
+            processor.run_system(multi_mol_system_irregular)
+
+    @staticmethod
+    def test_empty_system_empty_sequence():
+        """
+        There are no molecules, but the sequence is empty.
+        """
+        system = vermouth.system.System()
+        sequence = ''
+        processor = dssp.AnnotateResidues('test', sequence)
+        try:
+            processor.run_system(system)
+        except ValueError:
+            pytest.fail('Should not have raised a ValueError.')
+
+    @staticmethod
+    def test_empty_system_error():
+        """
+        There are no molecules, but there is a sequence. Should raise an error.
+        """
+        system = vermouth.system.System()
+        sequence = 'not empty'
+        processor = dssp.AnnotateResidues('test', sequence)
+        with pytest.raises(ValueError):
+            processor.run_system(system)
+
+    @staticmethod
+    def test_empty_with_filter(multi_mol_system_irregular):
+        """
+        There is a sequence, but no molecule are accepted by the molecule
+        selector. Should raise an error.
+        """
+        sequence = 'not empty'
+        processor = dssp.AnnotateResidues(
+            'test', sequence, molecule_selector=lambda mol: False
+        )
+        with pytest.raises(ValueError):
+            processor.run_system(multi_mol_system_irregular)
+
+    def test_run_molecule(self, single_mol_system):
+        """
+        The `run_molecule` method works.
+        """
+        sequence = 'ABCDE'
+        expected = list(itertools.chain(
+            *([element] * 3 for element in sequence)
+        ))
+        processor = dssp.AnnotateResidues('test', sequence)
+        processor.run_molecule(single_mol_system.molecules[0])
+        found = self.sequence_from_system(single_mol_system, 'test')
+        assert found == expected
+
+    def test_run_molecule_not_selected(self, single_mol_system):
+        """
+        The molecule selector works with `run_molecule`.
+        """
+        sequence = 'ABCDE'
+        processor = dssp.AnnotateResidues(
+            'test', sequence, molecule_selector=lambda mol: False
+        )
+        processor.run_molecule(single_mol_system.molecules[0])
+        found = self.sequence_from_system(single_mol_system, 'test')
+        assert vermouth.utils.are_all_equal(found)
+        assert found[0] is None
+
+
 @pytest.mark.parametrize(
     'molecule, reference_answer',
     [(read_pdb(str(path)), answer) for path, answer in [


### PR DESCRIPTION
The `-ss` option is used to manually set the secondary structures of protein instead of using DSSP. The feature is present in the legacy martinize, and has been requested several times by members of the group (Maria and Lorenzo among others).