### PR TITLE
Fix consistent test failures with strategic use of assume

### DIFF
--- a/vermouth/tests/molecule_strategies.py
+++ b/vermouth/tests/molecule_strategies.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import hypothesis.strategies as st
-from hypothesis import assume
 from hypothesis_networkx import strategy as hnst
 import vermouth
 import vermouth.molecule
@@ -110,8 +109,10 @@ def random_interaction(draw, graph, natoms=None,
     """
     if natoms is None:
         natoms = draw(st.integers(min_value=1, max_value=4))
-    assume(graph)
-    atoms = tuple(draw(st.sampled_from(list(graph.nodes))) for _ in range(natoms))
+    if graph:
+        atoms = tuple(draw(st.sampled_from(list(graph.nodes))) for _ in range(natoms))
+    else:
+        atoms = []
     parameters = st.lists(elements=st.one_of(st.text(), parameter_effectors()))
     meta = draw(st.one_of(st.none(), attribute_dict()))
     if attrs:

--- a/vermouth/tests/molecule_strategies.py
+++ b/vermouth/tests/molecule_strategies.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import hypothesis.strategies as st
+from hypothesis import assume
 from hypothesis_networkx import strategy as hnst
 import vermouth
 import vermouth.molecule
@@ -109,6 +110,7 @@ def random_interaction(draw, graph, natoms=None,
     """
     if natoms is None:
         natoms = draw(st.integers(min_value=1, max_value=4))
+    assume(graph)
     atoms = tuple(draw(st.sampled_from(list(graph.nodes))) for _ in range(natoms))
     parameters = st.lists(elements=st.one_of(st.text(), parameter_effectors()))
     meta = draw(st.one_of(st.none(), attribute_dict()))

--- a/vermouth/tests/test_ismags.py
+++ b/vermouth/tests/test_ismags.py
@@ -23,7 +23,7 @@ Contains unittests for vermouth.ismags.
 from pprint import pprint
 from time import perf_counter
 
-from hypothesis import given, note, settings, event, assume
+from hypothesis import given, note, settings, event
 import hypothesis.strategies as st
 from hypothesis_networkx import graph_builder
 
@@ -256,9 +256,12 @@ def test_isomorphism_match(data):
         node_match = nx.isomorphism.categorical_node_match(attrs, [None]*len(attrs))
 
     graph = data.draw(ISO_BUILDER)
-    assume(graph)
-    nodes = data.draw(st.sets(st.sampled_from(list(graph.nodes)),
-                              max_size=len(graph)))
+
+    if graph:
+        nodes = data.draw(st.sets(st.sampled_from(list(graph.nodes)),
+                                  max_size=len(graph)))
+    else:
+        nodes = []
     subgraph = graph.subgraph(nodes)
 
     note(("Graph nodes", graph.nodes(data=True)))
@@ -370,9 +373,12 @@ def test_mcs_match(data):
         node_match = nx.isomorphism.categorical_node_match(attrs, [None]*len(attrs))
 
     graph = data.draw(MCS_BUILDER)
-    assume(graph)
-    nodes = data.draw(st.sets(st.sampled_from(list(graph.nodes)),
-                              max_size=len(graph)))
+
+    if graph:
+        nodes = data.draw(st.sets(st.sampled_from(list(graph.nodes)),
+                                  max_size=len(graph)))
+    else:
+        nodes = []
     subgraph = graph.subgraph(nodes)
 
     note(("Graph nodes", graph.nodes(data=True)))

--- a/vermouth/tests/test_ismags.py
+++ b/vermouth/tests/test_ismags.py
@@ -23,7 +23,7 @@ Contains unittests for vermouth.ismags.
 from pprint import pprint
 from time import perf_counter
 
-from hypothesis import given, note, settings, event
+from hypothesis import given, note, settings, event, assume
 import hypothesis.strategies as st
 from hypothesis_networkx import graph_builder
 
@@ -256,6 +256,7 @@ def test_isomorphism_match(data):
         node_match = nx.isomorphism.categorical_node_match(attrs, [None]*len(attrs))
 
     graph = data.draw(ISO_BUILDER)
+    assume(graph)
     nodes = data.draw(st.sets(st.sampled_from(list(graph.nodes)),
                               max_size=len(graph)))
     subgraph = graph.subgraph(nodes)
@@ -369,6 +370,7 @@ def test_mcs_match(data):
         node_match = nx.isomorphism.categorical_node_match(attrs, [None]*len(attrs))
 
     graph = data.draw(MCS_BUILDER)
+    assume(graph)
     nodes = data.draw(st.sets(st.sampled_from(list(graph.nodes)),
                               max_size=len(graph)))
     subgraph = graph.subgraph(nodes)


### PR DESCRIPTION
Since Hypothesis 5.0 st.sampled_from([]) results in an error. Avoid those error by no longer sampling from empty graphs.