### PR TITLE
Fix failing DSSP test

### DIFF
--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -56,8 +56,9 @@ def read_dssp2(lines):
     The "C" code for loops and random coil is translated from the gap used in
     the DSSP file for an improved readability.
 
-    Only the version 2 of DSSP is supported. If the format is not recognized as
-    comming from that version of DSSP, then a :exc:`IOError` is raised.
+    Only the version 2 and 3 of DSSP is supported. If the format is not
+    recognized as comming from that version of DSSP, then a :exc:`IOError` is
+    raised.
 
     .. _`documentation of the DSSP format`: http://swift.cmbi.ru.nl/gv/dssp/DSSP_3.html
 
@@ -84,7 +85,7 @@ def read_dssp2(lines):
     # user to count lines in a file starting from 1 rather than 0.
     numbered_lines = enumerate(lines, start=1)
 
-    # The function can only read output from DSSP version 2. Hopefully, if the
+    # The function can only read output from DSSP version 2 and 3. Hopefully, if the
     # input file is not in this format, then the parser will break as it reads
     # the file; we can expect that the end of the header will not be found or
     # the secondary structure will be an unexpected character.
@@ -101,7 +102,7 @@ def read_dssp2(lines):
     if first_line and first_line.startswith('****'):
         msg = ('Based on its header, the input file could come from a '
                'pre-July 1995 version of DSSP (or the compatibility mode '
-               'of a more recent version). Only output from the version 2 '
+               'of a more recent version). Only output from the version 2 and 3'
                'of DSSP are supported.')
         raise IOError(msg)
 
@@ -155,7 +156,7 @@ def run_dssp(system, executable='dssp', savefile=None):
     'universal' force field for DSSP to recognize them.
     However, the molecules do not require the edges to be defined.
 
-    DSSP is assumed to be in version 2. The secondary structure codes are
+    DSSP is assumed to be in version 2 or 3. The secondary structure codes are
     described in :func:`read_dssp2`.
 
     If "savefile" is set to a path, then the output of DSSP is written in

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -343,8 +343,15 @@ def test_run_dssp(savefile, tmpdir):
     if savefile:
         assert path.exists()
         with open(str(path)) as genfile, open(str(DSSP_OUTPUT)) as reffile:
-            gen = '\n'.join(genfile.readlines()[6:])
-            ref = '\n'.join(reffile.readlines()[6:])
+            # DSSP 3 is outputs mostly the same thing as DSSP2, though there
+            # are some differences in non significant whitespaces, and an extra
+            # field header. We need to normalize these differences to be able
+            # to compare.
+            gen = '\n'.join([
+                line.strip().replace('            CHAIN', '')
+                for line in genfile.readlines()[6:]
+            ])
+            ref = '\n'.join([line.strip() for line in reffile.readlines()[6:]])
             assert gen == ref
     else:
         # Is the directory empty?


### PR DESCRIPTION
When running the tests with DSSP3, one test directly comparing the generated DSSP output with a reference was failing. This is due to insignificant differences between DSSP 2 and DSSP 3 to which the test was sensitive. The test now normalize the generated output so the test works equally with DSSP 2 and 3.