### PR TITLE
Remove deadline for test_maximum_common_subgraph

### DIFF
--- a/vermouth/tests/test_hypothesis_graph_utils.py
+++ b/vermouth/tests/test_hypothesis_graph_utils.py
@@ -41,7 +41,7 @@ MCS_BUILDER = graph_builder(node_data=NODE_DATA, min_nodes=0, max_nodes=MAX_NODE
                             node_keys=st.integers(max_value=MAX_NODES, min_value=0))
 
 
-@settings(max_examples=500)
+@settings(max_examples=500, deadline=None)
 @given(graph1=MCS_BUILDER, graph2=MCS_BUILDER, attrs=ATTRS)
 def test_maximum_common_subgraph(graph1, graph2, attrs):
     """


### PR DESCRIPTION
The test test_hypothesis_graph_utils/test_maximum_common_subgraph fails
on a regular basis because it is too slow, or because its timing is
inconsistent.

Hopefully, this is a temporary fix and ISMAGS will make the thing
faster.