### PR TITLE
Fix mapping files so they start by `[ molecule ]`

### DIFF
--- a/vermouth/data/mappings/ala.charmm36.map
+++ b/vermouth/data/mappings/ala.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ALA
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-ALA
 
 [ martini ]
 BB

--- a/vermouth/data/mappings/arg.charmm36.map
+++ b/vermouth/data/mappings/arg.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ARG
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-ARG
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/arg.charmm36.martini22p.map
+++ b/vermouth/data/mappings/arg.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ARG
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-ARG
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/asn.charmm36.map
+++ b/vermouth/data/mappings/asn.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASN
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-ASN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/asn.charmm36.martini22p.map
+++ b/vermouth/data/mappings/asn.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASN
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-ASN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/asp.charmm36.map
+++ b/vermouth/data/mappings/asp.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASP
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-ASP
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/asp.charmm36.martini22p.map
+++ b/vermouth/data/mappings/asp.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASP
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-ASP
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/chol.charmm36.map
+++ b/vermouth/data/mappings/chol.charmm36.map
@@ -11,6 +11,9 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
+[ molecule ]
+CHOL
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ martini22
 martini22p
 
 ; latest revision Kri 12.3.2013
-[ molecule ]
-CHOL
-
 [ martini ]
 ROH R1 R2 R3 R4 R5 C1 C2
 

--- a/vermouth/data/mappings/cys.charmm36.map
+++ b/vermouth/data/mappings/cys.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+CYS
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-CYS
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/dmpc.charmm36.map
+++ b/vermouth/data/mappings/dmpc.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DMPC
+
 [from]
 universal
 
@@ -20,9 +23,6 @@ martini22
 martini22p
 
 ; Mapping file created 24/11/2015 by Kri
-
-[ molecule ]
-DMPC
 
 [ martini ]
 NC3 PO4 GL1 GL2 C1A C2A C3A C1B C2B C3B

--- a/vermouth/data/mappings/dopc.charmm36.map
+++ b/vermouth/data/mappings/dopc.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DOPC
+
 [from]
 universal
 
@@ -21,15 +24,13 @@ martini22p
 
 ; Mapping file created 15/03/2013 by Kri
 
-[ molecule ]
-DOPC
+
+[ martini ]
+NC3 PO4 GL1 GL2 C1A C2A D3A C4A C5A C1B C2B D3B C4B C5B
 ;
 ; NC3-PO4-GL1-C1A-C2A-D3A-C4A-C5A
 ;         |
 ;         GL2-C1B-C2B-D3B-C4B-C5B
-
-[ martini ]
-NC3 PO4 GL1 GL2 C1A C2A D3A C4A C5A C1B C2B D3B C4B C5B
 
 [ mapping ]
 charmm27 charmm36

--- a/vermouth/data/mappings/dppc.charmm36.map
+++ b/vermouth/data/mappings/dppc.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DPPC
+
 [from]
 universal
 
@@ -21,8 +24,6 @@ martini22p
 
 ; Mapping file created 28/02/2013 by Kri
 
-[ molecule ]
-DPPC
 
 [ martini ]
 NC3 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B C3B C4B 

--- a/vermouth/data/mappings/dppg.charmm36.map
+++ b/vermouth/data/mappings/dppg.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DPPG
+
 [from]
 universal
 
@@ -20,9 +23,6 @@ martini22
 martini22p
 
 ; Created by Jagannath Mondal
-
-[ molecule ]
-DPPG
 
 [ martini ]
 GL0 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B C3B C4B 

--- a/vermouth/data/mappings/elnedyn/ala.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/ala.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ALA
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-ALA
 
 [ martini ]
 BB

--- a/vermouth/data/mappings/elnedyn/arg.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/arg.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ARG
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-ARG
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/elnedyn/arg.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/arg.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ARG
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-ARG
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/elnedyn/asn.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/asn.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASN
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-ASN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/asn.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/asn.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASN
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-ASN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/asp.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/asp.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASP
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-ASP
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/asp.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/asp.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASP
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-ASP
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/chol.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/chol.charmm36.map
@@ -11,6 +11,10 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
+
+[ molecule ]
+CHOL
+
 [from]
 universal
 
@@ -18,10 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-; latest revision Kri 12.3.2013
-[ molecule ]
-CHOL
 
 [ martini ]
 ROH R1 R2 R3 R4 R5 C1 C2

--- a/vermouth/data/mappings/elnedyn/cys.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/cys.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+CYS
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-CYS
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/dmpc.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/dmpc.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DMPC
+
 [from]
 universal
 
@@ -21,9 +24,6 @@ elnedyn22
 elnedyn22p
 
 ; Mapping file created 24/11/2015 by Kri
-
-[ molecule ]
-DMPC
 
 [ martini ]
 NC3 PO4 GL1 GL2 C1A C2A C3A C1B C2B C3B

--- a/vermouth/data/mappings/elnedyn/dopc.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/dopc.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DOPC
+
 [from]
 universal
 
@@ -22,8 +25,6 @@ elnedyn22p
 
 ; Mapping file created 15/03/2013 by Kri
 
-[ molecule ]
-DOPC
 ;
 ; NC3-PO4-GL1-C1A-C2A-D3A-C4A-C5A
 ;         |

--- a/vermouth/data/mappings/elnedyn/dppc.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/dppc.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DPPC
+
 [from]
 universal
 
@@ -21,9 +24,6 @@ elnedyn22
 elnedyn22p
 
 ; Mapping file created 28/02/2013 by Kri
-
-[ molecule ]
-DPPC
 
 [ martini ]
 NC3 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B C3B C4B 

--- a/vermouth/data/mappings/elnedyn/dppg.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/dppg.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+DPPG
+
 [from]
 universal
 
@@ -21,9 +24,6 @@ elnedyn22
 elnedyn22p
 
 ; Created by Jagannath Mondal
-
-[ molecule ]
-DPPG
 
 [ martini ]
 GL0 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B C3B C4B 

--- a/vermouth/data/mappings/elnedyn/gln.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/gln.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLN
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-GLN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/gln.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/gln.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLN
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-GLN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/glu.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/glu.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLU
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-GLU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/glu.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/glu.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLU
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-GLU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/gly.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/gly.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLY
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-GLY
 
 [ martini ]
 BB

--- a/vermouth/data/mappings/elnedyn/his.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/his.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/elnedyn/ile.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/ile.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ILE
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-ILE
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/leu.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/leu.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LEU
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-LEU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/lys.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/lys.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LYS
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-LYS
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/elnedyn/lys.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/lys.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LYS
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-LYS
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/elnedyn/met.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/met.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+MET
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-MET
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/phe.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/phe.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+PHE
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-PHE
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/elnedyn/popc.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/popc.charmm36.map
@@ -12,6 +12,10 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+; latest revision TAW 20160213
+[ molecule ]
+POPC
+
 [from]
 universal
 
@@ -19,10 +23,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-; latest revision TAW 20160213
-[ molecule ]
-POPC
 
 [ martini ]
 NC3 PO4 GL1 GL2 C1A D2A C3A C4A C1B C2B C3B C4B 

--- a/vermouth/data/mappings/elnedyn/pope.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/pope.charmm36.map
@@ -12,6 +12,10 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+; latest revision kri 15.3.2013
+[ molecule ]
+POPE
+
 [from]
 universal
 
@@ -19,10 +23,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-; latest revision kri 15.3.2013
-[ molecule ]
-POPE
 
 [ martini ]
 NH3 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B D3B C4B C5B

--- a/vermouth/data/mappings/elnedyn/popg.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/popg.charmm36.map
@@ -12,6 +12,10 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+; latest revision kri 15.3.2013
+[ molecule ]
+POPG
+
 [from]
 universal
 
@@ -19,10 +23,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-; latest revision kri 15.3.2013
-[ molecule ]
-POPG
 
 [ martini ]
 GL0 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B D3B C4B C5B

--- a/vermouth/data/mappings/elnedyn/pops.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/pops.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+POPS
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-POPS
 
 [ martini ]
 CNO PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B D3B C4B C5B

--- a/vermouth/data/mappings/elnedyn/pro.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/pro.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+PRO
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-PRO
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/ser.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/ser.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+SER
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-SER
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/ser.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/ser.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+SER
+
 [from]
 universal
 
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-SER
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/thr.charmm36.elnedyn22p.map
+++ b/vermouth/data/mappings/elnedyn/thr.charmm36.elnedyn22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+THR
+
 [from]
 universal
 
 [to]
 elnedyn22p
-
-[ molecule ]
-THR
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/elnedyn/thr.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/thr.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ martini ]
+BB SC1
+
 [from]
 universal
 
@@ -21,9 +24,6 @@ elnedyn22
 
 [ molecule ]
 THR
-
-[ martini ]
-BB SC1
 
 [ mapping ]
 charmm27 charmm36

--- a/vermouth/data/mappings/elnedyn/trp.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/trp.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+TRP
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-TRP
 
 [ martini ]
 BB SC1 SC2 SC3 SC4

--- a/vermouth/data/mappings/elnedyn/tyr.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/tyr.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+TYR
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-TYR
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/gln.charmm36.map
+++ b/vermouth/data/mappings/gln.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLN
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-GLN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/gln.charmm36.martini22p.map
+++ b/vermouth/data/mappings/gln.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLN
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-GLN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/glu.charmm36.map
+++ b/vermouth/data/mappings/glu.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLU
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-GLU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/glu.charmm36.martini22p.map
+++ b/vermouth/data/mappings/glu.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLU
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-GLU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/gly.charmm36.map
+++ b/vermouth/data/mappings/gly.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLY
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-GLY
 
 [ martini ]
 BB

--- a/vermouth/data/mappings/his.charmm36.map
+++ b/vermouth/data/mappings/his.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/ile.charmm36.map
+++ b/vermouth/data/mappings/ile.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ILE
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-ILE
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/leu.charmm36.map
+++ b/vermouth/data/mappings/leu.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LEU
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-LEU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/lys.charmm36.map
+++ b/vermouth/data/mappings/lys.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LYS
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-LYS
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/lys.charmm36.martini22p.map
+++ b/vermouth/data/mappings/lys.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LYS
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-LYS
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/martini30/ala.charmm36.map
+++ b/vermouth/data/mappings/martini30/ala.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ALA
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-ALA
 
 [ martini ]
 BB

--- a/vermouth/data/mappings/martini30/arg.charmm36.map
+++ b/vermouth/data/mappings/martini30/arg.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ARG
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-ARG
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/martini30/asn.charmm36.map
+++ b/vermouth/data/mappings/martini30/asn.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASN
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-ASN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/asp.charmm36.map
+++ b/vermouth/data/mappings/martini30/asp.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ASP
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-ASP
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/cys.charmm36.map
+++ b/vermouth/data/mappings/martini30/cys.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+CYS
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-CYS
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/gln.charmm36.map
+++ b/vermouth/data/mappings/martini30/gln.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLN
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-GLN
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/glu.charmm36.map
+++ b/vermouth/data/mappings/martini30/glu.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLU
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-GLU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/gly.charmm36.map
+++ b/vermouth/data/mappings/martini30/gly.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+GLY
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-GLY
 
 [ martini ]
 BB

--- a/vermouth/data/mappings/martini30/his.charmm36.map
+++ b/vermouth/data/mappings/martini30/his.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-HIS  ;;;; is in fact HSP but if one of hydrogen on a nitrogen is missing in the input topology file, will become HSE or HSD automatically
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/martini30/ile.charmm36.map
+++ b/vermouth/data/mappings/martini30/ile.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+ILE
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-ILE
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/leu.charmm36.map
+++ b/vermouth/data/mappings/martini30/leu.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LEU
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-LEU
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/lys.charmm36.map
+++ b/vermouth/data/mappings/martini30/lys.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+LYS
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-LYS
 
 [ martini ]
 BB SC1 SC2

--- a/vermouth/data/mappings/martini30/met.charmm36.map
+++ b/vermouth/data/mappings/martini30/met.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+MET
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-MET
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/phe.charmm36.map
+++ b/vermouth/data/mappings/martini30/phe.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+PHE
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-PHE
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/martini30/pro.charmm36.map
+++ b/vermouth/data/mappings/martini30/pro.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+PRO
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-PRO
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/ser.charmm36.map
+++ b/vermouth/data/mappings/martini30/ser.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+SER
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-SER
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/thr.charmm36.map
+++ b/vermouth/data/mappings/martini30/thr.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+THR
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-THR
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/martini30/trp.charmm36.map
+++ b/vermouth/data/mappings/martini30/trp.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+TRP
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-TRP
 
 [ mapping ]
 charmm27 charmm36

--- a/vermouth/data/mappings/martini30/tyr.charmm36.map
+++ b/vermouth/data/mappings/martini30/tyr.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+TYR
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-TYR
 
 [ mapping ]
 charmm27 charmm36

--- a/vermouth/data/mappings/martini30/val.charmm36.map
+++ b/vermouth/data/mappings/martini30/val.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+VAL
+
 [from]
 universal
 
 [to]
 martini30
-
-[ molecule ]
-VAL
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/met.charmm36.map
+++ b/vermouth/data/mappings/met.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+MET
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-MET
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/phe.charmm36.map
+++ b/vermouth/data/mappings/phe.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+PHE
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-PHE
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/popc.charmm36.map
+++ b/vermouth/data/mappings/popc.charmm36.map
@@ -12,16 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+POPC
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-; latest revision TAW 20160213
-[ molecule ]
-POPC
 
 [ martini ]
 NC3 PO4 GL1 GL2 C1A D2A C3A C4A C1B C2B C3B C4B 

--- a/vermouth/data/mappings/pope.charmm36.map
+++ b/vermouth/data/mappings/pope.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+POPE
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 martini22
 martini22p
 
-; latest revision kri 15.3.2013
-[ molecule ]
-POPE
 
 [ martini ]
 NH3 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B D3B C4B C5B

--- a/vermouth/data/mappings/popg.charmm36.map
+++ b/vermouth/data/mappings/popg.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+POPG
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 martini22
 martini22p
 
-; latest revision kri 15.3.2013
-[ molecule ]
-POPG
 
 [ martini ]
 GL0 PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B D3B C4B C5B

--- a/vermouth/data/mappings/pops.charmm36.map
+++ b/vermouth/data/mappings/pops.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+POPS
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-POPS
 
 [ martini ]
 CNO PO4 GL1 GL2 C1A C2A C3A C4A C1B C2B D3B C4B C5B

--- a/vermouth/data/mappings/pro.charmm36.map
+++ b/vermouth/data/mappings/pro.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+PRO
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-PRO
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/ser.charmm36.map
+++ b/vermouth/data/mappings/ser.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+SER
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-SER
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/ser.charmm36.martini22p.map
+++ b/vermouth/data/mappings/ser.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+SER
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-SER
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/thr.charmm36.map
+++ b/vermouth/data/mappings/thr.charmm36.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+THR
+
 [from]
 universal
 
 [to]
 martini22
-
-[ molecule ]
-THR
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/thr.charmm36.martini22p.map
+++ b/vermouth/data/mappings/thr.charmm36.martini22p.map
@@ -12,14 +12,14 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+THR
+
 [from]
 universal
 
 [to]
 martini22p
-
-[ molecule ]
-THR
 
 [ martini ]
 BB SC1

--- a/vermouth/data/mappings/trp.charmm36.map
+++ b/vermouth/data/mappings/trp.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+TRP
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-TRP
 
 [ martini ]
 BB SC1 SC2 SC3 SC4

--- a/vermouth/data/mappings/tyr.charmm36.map
+++ b/vermouth/data/mappings/tyr.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+TYR
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-TYR
 
 [ martini ]
 BB SC1 SC2 SC3

--- a/vermouth/data/mappings/val.charmm36.map
+++ b/vermouth/data/mappings/val.charmm36.map
@@ -12,15 +12,15 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+VAL
+
 [from]
 universal
 
 [to]
 martini22
 martini22p
-
-[ molecule ]
-VAL
 
 [ martini ]
 BB SC1


### PR DESCRIPTION
Since #101, mappings must start with the `[ molecule ]` section. The
mapping file were not following this rule, yet. This commit fixes the
mapping files so they are correctly read.