### PR TITLE
Fix deprecation warnings

### DIFF
--- a/vermouth/tests/gmx/test_gro.py
+++ b/vermouth/tests/gmx/test_gro.py
@@ -396,7 +396,7 @@ def assert_molecule_equal(molecule, reference):
 
 
 @st.composite
-def generate_dict(draw, min_size=None):
+def generate_dict(draw, min_size=0):
     """
     Strategy to generate an arbitrary dictionary.
     """

--- a/vermouth/tests/test_ismags.py
+++ b/vermouth/tests/test_ismags.py
@@ -123,7 +123,7 @@ def test_broken_edgecase():
     invalid coupling, losing out on a permutation.
     """
     graph = nx.Graph()
-    graph.add_path(range(5))
+    nx.add_path(graph, range(5))
     graph.add_edges_from([(2, 5), (5, 6)])
 
     ismags = vermouth.ismags.ISMAGS(graph, graph)


### PR DESCRIPTION
Running the tests was causing a couple of deprecation warnings. This PR fixes them. The detail of the warnings is provided in the commit messages.