### PR TITLE
Add generated doctrees and coverage reports to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ test.pdb
 **.pyc
 **.bak
 
+**.lprof
+
 .eggs/**
 *.swp
 .pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ test.pdb
 .coverage
 .hypothesis
 
+htmlcov
+
 doc/build
 doc/source/api
+doc/source/.doctrees


### PR DESCRIPTION
My git changed files were cluttering up with autogenerated doc sources and html coverage reports, so add them to `.gitignore`.