### PR TITLE
Minor performance optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ env:
     - VERMOUTH_TEST_DSSP=mkdssp
     - SKIP_GENERATE_AUTHORS=1
     - SKIP_WRITE_GIT_CHANGELOG=1
+  matrix:
+    - WITH_SCIPY=true
 install:
   - pip install --upgrade setuptools pip
+  - if [[ ${WITH_SCIPY} == true ]]; then pip install scipy; fi
   - pip install --upgrade -r requirements-tests.txt
   - pip install --upgrade .
 script:
@@ -42,6 +45,7 @@ jobs:
       sudo: true
     - python: "3.8-dev"
       sudo: true
+      env: WITH_SCIPY=false
 
     - stage: docs
       python: "3.5"

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -105,7 +105,7 @@ def pdb_to_universal(system, delete_unknown=False,
     if write_graph is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True)
     LOGGER.info('Repairing the graph.', type='step')
-    vermouth.RepairGraph(delete_unknown=delete_unknown).run_system(canonicalized)
+    vermouth.RepairGraph(delete_unknown=delete_unknown, include_graph=False).run_system(canonicalized)
     if write_repair is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_repair),
                                omit_charges=True, nan_missing_pos=True)

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -377,12 +377,12 @@ class Molecule(nx.Graph):
 
         nodes = set(nodes)
 
-        edges_to_add = [
-            (node, node2)
-            for node in nodes
-            for node2 in set(self[node]) & nodes
-        ]
-        subgraph.add_edges_from(edges_to_add)
+        #edges_to_add = [
+        #    (node, node2)
+        #    for node in nodes
+        #    for node2 in set(self[node]) & nodes
+        #]
+        subgraph.add_edges_from(self.edges_between(nodes, nodes, data=True))
 
         for interaction_type, interactions in self.interactions.items():
             for interaction in interactions:
@@ -646,7 +646,7 @@ class Molecule(nx.Graph):
         residue_graph = graph_utils.make_residue_graph(self)
         return (tuple(residue_graph.nodes[res]['graph'].nodes) for res in residue_graph.nodes)
 
-    def edges_between(self, n_bunch1, n_bunch2):
+    def edges_between(self, n_bunch1, n_bunch2, data=False):
         """
         Returns all edges in this molecule between nodes in `n_bunch1` and
         `n_bunch2`.
@@ -664,14 +664,15 @@ class Molecule(nx.Graph):
             A list of tuples of edges in this molecule. The first element of
             the tuple will be in `n_bunch1`, the second element in `n_bunch2`.
         """
-        result = []
         set_1 = set(n_bunch1)
         set_2 = set(n_bunch2)
         for node1 in set_1:
             cross = set_2 & set(self[node1])
             for node2 in cross:
-                result.append((node1, node2))
-        return result
+                if not data:
+                    yield (node1, node2)
+                else:
+                    yield (node1, node2, self.edges[node1, node2])
 
 
 class Block(Molecule):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -646,9 +646,14 @@ class Molecule(nx.Graph):
             A list of tuples of edges in this molecule. The first element of
             the tuple will be in `n_bunch1`, the second element in `n_bunch2`.
         """
-        return [(node1, node2)
-                for node1, node2 in itertools.product(n_bunch1, n_bunch2)
-                if self.has_edge(node1, node2)]
+        result = []
+        set_1 = set(n_bunch1)
+        set_2 = set(n_bunch2)
+        for node1 in set_1:
+            cross = set_2 & set(self[node1])
+            for node2 in cross:
+                result.append((node1, node2))
+        return result
 
 
 class Block(Molecule):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -377,8 +377,11 @@ class Molecule(nx.Graph):
 
         nodes = set(nodes)
 
-        edges_to_add = [edge for edge in self.edges
-                        if edge[0] in nodes and edge[1] in nodes]
+        edges_to_add = [
+            (node, node2)
+            for node in nodes
+            for node2 in set(self[node]) & nodes
+        ]
         subgraph.add_edges_from(edges_to_add)
 
         for interaction_type, interactions in self.interactions.items():

--- a/vermouth/redistributed/kdtree.py
+++ b/vermouth/redistributed/kdtree.py
@@ -1,5 +1,11 @@
 # Copyright Anne M. Archibald 2008
 # Released under the scipy license
+
+
+# KDTree.sparse_distance_matrix has been added as part of the vermouth library.
+# It does not exactly match the scipy corresponding function from the cKDTree
+# module.
+
 from __future__ import division, print_function, absolute_import
 
 import sys
@@ -693,6 +699,38 @@ class KDTree(object):
         traverse_checking(self.tree, Rectangle(self.maxes, self.mins),
                           other.tree, Rectangle(other.maxes, other.mins))
         return results
+
+    def sparse_distance_matrix(self, other, max_distance, p=2.0):
+        """
+        Emulate :meth:`scipy.spacial.KDtree.sparse_distance_matrix` without scipy.
+
+        The return value is a dictionary instead of scipy sparse matrix.
+
+        Notes
+        -----
+        This is not the original scipy method!
+
+        Parameters
+        ----------
+        other: KDTree
+        max_distance: positive float
+        p: float, optional
+
+        Returns
+        -------
+        dict
+            Pseudo `dok_matrix` where the keys are
+            `(index_in_self, index_in_other)` and the values are distances.
+        """
+        result = {}
+        pairs = self.query_ball_tree(other, max_distance, p=p)
+        for idx1, neighbors in enumerate(pairs):
+            for idx2 in neighbors:
+                dist = minkowski_distance(self.data[idx1], other.data[idx2], p=p)
+                if dist <= max_distance:
+                    result[(idx1, idx2)] = dist
+        return result
+
 
     def query_pairs(self, r, p=2., eps=0):
         """

--- a/vermouth/redistributed/kdtree.py
+++ b/vermouth/redistributed/kdtree.py
@@ -702,7 +702,7 @@ class KDTree(object):
 
     def sparse_distance_matrix(self, other, max_distance, p=2.0):
         """
-        Emulate :meth:`scipy.spacial.KDtree.sparse_distance_matrix` without scipy.
+        Emulate :meth:`scipy.spacial.cKDtree.sparse_distance_matrix` without scipy.
 
         The return value is a dictionary instead of scipy sparse matrix.
 

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -197,4 +197,6 @@ def test_subgraph_edges(edges_between_molecule, edges_between_selections,
         but the graph has metadata.
     """
     subgraph = edges_between_molecule.subgraph(edges_between_selections[selidx])
-    assert tuple(subgraph.edges) == expected
+    sorted_found = sorted(sorted(edge) for edge in subgraph.edges)
+    sorted_expected = sorted(sorted(edge) for edge in expected)
+    assert sorted_found == sorted_expected

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -175,3 +175,26 @@ def test_edges_between(edges_between_molecule, edges_between_selections,
     sorted_found = sorted(sorted(edge) for edge in found)
     sorted_expected = sorted(sorted(edge) for edge in expected)
     assert sorted_found == sorted_expected
+
+
+@pytest.mark.parametrize('selidx, expected', (
+    (0, ((0, 1), (1, 2), (1, 3))),
+    (1, ((5, 6), (5, 7), (7, 8))),
+    (2, ((9, 10), (10, 11), (11, 12))),
+    (3, ((3, 4), (4, 5), (5, 6))),
+    (4, ((7, 8), (9, 10))),
+))
+def test_subgraph_edges(edges_between_molecule, edges_between_selections,
+                        selidx, expected):
+    """
+    :meth:`vermouth.molecule.Molecule.subgraph` select the expected edges.
+
+    See Also
+    --------
+    test_subgraph_base
+        This test deals with a larger graph, but no metadata; while the graph
+        in :func:`test_subgraph_base` uses a very small and simple selection
+        but the graph has metadata.
+    """
+    subgraph = edges_between_molecule.subgraph(edges_between_selections[selidx])
+    assert tuple(subgraph.edges) == expected

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -44,7 +44,7 @@ def molecule():
 
 @pytest.fixture
 def molecule_copy(molecule):
-    return molecule.copy(as_view=False)
+    return molecule.copy()
 
 
 @pytest.fixture
@@ -52,7 +52,6 @@ def molecule_subgraph(molecule):
     return molecule.subgraph([2, 0])
 
 
-@pytest.mark.xfail(reason='issue #61')
 def test_copy(molecule, molecule_copy):
     assert molecule_copy is not molecule
     assert molecule_copy.meta == molecule.meta
@@ -93,7 +92,6 @@ def test_copy_edge_mod(molecule, molecule_copy):
     assert 'attribute' not in molecule.edges[(0, 1)]
 
 
-@pytest.mark.xfail(reason='issue #61')
 def test_copy_interactions_mod(molecule, molecule_copy):
     molecule_copy.add_interaction(
         type_='bonds',
@@ -105,23 +103,13 @@ def test_copy_interactions_mod(molecule, molecule_copy):
     n_bonds_copy = len(molecule_copy.interactions['bonds'])
     assert n_bonds_copy > n_bonds
 
-    molecule_copy.add_interaction(
-        type_='angles',
-        atoms=(0, 2, 3),
-        parameters=['5', '6'],
-        meta={'unmutable': 2},
-    )
-    assert 'angles' not in molecule.interactions
 
-
-@pytest.mark.xfail(reason='issue #60')
 def test_subgraph_base(molecule_subgraph):
     assert tuple(molecule_subgraph) == (2, 0)  # order matters!
     assert (0, 2) in molecule_subgraph.edges
     assert (0, 1) not in molecule_subgraph.edges  # node 1 is not there
 
 
-@pytest.mark.xfail(reason='issue #61')
 def test_subgraph_interactions(molecule_subgraph):
     bond_atoms = [bond.atoms for bond in molecule_subgraph.interactions['bonds']]
     assert (0, 2) in bond_atoms

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -132,3 +132,58 @@ def test_link_predicate_match():
     lp = vermouth.molecule.LinkPredicate(None)
     with pytest.raises(NotImplementedError):
         lp.match(1, 2)
+
+
+@pytest.fixture
+def edges_between_molecule():
+    """
+    Build an empty molecule with known connectivity.
+
+    The molecule does not have any node attribute nor any molecule metadata. It
+    only has a bare graph with a few nodes and edges.
+
+    The graph looks like::
+
+        0 - 1 - 3 - 4 - 5 - 7 - 8     9 - 10 - 11 - 12
+            |           |
+            2           6
+
+    """
+    molecule = vermouth.molecule.Molecule()
+    molecule.add_edges_from((
+        (0, 1), (1, 2), (1, 3), (3, 4), (4, 5), (5, 6), (5, 7), (7, 8),
+        (9, 10), (10, 11), (11, 12),
+    ))
+    return molecule
+
+
+@pytest.fixture
+def edges_between_selections():
+    """
+    Build a static list of selections of nodes from :func:`edges_between_molecule`.
+    """
+    return [
+        (0, 1, 2, 3),
+        (5, 6, 7, 8),
+        (9, 10, 11, 12),
+        (3, 4, 5, 6),
+        (7, 8, 9, 10),
+    ]
+
+
+@pytest.mark.parametrize('bunch1, bunch2, expected', (
+    (0, 1, []), (0, 2, []), (0, 4, []), (1, 2, []), (2, 3, []),  # non-overlapping
+    (0, 3, [(1, 3), (3, 4)]), (1, 3, [(4, 5), (5, 6), (5, 6), (5, 7)]),
+    (1, 4, [(5, 7), (7, 8), (7, 8)]), (2, 4, [(9, 10), (9, 10), (10, 11)]),
+))
+def test_edges_between(edges_between_molecule, edges_between_selections,
+                       bunch1, bunch2, expected):
+    """
+    Test :meth:`vermouth.molecule.Molecule.edges_between`.
+    """
+    selection_1 = edges_between_selections[bunch1]
+    selection_2 = edges_between_selections[bunch2]
+    found = edges_between_molecule.edges_between(selection_1, selection_2)
+    sorted_found = sorted(sorted(edge) for edge in found)
+    sorted_expected = sorted(sorted(edge) for edge in expected)
+    assert sorted_found == sorted_expected

--- a/vermouth/tests/test_redistributed_kdtree.py
+++ b/vermouth/tests/test_redistributed_kdtree.py
@@ -1,0 +1,68 @@
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test the modifications made to the redistributed KDTree.
+"""
+
+
+import numpy as np
+
+from scipy.spatial import cKDTree as scipyKDTree
+from vermouth.redistributed.kdtree import KDTree as redisKDTree
+
+import hypothesis
+from hypothesis import strategies as st
+import hypothesis.extra.numpy as hnp
+
+
+def dict_close(left, right):
+    """
+    Compare 2 dicts whith floats as values.
+
+    Returns `True` is all the keys are the same and the values are all close
+    according to :func:`np.allclose`.
+
+    The order of the keys is not kept.
+    """
+    if left.keys() != right.keys():
+        return False
+    keys = sorted(left)
+    values_left = np.array([left[key] for key in keys])
+    values_right = np.array([right[key] for key in keys])
+    return np.allclose(values_left, values_right)
+
+
+@hypothesis.given(
+    coordinates=hnp.arrays(
+        dtype=st.sampled_from((np.float32, np.float64)),
+        shape=st.tuples(st.integers(1, 10), st.integers(1, 10)),
+        elements=st.floats(allow_nan=False, allow_infinity=False, width=32),
+    ),
+    max_dist=st.floats(0, 5, width=32),
+    p=st.integers(1, 5),
+)
+def test_sparse_distance_matrix(coordinates, max_dist, p):
+    """
+    Test that the `sparse_distance_matrix` method returns the same thing in the
+    redistributed KDTree and on the actual scipy one.
+    """
+    original_tree = scipyKDTree(coordinates)
+    redis_tree = redisKDTree(coordinates)
+
+    original_output = original_tree.sparse_distance_matrix(original_tree, max_dist, p)
+    redis_output = redis_tree.sparse_distance_matrix(redis_tree, max_dist, p)
+
+    assert dict_close(redis_output, original_output)
+

--- a/vermouth/tests/test_redistributed_kdtree.py
+++ b/vermouth/tests/test_redistributed_kdtree.py
@@ -19,9 +19,16 @@ Test the modifications made to the redistributed KDTree.
 
 import numpy as np
 
-from scipy.spatial import cKDTree as scipyKDTree
+try:
+    from scipy.spatial import cKDTree as scipyKDTree
+except ImportError:
+    # scipy is not available
+    HAS_SCIPY = False
+else:
+    HAS_SCIPY = True
 from vermouth.redistributed.kdtree import KDTree as redisKDTree
 
+import pytest
 import hypothesis
 from hypothesis import strategies as st
 import hypothesis.extra.numpy as hnp
@@ -44,6 +51,7 @@ def dict_close(left, right):
     return np.allclose(values_left, values_right)
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason="Scipy is not available.")
 @hypothesis.given(
     coordinates=hnp.arrays(
         dtype=st.sampled_from((np.float32, np.float64)),

--- a/vermouth/tests/test_repair_graph.py
+++ b/vermouth/tests/test_repair_graph.py
@@ -129,9 +129,9 @@ def system_mod(forcefield_with_mods):
     return system
 
 
-@pytest.fixture
-def repaired_graph(system_mod):
-    vermouth.RepairGraph().run_system(system_mod)
+@pytest.fixture(params=(True, False))
+def repaired_graph(request, system_mod):
+    vermouth.RepairGraph(include_graph=request.param).run_system(system_mod)
     return system_mod
 
 


### PR DESCRIPTION
This PR introduces some minor performance optimizations to reduce the slow portion of the code that are not isomorphism related. The commit messages describe the changes detail.

The performance gain is limited because this PR also rewrites `Molecule.subgraph` and `Molecule.copy` to fix #60 and to fix #61.

On a small example, this branch reduces the run time from 10.321 seconds to 9.148 seconds; so a ~10% speed gain. On a larger example, the run time is reduced from 1m42 to 1m23; so a bit less than 20% gain.

The mapping step is the slowest in both examples and represents about half of the run time, followed by the block and link steps.

Among the non-isomorphism related slow operations, querying the adjacency matrix is surprisingly slow. We should limit as much as possible how often we look for neighbors.