### PR TITLE
Fix issue where consecutive interactions would not be deleted.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -178,6 +178,7 @@ apidoc_output_dir = 'api'
 apidoc_separate_modules = True
 apidoc_excluded_paths = ['tests', 'redistributed']
 
+autodoc_inherit_docstrings = False
 autoclass_content = 'both'
 autodoc_default_options = {'members': None,
                            'undoc-members': None,

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -836,7 +836,10 @@ class Molecule(nx.Graph):
         empty after all the necessary interactions have been deleted.
         """
         for name, interactions in self.interactions.items():
-            for interaction in interactions:
+            # We *must* copy interactions (list call), otherwise you change
+            # interactions while iterating over it, causing it to miss 
+            # consecutive interactions that should be removed.
+            for interaction in list(interactions):
                 if node in interaction.atoms:
                     self.interactions[name].remove(interaction)
 

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -166,6 +166,13 @@ def test_remove_nodes_from(atoms, bonds, interactions, removed, expected):
          'bond': [vermouth.molecule.Interaction(atoms=(1, 6), meta={}, parameters={}),
                   vermouth.molecule.Interaction(atoms=(5, 4), meta={}, parameters={})]}
     ),
+    (
+        [1, 2, 3, 4],
+        [(1, 2), (2, 3), (3, 4)],
+        [('bond', (1, 2), {}), ('bond', (2, 3), {}), ('bond', (3, 4), {})],
+        2,
+        {'bond': [vermouth.molecule.Interaction(atoms=(3, 4), meta={}, parameters={})]},
+    ),
 ])
 def test_remove_node(atoms, bonds, interactions, removed, expected):
     """


### PR DESCRIPTION
Turns out we were modifying the list of interactions we were iterating over, causing all sorts of havoc.

Sem-Ver: bugfix