### PR TITLE
Fix typo in the definition of disulfide bridges

### DIFF
--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -599,7 +599,7 @@ resname $protein_resnames
 [ link ]
 resname "CYS"
 [ constraints ]
-SC1 >SC1 0.24 {"comment": "Disulfide bridge"}
+SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -599,7 +599,7 @@ resname $protein_resnames
 [ link ]
 resname "CYS"
 [ constraints ]
-SC1 >SC1 0.24 {"comment": "Disulfide bridge"}
+SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -661,7 +661,7 @@ resname $protein_resnames
 [ link ]
 resname "CYS"
 [ constraints ]
-SC1 >SC1 0.24 {"comment": "Disulfide bridge"}
+SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 

--- a/vermouth/data/force_fields/martini22/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22/aminoacids.ff
@@ -835,7 +835,7 @@ BB +++BB 1 0.970 2500
 [ link ]
 resname "CYS"
 [ constraints ]
-SC1 >SC1 0.24 {"comment": "Disulfide bridge"}
+SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -876,7 +876,7 @@ BB +++BB 1 0.970 2500
 [ link ]
 resname "CYS"
 [ constraints ]
-SC1 >SC1 0.24 {"comment": "Disulfide bridge"}
+SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 


### PR DESCRIPTION
The link defining disulfide bridges in martini2 and elnedyn variants
were missing the function number in the constraint definition.