### PR TITLE
Update m3

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -324,6 +324,9 @@ def entry():
     prot_group.add_argument('-nt', dest='neutral_termini',
                             action='store_true', default=False,
                             help='Set neutral termini (charged is default)')
+    prot_group.add_argument('-scfix', dest='scfix',
+                            action='store_true', default=False,
+                            help='Apply side chain corrections.')
     prot_group.add_argument('-cys', dest='cystein_bridge',
                             type=_cys_argument,
                             default='none', help='Cystein bonds')
@@ -423,6 +426,11 @@ def entry():
                         'parameters for neutral termini (-nt).'
                         .format(target_ff.name))
     vermouth.SetMoleculeMeta(neutral_termini=args.neutral_termini).run_system(system)
+    if args.scfix and not target_ff.has_feature('scfix'):
+        logging.warning('The force field "{}" does not define angle and '
+                        'torsion for the side chain corrections (-scfix).'
+                        .format(target_ff.name))
+    vermouth.SetMoleculeMeta(scfix=args.scfix).run_system(system)
 
     ss_sequence = list(itertools.chain(*(
         dssp.sequence_from_residues(molecule, 'secstruct')

--- a/vermouth/data/force_fields/martini30/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30/aminoacids.ff
@@ -51,7 +51,7 @@ CYS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.341     7500        
+  BB   SC1    1       0.341     7500        
 
 ;;; VALINE
 
@@ -67,7 +67,7 @@ VAL                1
 [constraints]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  
-   1     2    1       0.292
+  BB   SC1    1       0.292
 
 ;;; LEUCINE
 
@@ -83,7 +83,7 @@ LEU                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.363     7500    
+  BB   SC1    1       0.363     7500    
 
 ;;; ISOLEUCINE
 
@@ -99,7 +99,7 @@ ILE                1
 [constraints]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  
-   1     2    1       0.341
+  BB   SC1    1       0.341
 
 ;;; METHIONINE
 
@@ -115,7 +115,7 @@ MET                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.40     2500
+  BB   SC1    1       0.40     2500
 
 ;;; PROLINE
 
@@ -125,13 +125,27 @@ PRO                1
 
 [ atoms ]
 ;id type resnr residu atom cgnr   charge
- 1   SP1a   1     PRO     BB     1      0    
+ 1   SP2a   1     PRO     BB     1      0    
  2   SC3    1     PRO     SC1    2      0    
 
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-  1     2    1       0.333     7500
+  BB   SC1   1       0.330     7500
+
+[ moleculetype ]
+; molname       nrexcl
+HYP                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+ 1    P1   1     HYP     BB     1      0    
+ 2    P1   1     HYP     SC1    2      0    
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+  BB   SC1   1       0.300     7500
 
 ;;; ASPARAGINE
 
@@ -147,7 +161,7 @@ ASN                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.352     5000
+  BB   SC1    1       0.352     5000
 
 ;;; GLUTAMINE
 
@@ -163,7 +177,7 @@ GLN                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.40     5000     
+  BB   SC1    1       0.400    5000     
 
 ;;; ASPARTATE
 
@@ -179,7 +193,7 @@ ASP                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.352     7500
+  BB   SC1    1       0.352     7500
 
 ;;; GLUTAMATE
 
@@ -195,7 +209,7 @@ GLU                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.40     5000     
+  BB   SC1    1       0.400    5000     
 
 ;;; THREONINE
 
@@ -211,7 +225,7 @@ THR                1
 [constraints]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length 
-   1     2    1       0.286
+  BB   SC1    1       0.286
 
 ;;; SERINE
 
@@ -227,7 +241,7 @@ SER                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.287     7500
+  BB   SC1    1       0.287     7500
 
 ;;; LYSINE 
 
@@ -244,13 +258,13 @@ LYS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.347     5000      
-   2     3    1       0.280     5000  
+  BB   SC1    1       0.347     5000      
+ SC1   SC2    1       0.280     5000  
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-    1     2    3       2   180.000    25.0      
+  BB   SC1  SC2       2   180.000    25.0      
 
 ;;; ARGININE 
 
@@ -267,13 +281,13 @@ ARG                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.347     5000   
-   2     3    1       0.340     5000  
+  BB   SC1    1       0.347     5000   
+ SC1   SC2    1       0.340     5000  
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-    1     2    3       2   180.000    25.0      
+  BB   SC1  SC2       2   180.000    25.0      
 
 ;;; HISTIDINE 
 
@@ -291,24 +305,57 @@ HIS                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.336     7500 
+  BB   SC1    1       0.336     7500 
 
 [constraints]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  
-   2     3    1       0.285
-   2     4    1       0.285  
-   3     4    1       0.285
+ SC1   SC2    1       0.285
+ SC1   SC3    1       0.285  
+ SC2   SC3    1       0.285
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-    1     2    3       2   150.000   50.0  
-    1     2    4       2   150.000   50.0 
+   BB   SC1  SC2       2   150.000   50.0  
+   BB   SC1  SC3       2   150.000   50.0 
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
-   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+  BB   SC2  SC3  SC1       2    0.0    50.0     ; to prevent backflipping of ring
+
+[ moleculetype ]
+;molname       nrexcl
+HIH                1
+
+[ atoms ]
+;id type resnr residu atom cgnr   charge
+1   $prot_default_bb_type     1     HIS     BB     1      0    
+2   TC3     1     HIH     SC1    2    0    ; three side chains in triangle
+3   TN3d    1     HIH     SC2    3    0    ; configuration, mimicking
+4   TQp     1     HIH     SC3    4   +1    ; ring structure
+
+[bonds]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  force.c.
+  BB   SC1    1       0.336     7500 
+
+[constraints]
+#meta {"group": "Side chain bonds"}
+;  i     j   funct   length  
+ SC1   SC2    1       0.285
+ SC1   SC3    1       0.285  
+ SC2   SC3    1       0.285
+
+[angles]
+#meta {"group": "Side chain angles"}
+;  i     j    k     funct   angle  force.c.
+   BB   SC1  SC2       2   150.000   50.0  
+   BB   SC1  SC3       2   150.000   50.0 
+
+[dihedrals]
+;  i     j    k    l   funct   angle  force.c.
+  BB   SC2  SC3  SC1       2    0.0    50.0     ; to prevent backflipping of ring
 
 ;;; PHENYLALANINE
 
@@ -326,24 +373,24 @@ PHE                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.325     7500 	
+  BB   SC1    1       0.325     7500 	
 
 [constraints]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  
-   2     3    1       0.285
-   2     4    1       0.285
-   3     4    1       0.285
+ SC1   SC2    1       0.285
+ SC1   SC3    1       0.285
+ SC2   SC3    1       0.285
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-    1     2    3       2   150.000   50.0  
-    1     2    4       2   150.000   50.0 
+  BB   SC1  SC2        2   150.000   50.0  
+  BB   SC1  SC3        2   150.000   50.0 
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
-   1     3    4    2       2    0.0    50.0     ; to prevent backflipping of ring
+  BB   SC2  SC3  SC1       2    0.0    50.0     ; to prevent backflipping of ring
 
 ;;; TYROSINE
 
@@ -362,25 +409,26 @@ TYR                1
 [bonds]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.325    5000 	
+  BB   SC1    1       0.336    5000 	
 
 [constraints]
+#meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  
-   2     3    1       0.290
-   2     4    1       0.290
-   3     5    1       0.290
-   4     5    1       0.290
-   3     4    1       0.285
+ SC1   SC2    1       0.290
+ SC1   SC3    1       0.290
+ SC2   SC4    1       0.290
+ SC3   SC4    1       0.290
+ SC2   SC3    1       0.285
 
 [angles]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-    1     2    3       2   125.000   60.0  
-    1     2    4       2   125.000   60.0 
+   BB   SC1  SC2       2   125.000   60.0  
+   BB   SC1  SC3       2   125.000   60.0 
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.
-   5     3    2    1       2    180.0    50.0     ; to prevent backflipping of ring
+ SC4   SC2  SC3  SC1       2    180.0    50.0     ; to prevent backflipping of ring
 
 ;;; TRYPTOPHAN
 
@@ -397,31 +445,31 @@ TRP                1
 5   TC4      1     TRP     SC4    5    0       36
 6   TC4      1     TRP     SC5    6    0       36
 
-[bonds]
+[ bonds ]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  force.c.
-   1     2    1       0.315     5000 	
+  BB   SC1    1       0.315     5000 	
 
-[constraints]
+[ constraints ]
 #meta {"group": "Side chain bonds"}
 ;  i     j   funct   length  
-   2     3    1       0.285
-   3     6    1       0.494
-   5     6    1       0.295
-   2     5    1       0.494
+ SC1   SC2    1       0.285
+ SC2   SC5    1       0.494
+ SC4   SC5    1       0.285
+ SC1   SC4    1       0.494
 
-[angles]
+[ angles ]
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
-   1     2    3       2   210.000   50.0 
-   1     2    4       2   90.000    60.0  
+  BB   SC1  SC2       2   210.000   60.0 
+  BB   SC1  SC4       2   90.000    60.0  
 
-[dihedrals]
+[ dihedrals ]
 ;  i     j    k    l   funct   angle  force.c.
-   6     5    3    2       2   180.0     60.0    ; to keep plane fixed
+ SC5   SC4  SC2  SC1       2   180.0     60.0    ; to keep plane fixed
 
 [ virtual_sitesn ]
-4 6 5 3 2 -- 2
+SC3 SC5 SC4 SC2 SC1 -- 2
 
 ;;; Links
 
@@ -495,6 +543,7 @@ BB +BB 1 0.365 1250
 [ link ]
 resname $protein_resnames
 [ constraints ]
+#meta {"group": "Backbone bonds"}
 BB +BB 1 0.310 
 [ !bonds ]
 BB +BB
@@ -505,6 +554,7 @@ BB +BB {"cgsecstruct": "H|1|2|3"}
 [ link ]
 resname $protein_resnames
 [ constraints ]
+#meta {"group": "Backbone bonds"}
 BB +BB 1 0.33
 [ !bonds ]
 BB +BB
@@ -515,6 +565,7 @@ BB {"cgsecstruct": "S|C|T|E"} +BB {"cgsecstruct": "H|1|2|3"}
 [ link ]
 resname $protein_resnames
 [ constraints ]
+#meta {"group": "Backbone bonds"}
 BB +BB 1 0.3375
 [ !bonds ]
 BB +BB
@@ -537,7 +588,7 @@ resname $protein_resnames
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "E"} +BB 2 134 25 {"group": "BBB angles"}
+-BB BB +BB 2 134 25 {"group": "BBB angles"}
 [ patterns ]
 -BB BB {"cgsecstruct": "E"} +BB 
 -BB {"cgsecstruct": "E"} BB +BB 
@@ -546,7 +597,7 @@ resname $protein_resnames
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "S"} +BB 2 130 20 {"group": "BBB angles"}
+-BB BB +BB 2 130 20 {"group": "BBB angles"}
 [ patterns ]
 -BB BB {"cgsecstruct": "S"} +BB 
 -BB {"cgsecstruct": "S"} BB +BB 
@@ -555,7 +606,7 @@ resname $protein_resnames
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB {"cgsecstruct": "F"} +BB 2 119.2 150 {"group": "BBB angles"}
+-BB BB +BB 2 119.2 150 {"group": "BBB angles"}
 [ patterns ]
 -BB BB {"cgsecstruct": "F"} +BB 
 -BB {"cgsecstruct": "F"} BB +BB 
@@ -601,6 +652,7 @@ resname $protein_resnames
 -BB {"cgsecstruct": "T", "resname": "PRO|HYP"} BB +BB 
 -BB  BB +BB {"cgsecstruct": "T", "resname": "PRO|HYP"}
 
+
 [ link ]
 [ angles ]
 -BB BB +BB 2 130 20 {"group": "BBB angles"}
@@ -614,9 +666,9 @@ resname $protein_resnames
 [ angles ]
 -BB BB +BB 2 127 20 {"group": "BBB angles"}
 [ patterns ]
--BB BB {"cgsecstruct": "C"} +BB 
--BB {"cgsecstruct": "C"} BB +BB 
--BB  BB +BB {"cgsecstruct": "C"}
+-BB BB {"cgsecstruct": "C", "resname": $protein_resnames_non_pro} +BB 
+-BB {"cgsecstruct": "C", "resname": $protein_resnames_non_pro} BB +BB 
+-BB  BB +BB {"cgsecstruct": "C", "resname": $protein_resnames_non_pro}
 -BB {"cgsecstruct": null} BB {"cgsecstruct": null} +BB {"cgsecstruct": null}
 
 [ link ]

--- a/vermouth/data/force_fields/martini30/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30/aminoacids.ff
@@ -736,12 +736,20 @@ BB +++BB 1 0.970 2500
 
 ;; Protein terminii. These links should be applied last.
 [ link ]
+[ molmeta ]
+neutral_termini not(true)
+[ features ]
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qp", "charge": 1}}
 [ non-edges ]
 BB -BB
 
 [ link ]
+[ molmeta ]
+neutral_termini not(true)
+[ features ]
+neutral_termini
 [ atoms ]
 BB {"replace": {"atype": "Qn", "charge": -1}}
 [ non-edges ]

--- a/vermouth/data/force_fields/martini30/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30/aminoacids.ff
@@ -746,3 +746,11 @@ BB -BB
 BB {"replace": {"atype": "Qn", "charge": -1}}
 [ non-edges ]
 BB +BB
+
+;; Cystein bridge
+[ link ]
+resname "CYS"
+[ constraints ]
+SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
+[ features ]
+disulfide

--- a/vermouth/data/force_fields/martini30/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30/aminoacids.ff
@@ -588,24 +588,6 @@ resname $protein_resnames
 [ link ]
 resname $protein_resnames
 [ angles ]
--BB BB +BB 2 134 25 {"group": "BBB angles"}
-[ patterns ]
--BB BB {"cgsecstruct": "E"} +BB 
--BB {"cgsecstruct": "E"} BB +BB 
--BB  BB +BB {"cgsecstruct": "E"}
-
-[ link ]
-resname $protein_resnames
-[ angles ]
--BB BB +BB 2 130 20 {"group": "BBB angles"}
-[ patterns ]
--BB BB {"cgsecstruct": "S"} +BB 
--BB {"cgsecstruct": "S"} BB +BB 
--BB  BB +BB {"cgsecstruct": "S"}
-
-[ link ]
-resname $protein_resnames
-[ angles ]
 -BB BB +BB 2 119.2 150 {"group": "BBB angles"}
 [ patterns ]
 -BB BB {"cgsecstruct": "F"} +BB 
@@ -619,6 +601,16 @@ resname $protein_resnames
 -BB BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"} +BB 
 -BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"} BB +BB 
 -BB  BB +BB {"cgsecstruct": "H|1|2|3", "resname": "PRO|HYP"}
+
+
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB +BB 2 134 25 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "E"} +BB 
+-BB {"cgsecstruct": "E"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "E"}
 
 [ link ]
 [ angles ]
@@ -652,6 +644,14 @@ resname $protein_resnames
 -BB {"cgsecstruct": "T", "resname": "PRO|HYP"} BB +BB 
 -BB  BB +BB {"cgsecstruct": "T", "resname": "PRO|HYP"}
 
+[ link ]
+resname $protein_resnames
+[ angles ]
+-BB BB +BB 2 130 20 {"group": "BBB angles"}
+[ patterns ]
+-BB BB {"cgsecstruct": "S"} +BB 
+-BB {"cgsecstruct": "S"} BB +BB 
+-BB  BB +BB {"cgsecstruct": "S"}
 
 [ link ]
 [ angles ]

--- a/vermouth/data/force_fields/martini30/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30/aminoacids.ff
@@ -433,17 +433,29 @@ BB +BB 1 0.350 1250 {"group": "Backbone bonds"}
 
 [ link ]
 resname $protein_resnames
+[ features ]
+scfix
+[ molmeta ]
+scfix true
 [ dihedrals ]
 #meta {"group": "SC-BB-BB-SC scFix"}
 SC1 BB +BB +SC1 1 dihphase(SC1,BB,+BB,+SC1|.0f) 75 1
 
 [ link ]
 resname $protein_resnames
+[ features ]
+scfix
+[ molmeta ]
+scfix true
 [ angles ]
 SC1 BB +BB 10 100 15 {"group": "SC-BB-BB and BB-BB-SC scFix", "comment": "SC-BB-BB"}
 
 [ link ]
 resname $protein_resnames
+[ features ]
+scfix
+[ molmeta ]
+scfix true
 [ angles ]
 BB +BB +SC1 10 100 15 {"group": "SC-BB-BB and BB-BB-SC scFix", "comment": "BB-BB-SC"}
 

--- a/vermouth/data/force_fields/universal/modifications.ff
+++ b/vermouth/data/force_fields/universal/modifications.ff
@@ -33,3 +33,30 @@ HE1 {"element": "H", "PTM_atom": true}
 CD OE1
 CD OE2
 OE1 HE1
+
+[ modification ]
+HSD
+[ atoms ]
+ND1 {"resname": "HIS", "element": "N"}
+HD1 {"resname": "HIS", "element": "H", "PTM_atom": true}
+[ edges ]
+ND1 HD1
+
+[ modification ]
+HSE
+[ atoms ]
+NE1 {"resname": "HIS", "element": "N"}
+HE1 {"resname": "HIS", "element": "H", "PTM_atom": true}
+[ edges ]
+NE1 HE1
+
+[ modification ]
+HSP
+[ atoms ]
+NE1 {"resname": "HIS", "element": "N"}
+HE1 {"resname": "HIS", "element": "H", "PTM_atom": true}
+ND1 {"resname": "HIS", "element": "N"}
+HD1 {"resname": "HIS", "element": "H", "PTM_atom": true}
+[ edges ]
+NE1 HE1
+ND1 HD1


### PR DESCRIPTION
Update and fix the data for martini 3 so it is in sync with the open beta. Fixes #125.

Also make scFix optional via the command line. Fixes #123.

Finally, add modifications for the protonation states of histidine. See #128.