### PR TITLE
Increase the fudge factor of make_bonds

### DIFF
--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -18,7 +18,6 @@ Provides a processor that can add edges to a graph based on geometric criteria.
 """
 
 
-
 import networkx as nx
 import numpy as np
 
@@ -55,7 +54,7 @@ VDW_RADII = {  # in nm
 #VALENCES = {'H': 1, 'C': 4, 'N': 3, 'O': 2, 'S': 6}
 
 
-def bonds_from_distance(system, fudge=1.1):
+def bonds_from_distance(system, fudge=1.2):
     """
     Creates edges between nodes of molecules in system based on a distance
     criterion. Nodes in system must have `position` and `element` attributes.


### PR DESCRIPTION
The fudge factor is increased from 1.1 to 1.2. This gives better results
on a few test proteins. It also aligns to tolerance with VMD. Indeed,
VMD uses `0.6 * (radiusA + radiusB)` which is the same as what we now
uses, being `0.5 * (radiusA + radiusB) * 1.2`.