### PR TITLE
Change naming of Cterm oxygens to make DSSP happy

### DIFF
--- a/vermouth/data/force_fields/universal/modifications.ff
+++ b/vermouth/data/force_fields/universal/modifications.ff
@@ -3,26 +3,26 @@ C-ter
 [ atoms ]
 CA {"element": "C"}
 C {"element": "C"}
-O {"element": "O", "replace": {"atomname": "O1"}}
-O2 {"element": "O", "PTM_atom": true}
+O {"element": "O"}
+OXT {"element": "O", "PTM_atom": true}
 [ edges ]
 CA C
 C O
-C O2
+C OXT
 
 [ modification ]
 COOH-ter
 [ atoms ]
 CA {"element": "C"}
 C {"element": "C"}
-O {"element": "O", "replace": {"atomname": "O1"}}
-O2 {"element": "O", "PTM_atom": true}
-HO2 {"element": "H", "PTM_atom": true}
+O {"element": "O"}
+OXT {"element": "O", "PTM_atom": true}
+HO {"element": "H", "PTM_atom": true}
 [ edges ]
 CA C
 C O
-C O2
-O2 HO2
+C OXT
+OXT HO2
 
 [ modification ]
 N-ter

--- a/vermouth/data/mappings/modifications.mapping
+++ b/vermouth/data/mappings/modifications.mapping
@@ -20,8 +20,8 @@ N CA
 [ mapping ]
 CA BB
 C  BB
-O1 BB
-O2 BB
+O  BB
+OXT BB
 
 
 [modification]


### PR DESCRIPTION
DSSP requires at least one O atom in every residue, even for Cterminal atoms. So rename O1/O2 to O/OXT.
This probably caused quite a lot of issues for many people. DSSP 3 seems to trash just that residue, DSSP 2 might not work at all (molecule is not a protein). That means this is a fairly high priority hotfix.