### PR TITLE
Include all the hydrogens to the martini3 mappings

### DIFF
--- a/vermouth/data/mappings/martini30/ala.charmm36.map
+++ b/vermouth/data/mappings/martini30/ala.charmm36.map
@@ -31,7 +31,11 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB    BB
+    6   HB1    !BB
+    7   HB2    !BB
+    8   HB3    !BB
     9     C    BB
    10     O    BB
 

--- a/vermouth/data/mappings/martini30/arg.charmm36.map
+++ b/vermouth/data/mappings/martini30/arg.charmm36.map
@@ -31,9 +31,16 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
+    9   HG1   !SC1
+   10   HG2   !SC1
    11    CD   SC1 
+   12   HD1   !SC1
+   13   HD2   !SC1
    14    NE   SC2
    15    HE   SC2
    16    CZ   SC2

--- a/vermouth/data/mappings/martini30/asn.charmm36.map
+++ b/vermouth/data/mappings/martini30/asn.charmm36.map
@@ -31,10 +31,10 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6   HB1   SC1
-;    7   HB2   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
     9   OD1   SC1
    10   ND2   SC1

--- a/vermouth/data/mappings/martini30/asp.charmm36.map
+++ b/vermouth/data/mappings/martini30/asp.charmm36.map
@@ -31,14 +31,14 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6   HB1   SC1
-;    7   HB2   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
     9   OD1   SC1
    10   OD2   SC1
-;   11   HD2   SC1
+   11   HD2   !SC1
    12     C    BB
    13     O    BB
 

--- a/vermouth/data/mappings/martini30/cys.charmm36.map
+++ b/vermouth/data/mappings/martini30/cys.charmm36.map
@@ -31,10 +31,14 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-    4    CB   SC1
-    7    SG   SC1
-    9     C    BB
-   10     O    BB
+    4    HA    !BB
+    5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
+    8    SG   SC1
+    9   HG1  !SC1
+   10     C    BB
+   11     O    BB
 
 [ chiral ]
   CB     CA    N    C

--- a/vermouth/data/mappings/martini30/gln.charmm36.map
+++ b/vermouth/data/mappings/martini30/gln.charmm36.map
@@ -31,17 +31,22 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-    4    CB   SC1
-    5    CG   SC1
-    6    CD   SC1 
-    7   OE1   SC1
-    8   NE2   SC1
-    9  HE21   SC1
-   10  HE22   SC1
-   11  HE11   SC1
-   12  HE12   SC1
-   13     C    BB
-   14     O    BB
+    4    HA    !BB
+    5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
+    8    CG   SC1
+    9   HG1   !SC1
+   10   HG2   !SC1
+   11    CD   SC1 
+   12   OE1   SC1
+   13   NE2   SC1
+   14  HE21   SC1
+   15  HE22   SC1
+   16  HE11   SC1
+   17  HE12   SC1
+   18     C    BB
+   19     O    BB
 
 [ chiral ]
   CB     CA    N    C

--- a/vermouth/data/mappings/martini30/glu.charmm36.map
+++ b/vermouth/data/mappings/martini30/glu.charmm36.map
@@ -31,17 +31,17 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6   HB1   SC1
-;    7   HB2   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
-;    9   HG1   SC1
-;   10   HG2   SC1
+    9   HG1   !SC1
+   10   HG2   !SC1
    11    CD   SC1
    12   OE1   SC1
    13   OE2   SC1
-;   14   HE2   SC1
+   14   HE2   !SC1
    15     C    BB
    16     O    BB
 

--- a/vermouth/data/mappings/martini30/gly.charmm36.map
+++ b/vermouth/data/mappings/martini30/gly.charmm36.map
@@ -31,5 +31,7 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4   HA1    !BB
+    5   HA2    !BB
     9     C    BB
    10     O    BB

--- a/vermouth/data/mappings/martini30/his.charmm36.map
+++ b/vermouth/data/mappings/martini30/his.charmm36.map
@@ -31,7 +31,10 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8   CD2   SC2
     9   HD2   SC2
    10    CG   SC1

--- a/vermouth/data/mappings/martini30/ile.charmm36.map
+++ b/vermouth/data/mappings/martini30/ile.charmm36.map
@@ -31,20 +31,20 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6    HB   SC1
+    6    HB   !SC1
     7   CG2   SC1
-;    8  HG21   SC1
-;    9  HG22   SC1
-;   10  HG23   SC1
+    8  HG21   !SC1
+    9  HG22   !SC1
+   10  HG23   !SC1
    11   CG1   SC1
-;   12  HG11   SC1
-;   13  HG12   SC1
+   12  HG11   !SC1
+   13  HG12   !SC1
    14    CD   SC1
-;   15   HD1   SC1
-;   16   HD2   SC1
-;   17   HD3   SC1
+   15   HD1   !SC1
+   16   HD2   !SC1
+   17   HD3   !SC1
    18     C    BB
    19     O    BB
 

--- a/vermouth/data/mappings/martini30/leu.charmm36.map
+++ b/vermouth/data/mappings/martini30/leu.charmm36.map
@@ -31,10 +31,20 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
+    9    HG   !SC1
    10   CD1   SC1
+   11  HD11   !SC1
+   12  HD12   !SC1
+   13  HD13   !SC1
    14   CD2   SC1
+   15  HD21   !SC1
+   16  HD22   !SC1
+   17  HD23   !SC1
    18     C    BB
    19     O    BB
 

--- a/vermouth/data/mappings/martini30/lys.charmm36.map
+++ b/vermouth/data/mappings/martini30/lys.charmm36.map
@@ -31,19 +31,19 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6   HB1   SC1
-;    7   HB2   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
-;    9   HG1   SC1
-;   10   HG2   SC1
+    9   HG1   !SC1
+   10   HG2   !SC1
    11    CD   SC1
-;   12   HD1   SC1
-;   13   HD2   SC1
+   12   HD1   !SC1
+   13   HD2   !SC1
    14    CE   SC2
-;   15   HE1   SC2
-;   16   HE2   SC2
+   15   HE1   !SC2
+   16   HE2   !SC2
    17    NZ   SC2
    18   HZ1   SC2
    19   HZ2   SC2

--- a/vermouth/data/mappings/martini30/met.charmm36.map
+++ b/vermouth/data/mappings/martini30/met.charmm36.map
@@ -31,18 +31,18 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6   HB1   SC1
-;    7   HB2   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
-;    9   HG1   SC1
-;   10   HG2   SC1
+    9   HG1   !SC1
+   10   HG2   !SC1
    11    SD   SC1
    12    CE   SC1
-;   13   HE1   SC1
-;   14   HE2   SC1
-;   15   HE3   SC1
+   13   HE1   !SC1
+   14   HE2   !SC1
+   15   HE3   !SC1
    16     C    BB
    17     O    BB
 

--- a/vermouth/data/mappings/martini30/phe.charmm36.map
+++ b/vermouth/data/mappings/martini30/phe.charmm36.map
@@ -31,10 +31,10 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
-;    4    HA    BB
+    4    HA    !BB
     5    CB   SC1
-;    6   HB1   SC1
-;    7   HB2   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
     9   CD1   SC1
    10   HD1   SC1

--- a/vermouth/data/mappings/martini30/pro.charmm36.map
+++ b/vermouth/data/mappings/martini30/pro.charmm36.map
@@ -30,11 +30,18 @@ charmm27 charmm36
 [ atoms ]
     1     N    BB
     2    CD   SC1
-    3    CA    BB
-    4    CB   SC1
-    5    CG   SC1
-    6     C    BB
-    7     O    BB
+    3   HD1   !SC1
+    4   HD2   !SC1
+    5    CA    BB
+    6    HA    !BB
+    7    CB   SC1
+    8   HB1   !SC1
+    9   HB2   !SC1
+   10    CG   SC1
+   11   HG1   !SC1
+   12   HG2   !SC1
+   13     C    BB
+   14     O    BB
 
 [ chiral ]
   CB     CA    N    C

--- a/vermouth/data/mappings/martini30/ser.charmm36.map
+++ b/vermouth/data/mappings/martini30/ser.charmm36.map
@@ -31,7 +31,10 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    OG   SC1
     9   HG1   SC1
    10     C    BB

--- a/vermouth/data/mappings/martini30/thr.charmm36.map
+++ b/vermouth/data/mappings/martini30/thr.charmm36.map
@@ -31,10 +31,15 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6    HB   !SC1
     7   OG1   SC1
     8   HG1   SC1
     9   CG2   SC1 
+   10  HG21   !SC1
+   11  HG22   !SC1
+   11  HG23   !SC1
    13     C    BB
    14     O    BB
 

--- a/vermouth/data/mappings/martini30/trp.charmm36.map
+++ b/vermouth/data/mappings/martini30/trp.charmm36.map
@@ -28,7 +28,10 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC2
     8    CG   SC1
     9   CD1   SC2 
    10   HD1   SC2

--- a/vermouth/data/mappings/martini30/tyr.charmm36.map
+++ b/vermouth/data/mappings/martini30/tyr.charmm36.map
@@ -28,7 +28,10 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6   HB1   !SC1
+    7   HB2   !SC1
     8    CG   SC1
     9   CD1   SC2
    10   HD1   SC2

--- a/vermouth/data/mappings/martini30/val.charmm36.map
+++ b/vermouth/data/mappings/martini30/val.charmm36.map
@@ -31,9 +31,17 @@ charmm27 charmm36
     1     N    BB
     2    HN    BB
     3    CA    BB
+    4    HA    !BB
     5    CB   SC1
+    6    HB   !SC1
     8   CG1   SC1 
+    9  HG11   !SC1
+   10  HG12   !SC1
+   11  HG13   !SC1
    12   CG2   SC1
+   13  HG21   !SC1
+   14  HG22   !SC1
+   15  HG23   !SC1
    16     C    BB
    17     O    BB
 


### PR DESCRIPTION
Do not let `martize2 -ff martini30 -v ...` shame me about the unmapped hydrogen atoms.