### PR TITLE
Improve the logic behind the MakeBonds processor. Add tests

### DIFF
--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -24,7 +24,6 @@ import numpy as np
 from .. import KDTree
 from ..molecule import Molecule
 from .processor import Processor
-from ..utils import distance
 
 # Van der Waals radii from A. Bondi, J. Phys. Chem., 68, 441-452, 1964.
 # https://doi.org/10.1021/j100785a001
@@ -78,7 +77,7 @@ def bonds_from_distance(system, fudge=1.2):
         A new graph where edges are added between nodes that are within a
         certain distance from each other. It is probably disconnected.
     """
-    system = nx.compose_all(system.molecules)
+    system = nx.disjoint_union_all(system.molecules)
     # We filter out the nodes for which we do not know the radius. Indeed, we
     # consider these nodes cannot make bonds. The filtering is done before we
     # enter the KDTree; we only provide to the KDTree the position of the nodes
@@ -88,11 +87,17 @@ def bonds_from_distance(system, fudge=1.2):
     idx_to_nodenum = {
         idx: n
         for idx, n in enumerate(
-                subn
-                for subn in system
-                if system.nodes[subn].get('element') in VDW_RADII
+            subn
+            for subn in system
+            if system.nodes[subn].get('element') in VDW_RADII
         )
     }
+
+    # We also make a set of all nodes that have gotten bonds from CONECT records
+    # (in case of PDB input). Later on we only make new bonds between pairs of
+    # atoms if at least one of those does *not* have a CONECT record. If both
+    # have CONECT records the bond between them should also have been specified.
+    has_conect = {idx for idx in system if system[idx]}
     max_dist = max(
         VDW_RADII[node.get('element')]
         for node in system.nodes.values()
@@ -107,7 +112,7 @@ def bonds_from_distance(system, fudge=1.2):
     pairs = tree.sparse_distance_matrix(tree, max_dist * fudge)
 
     for (idx1, idx2), dist in pairs.items():
-        if idx1 >= idx2:
+        if idx1 >= idx2 or (idx1 in has_conect and idx2 in has_conect):
             continue
         node_idx1 = idx_to_nodenum[idx1]
         node_idx2 = idx_to_nodenum[idx2]
@@ -124,6 +129,9 @@ def bonds_from_distance(system, fudge=1.2):
 
 class MakeBonds(Processor):
     def run_system(self, system):
+        if not system.molecules:
+            # No molecules means nothing to do.
+            return
         mols = bonds_from_distance(system)
         system.molecules = list(map(Molecule, (mols.subgraph(mol)
                                                for mol in nx.connected_components(mols))))

--- a/vermouth/tests/test_make_bonds.py
+++ b/vermouth/tests/test_make_bonds.py
@@ -1,0 +1,149 @@
+# Copyright 2019 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test the MakeBonds processor.
+"""
+
+import pytest
+from vermouth.molecule import Molecule
+from vermouth.system import System
+from vermouth.processors import MakeBonds
+
+
+@pytest.mark.parametrize('nodes, edges, expected_edges', (
+    [
+        # No molecules
+        [],
+        [],
+        []
+    ],
+    [
+        # Single molecule with single node
+        [[{'element': 'H', 'position': [0, 0, 0]}], ],
+        [[], ],
+        [{}, ],
+    ],
+    [
+        # Single molecule with two nodes that should be connected
+        [[{'element': 'H', 'position': [0, 0, 0]},
+          {'element': 'H', 'position': [0, 0, 0.12]}], ],
+        [[], ],
+        [{(0, 1): {'distance': 0.12}}, ],
+    ],
+    [
+        # Two molecule with one node each that should be connected
+        [[{'element': 'H', 'position': [0, 0, 0]}, ],
+         [{'element': 'H', 'position': [0, 0, 0.12]}], ],
+        [[], []],
+        [{(0, 1): {'distance': 0.12}}],
+    ],
+    [
+        # Single molecule with two nodes that should not be connected
+        [[{'element': 'H', 'position': [0, 0, 0]},
+          {'element': 'H', 'position': [0, 0, 0.2]}], ],
+        [[], ],
+        [{}, {}],
+    ],
+    [
+        # Two molecule with one node each that should not be connected
+        [[{'element': 'H', 'position': [0, 0, 0]}, ],
+         [{'element': 'H', 'position': [0, 0, 0.2]}], ],
+        [[], []],
+        [{}, {}],
+    ],
+    [
+        # Two molecule with one node each that should not be connected because
+        # the element is not known
+        [[{'element': 'H', 'position': [0, 0, 0]}, ],
+         [{'element': 'X', 'position': [0, 0, 0]}], ],
+        [[], []],
+        [{}, {}],
+    ],
+    [
+        # Single molecule with two nodes that should remain connected
+        [[{'element': 'H', 'position': [0, 0, 0]},
+          {'element': 'H', 'position': [0, 0, 0.2]}], ],
+        [[(0, 1, {'attr': True})], ],
+        [{(0, 1): {'attr': True}}],
+    ],
+    [
+        # Single molecule with two nodes that should remain connected
+        [[{'element': 'H', 'position': [0, 0, 0]},
+          {'element': 'H', 'position': [0, 0, 0.2]}], ],
+        [[(0, 1, {})], ],
+        [{(0, 1): {}}],
+    ],
+    [
+        # Single molecule with four nodes that should be connected
+        [[
+            {'element': 'H', 'position': [0, 0, 0]},
+            {'element': 'C', 'position': [0, 0, 0.145]},
+            {'element': 'C', 'position': [0, 0, 0.315]},
+            {'element': 'H', 'position': [0, 0, 0.460]},
+        ], ],
+        [[], ],
+        [{(0, 1): {'distance': pytest.approx(0.145)},
+          (1, 2): {'distance': pytest.approx(0.170)},
+          (2, 3): {'distance': pytest.approx(0.145)}}],
+    ],
+    [
+        # Single molecule with four nodes that should be connected
+        [[
+            {'element': 'H', 'position': [0, 0, 0]},
+            {'element': 'C', 'position': [0, 0, 0.145]},
+            {'element': 'C', 'position': [0, 0, 0.315]},
+            {'element': 'H', 'position': [0, 0, 0.460]},
+        ], ],
+        [[(1, 2, {})], ],
+        [{(0, 1): {'distance': pytest.approx(0.145)},
+          (1, 2): {},
+          (2, 3): {'distance': pytest.approx(0.145)}}],
+    ],
+    [
+        # Single molecule with four nodes that should not be connected despite
+        # being close enough
+        [[
+            {'element': 'H', 'position': [0, 0, 0]},
+            {'element': 'C', 'position': [0, 0, 0.145]},
+            {'element': 'C', 'position': [0, 0, 0.315]},
+            {'element': 'H', 'position': [0, 0, 0.460]},
+        ], ],
+        [[(0, 1, {}), (2, 3, {})], ],
+        [{(0, 1): {}},
+         {(2, 3): {}}],
+    ],
+))
+def test_make_bonds(nodes, edges, expected_edges):
+    """
+    Test to make sure that make_bonds makes the bonds it is expected to, and not
+    too many.
+    nodes is a List[List[Dict]], allowing for multiple molecules
+    edges is a List[List[Tuple[Int, Int, Dict]]], allowing for
+        multiple molecules
+    expected_edges is a List[Dict[Tuple[Int, Int], Dict]], allowing for
+        multiple molecules
+    """
+    system = System()
+    for node_set, edge_set in zip(nodes, edges):
+        mol = Molecule()
+        mol.add_nodes_from(enumerate(node_set))
+        mol.add_edges_from(edge_set)
+        system.add_molecule(mol)
+    MakeBonds().run_system(system)
+    # Make sure number of connected components is the same
+    assert len(system.molecules) == len(expected_edges)
+    # Make sure that for every molecule found, the edges are correct
+    for found_mol, ref_edges in zip(system.molecules, expected_edges):
+        assert dict(found_mol.edges) == ref_edges


### PR DESCRIPTION
This will make the make_bonds function not add bonds between nodes that already have edges, for example from CONECT records. This means that if both node1 and node2 have edges, make_bonds will not add one between node1 and node2, even if they are at the correct distance.
In addition, there's some of bug fixes that were previously hidden.

This is a start of fixing #202.