### PR TITLE
Improve error message when residue is not recognozed by repair_graph

### DIFF
--- a/vermouth/processors/repair_graph.py
+++ b/vermouth/processors/repair_graph.py
@@ -306,8 +306,9 @@ class RepairGraph(Processor):
                 if not self.delete_unknown:
                     raise err
                 else:
-                    LOGGER.warning("Can't recognize molecule {}. Deleting.",
-                                   idx, type='unknown-residue')
+                    LOGGER.warning("Cannot recognize residue {} in  molecule {}. "
+                                   "Deleting the molecule.",
+                                   str(err), idx, type='unknown-residue')
             else:
                 mols.append(new_molecule)
         system.molecules = mols


### PR DESCRIPTION
The new message is more useful to understand what is missing in the input data.