### PR TITLE
Remove needless GraphMatcher subclasses

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,7 +82,7 @@ pygments_style = 'sphinx'
 
 
 nitpick_ignore = [
-#        ('py:class', 'networkx.classes.graph.Graph'),
+        ('py:class', 'networkx.algorithms.isomorphism.isomorphvf2.GraphMatcher'),
         ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -83,7 +83,7 @@ pygments_style = 'sphinx'
 
 nitpick_ignore = [
         ('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'),
-        ('py:class', 'networkx.algorithms.isomorphism.isomorphvf2.GraphMatcher'),
+        ('py:class', 'networkx.isomorphism.GraphMatcher'),
         ('py:class', 'networkx.classes.graph.Graph'),
         ]
 
@@ -187,8 +187,8 @@ autodoc_default_options = {'members': None,
 # -- Options for intersphinx extension ---------------------------------------
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-                       'python': ('https://docs.python.org/', None),
+                       'python': ('https://docs.python.org', None),
                        'networkx': ('https://networkx.github.io/documentation/latest', None),
-                       'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'numpy': ('http://docs.scipy.org/doc/numpy', None),
                        'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
                       }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,9 +82,7 @@ pygments_style = 'sphinx'
 
 
 nitpick_ignore = [
-        ('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'),
-        ('py:class', 'networkx.isomorphism.GraphMatcher'),
-        ('py:class', 'networkx.classes.graph.Graph'),
+#        ('py:class', 'networkx.classes.graph.Graph'),
         ]
 
 # -- Options for HTML output -------------------------------------------------
@@ -192,3 +190,36 @@ intersphinx_mapping = {
                        'numpy': ('http://docs.scipy.org/doc/numpy', None),
                        'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
                       }
+
+
+# Borrowed from https://github.com/sphinx-doc/sphinx/issues/5603
+# On top of that, networkx.isomorphism.GraphMatcher is not documented, so link
+# to the VF2 isomorphism module instead.
+# See https://github.com/networkx/networkx/issues/3239
+intersphinx_aliases = {
+        ('py:class', 'networkx.classes.graph.Graph'): ('py:class', 'networkx.Graph'),
+        #('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'): ('py:class', 'networkx.isomorphism.GraphMatcher'),
+        ('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'): ('py:module', 'networkx.algorithms.isomorphism.isomorphvf2'),
+        ('py:class', 'networkx.isomorphism.GraphMatcher'): ('py:module', 'networkx.algorithms.isomorphism.isomorphvf2')
+        }
+
+def add_intersphinx_aliases_to_inv(app):
+    from sphinx.ext.intersphinx import InventoryAdapter
+    inventories = InventoryAdapter(app.builder.env)
+
+    for alias, target in app.config.intersphinx_aliases.items():
+        alias_domain, alias_name = alias
+        target_domain, target_name = target
+        try:
+            found = inventories.main_inventory[target_domain][target_name]
+            try:
+                inventories.main_inventory[alias_domain][alias_name] = found
+            except KeyError:
+                continue
+        except KeyError:
+            continue
+
+
+def setup(app):
+    app.add_config_value('intersphinx_aliases', {}, 'env')
+    app.connect('builder-inited', add_intersphinx_aliases_to_inv)

--- a/vermouth/processors/canonicalize_modifications.py
+++ b/vermouth/processors/canonicalize_modifications.py
@@ -32,32 +32,22 @@ from ..utils import format_atom_string
 LOGGER = StyleAdapter(get_logger(__name__))
 
 
-class PTMGraphMatcher(nx.isomorphism.GraphMatcher):
+def ptm_node_matcher(node1, node2):
     """
-    Implements matching logic for PTMs
+    Returns True iff node1 and node2 should be considered equal. This means
+    they are both either marked as PTM_atom, or not. If they both are PTM
+    atoms, the elements need to match, and otherwise, the atomnames must
+    match.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    # G1 >= G2; G1 is the found residue; G2 the PTM reference
-    def semantic_feasibility(self, node1, node2):
-        """
-        Returns True iff node1 and node2 should be considered equal. This means
-        they are both either marked as PTM_atom, or not. If they both are PTM
-        atoms, the elements need to match, and otherwise, the atomnames must
-        match.
-        """
-        node1 = self.G1.nodes[node1]
-        node2 = self.G2.nodes[node2]
-        if node1.get('PTM_atom', False) == node2['PTM_atom']:
-            if node2['PTM_atom']:
-                # elements must match
-                return node1['element'] == node2['element']
-            else:
-                # atomnames must match
-                return node1['atomname'] == node2['atomname']
+    if node1.get('PTM_atom', False) == node2['PTM_atom']:
+        if node2['PTM_atom']:
+            # elements must match
+            return node1['element'] == node2['element']
         else:
-            return False
+            # atomnames must match
+            return node1['atomname'] == node2['atomname']
+    else:
+        return False
 
 
 def find_ptm_atoms(molecule):
@@ -139,7 +129,7 @@ def identify_ptms(residue, residue_ptms, known_ptms):
         As returned by ``find_PTM_atoms``, but only those relevant for
         ``residue``.
 
-    known_PTMs : collections.abc.Sequence[tuple[networkx.Graph, PTMGraphMatcher]]
+    known_PTMs : collections.abc.Sequence[tuple[networkx.Graph, networkx.isomorphism.GraphMatcher]]
         The nodes in the graph must have the `PTM_atom` attribute (True or
         False). It should be True for atoms that are not part of the PTM
         itself, but describe where it is attached to the molecule.
@@ -219,12 +209,12 @@ def allowed_ptms(residue, res_ptms, known_ptms):
 
     Yields
     ------
-    tuple[networkx.Graph, PTMGraphMatcher]
+    tuple[networkx.Graph, networkx.isomorphism.GraphMatcher]
         All graphs in known_ptms which are subgraphs of residue.
     """
     # TODO: filter by element count first
     for ptm in known_ptms:
-        ptm_graph_matcher = PTMGraphMatcher(residue, ptm)
+        ptm_graph_matcher = nx.isomorphism.GraphMatcher(residue, ptm, node_match=ptm_node_matcher)
         if ptm_graph_matcher.subgraph_is_isomorphic():
             yield ptm, ptm_graph_matcher
 

--- a/vermouth/processors/do_links.py
+++ b/vermouth/processors/do_links.py
@@ -24,18 +24,6 @@ from ..molecule import attributes_match
 from .processor import Processor
 
 
-class LinkGraphMatcher(nx.isomorphism.isomorphvf2.GraphMatcher):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def semantic_feasibility(self, node1_name, node2_name):
-        # TODO: implement (partial) wildcards
-        # Node2 is the link
-        node1 = self.G1.nodes[node1_name]
-        node2 = self.G2.nodes[node2_name]
-        return _atoms_match(node1, node2)
-
-
 def _atoms_match(node1, node2):
     return attributes_match(node1, node2, ignore_keys=('order', 'replace'))
 
@@ -225,7 +213,7 @@ def match_link(molecule, link):
     if not attributes_match(molecule.meta, link.molecule_meta):
         return
 
-    GM = LinkGraphMatcher(molecule, link)
+    GM = nx.isomorphism.GraphMatcher(molecule, link, node_match=_atoms_match)
 
     raw_matches = GM.subgraph_isomorphisms_iter()
     for raw_match in raw_matches:

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -158,7 +158,7 @@ def build_graph_mapping_collection(from_ff, to_ff, mappings):
     return graph_mapping_collection
 
 
-class MappingGraphMatcher(nx.isomorphism.isomorphvf2.GraphMatcher):
+class MappingGraphMatcher(nx.isomorphism.GraphMatcher):
     def __init__(self, *args, edge_match=None, node_match=None, **kwargs):
         self.edge_match = edge_match
         self.node_match = node_match

--- a/vermouth/tests/test_ptm_detection.py
+++ b/vermouth/tests/test_ptm_detection.py
@@ -185,7 +185,7 @@ def test_identify_ptms(known_ptm_graphs, atoms, edges, expected):
     molecule = make_molecule(atoms, edges)
 
     ptms = canmod.find_ptm_atoms(molecule)
-    known_ptms = [(ptm_graph, canmod.PTMGraphMatcher(molecule, ptm_graph))
+    known_ptms = [(ptm_graph, nx.isomorphism.GraphMatcher(molecule, ptm_graph, node_match=canmod.ptm_node_matcher))
                   for ptm_graph in known_ptm_graphs]
 
     found = canmod.identify_ptms(molecule, ptms, known_ptms)

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -35,12 +35,10 @@ except ImportError:
 
 
 def format_atom_string(node, atomid=None):
-    if atomid is None:
-        atomid = node['atomid']
     node = node.copy()
-    if 'atomid' in node:
-        del node['atomid']
-    return '{atomid}{chain}-{resname}{resid}:{atomname}'.format(**node, atomid=atomid)
+    if atomid is not None:
+        node['atomid'] = atomid
+    return '{atomid}{chain}-{resname}{resid}:{atomname}'.format(**node)
 
 
 def maxes(iterable, key=lambda x: x):

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -34,10 +34,9 @@ except ImportError:
     distance = _distance
 
 
-def format_atom_string(node, atomid=None):
+def format_atom_string(node, **kwargs):
     node = node.copy()
-    if atomid is not None:
-        node['atomid'] = atomid
+    node.update(kwargs)
     return '{atomid}{chain}-{resname}{resid}:{atomname}'.format(**node)
 
 

--- a/vermouth/utils.py
+++ b/vermouth/utils.py
@@ -34,8 +34,13 @@ except ImportError:
     distance = _distance
 
 
-def format_atom_string(node):
-    return '{atomid}{chain}-{resname}{resid}:{atomname}'.format(**node)
+def format_atom_string(node, atomid=None):
+    if atomid is None:
+        atomid = node['atomid']
+    node = node.copy()
+    if 'atomid' in node:
+        del node['atomid']
+    return '{atomid}{chain}-{resname}{resid}:{atomname}'.format(**node, atomid=atomid)
 
 
 def maxes(iterable, key=lambda x: x):


### PR DESCRIPTION
In addition, set up some intersphinx aliases to make links to external docs, even when they can't be found in the networkx's objects.inv.
See also:
https://github.com/sphinx-doc/sphinx/issues/5603
https://github.com/networkx/networkx/issues/3239