### PR TITLE
Change make_bonds processor to use atom names and keep residues intact

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -94,7 +94,7 @@ def read_system(path, ignore_resnames=(), ignh=None, modelidx=None):
 
 
 def pdb_to_universal(system, delete_unknown=False, force_field=None,
-                     bonds_from_name=True, bonds_from_dist=True,
+                     bonds_from_name=True, bonds_from_dist=True, bonds_fudge=1,
                      write_graph=None, write_repair=None, write_canon=None):
     """
     Convert a system read from the PDB to a clean canonical atomistic system.
@@ -105,7 +105,8 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
     canonicalized.force_field = force_field
     LOGGER.info('Guessing the bonds.', type='step')
     vermouth.MakeBonds(allow_name=bonds_from_name,
-                       allow_dist=bonds_from_dist).run_system(canonicalized)
+                       allow_dist=bonds_from_dist,
+                       fudge=bonds_fudge).run_system(canonicalized)
     vermouth.MergeNucleicStrands().run_system(canonicalized)
     if write_graph is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True)
@@ -295,6 +296,10 @@ def entry():
                             help="How to determine connectivity in the input. "
                             "If 'none', only bonds from the input file (CONECT)"
                             " will be used.")
+    file_group.add_argument('-bonds-fudge', dest='bonds_fudge', type=float,
+                            default=1.0, help='Factor with which Van der Waals'
+                            ' radii should be scaled when determining bonds '
+                            'based on distances.')
 
     ff_group = parser.add_argument_group('Force field selection')
     ff_group.add_argument('-ff', dest='to_ff', default='martini22',
@@ -450,6 +455,7 @@ def entry():
         force_field=known_force_fields[from_ff],
         bonds_from_name=bonds_from_name,
         bonds_from_dist=bonds_from_dist,
+        bonds_fudge=args.bonds_fudge,
         write_graph=args.write_graph,
         write_repair=args.write_repair,
         write_canon=args.write_canon,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -94,6 +94,7 @@ def read_system(path, ignore_resnames=(), ignh=None, modelidx=None):
 
 
 def pdb_to_universal(system, delete_unknown=False, force_field=None,
+                     bonds_from_name=True, bonds_from_dist=True,
                      write_graph=None, write_repair=None, write_canon=None):
     """
     Convert a system read from the PDB to a clean canonical atomistic system.
@@ -103,7 +104,8 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
     canonicalized = system.copy()
     canonicalized.force_field = force_field
     LOGGER.info('Guessing the bonds.', type='step')
-    vermouth.MakeBonds().run_system(canonicalized)
+    vermouth.MakeBonds(allow_name=bonds_from_name,
+                       allow_dist=bonds_from_dist).run_system(canonicalized)
     vermouth.MergeNucleicStrands().run_system(canonicalized)
     if write_graph is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True)
@@ -287,6 +289,12 @@ def entry():
     file_group.add_argument('-model', dest='modelidx', default=None, type=int,
                             help='Which MODEL to select. Only meaningful for'
                             ' PDB files.')
+    file_group.add_argument('-bonds-from', dest='bonds_from',
+                            choices=['name', 'distance', 'none', 'both'],
+                            default='both',
+                            help="How to determine connectivity in the input. "
+                            "If 'none', only bonds from the input file (CONECT)"
+                            " will be used.")
 
     ff_group = parser.add_argument_group('Force field selection')
     ff_group.add_argument('-ff', dest='to_ff', default='martini22',
@@ -389,6 +397,9 @@ def entry():
         # since we need to be able to check whether the flag was given.
         args.modelidx = 1
 
+    bonds_from_name = args.bonds_from in ('name', 'both')
+    bonds_from_dist = args.bonds_from in ('distance', 'both')
+
     loglevels = {0: logging.INFO, 1: logging.DEBUG, 2: 5}
     LOGGER.setLevel(loglevels[args.verbosity])
 
@@ -437,6 +448,8 @@ def entry():
         system,
         delete_unknown=True,
         force_field=known_force_fields[from_ff],
+        bonds_from_name=bonds_from_name,
+        bonds_from_dist=bonds_from_dist,
         write_graph=args.write_graph,
         write_repair=args.write_repair,
         write_canon=args.write_canon,

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -70,7 +70,7 @@ def _residue_key_func(node):
 
 def _collect_residues(graph):
     """
-    Creates groups of indices per residue. 
+    Creates groups of indices per residue.
     Returns a dict of {<key>: set(indices)}. <key> comes from _residue_key_func.
     """
     residues = defaultdict(set)
@@ -121,7 +121,8 @@ def _bonds_from_distance(graph, nodes=None, non_edges=None, fudge=1.0):
         for node in idx_to_nodenum
     ], dtype=float)
 
-    if len(positions):
+    # Pylint ignore because positions is a numpy array.
+    if len(positions):  # pylint: disable=len-as-condition
         positions = np.atleast_2d(positions)
         tree = KDTree(positions)
         pairs = tree.sparse_distance_matrix(tree, max_dist * fudge)

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -297,9 +297,10 @@ def make_bonds(system, allow_name=True, allow_dist=True, fudge=1.0):
 
 
 class MakeBonds(Processor):
-    def __init__(self, allow_name=True, allow_dist=True):
+    def __init__(self, allow_name=True, allow_dist=True, fudge=1):
         self.allow_name = allow_name
         self.allow_dist = allow_dist
+        self.fudge = fudge
 
     def run_system(self, system):
         if not system.molecules:
@@ -307,7 +308,8 @@ class MakeBonds(Processor):
             return
         mols = make_bonds(system,
                           allow_name=self.allow_name,
-                          allow_dist=self.allow_dist)
+                          allow_dist=self.allow_dist,
+                          fudge=self.fudge)
         system.molecules = mols
         # Restore the force field in each molecule. Setting the force field
         # at the system level propagates it to all the molecules.

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -17,13 +17,19 @@
 Provides a processor that can add edges to a graph based on geometric criteria.
 """
 
-
+from collections import defaultdict
 import networkx as nx
 import numpy as np
 
 from .. import KDTree
 from ..molecule import Molecule
 from .processor import Processor
+from ..utils import format_atom_string
+
+from ..log_helpers import StyleAdapter, get_logger
+
+LOGGER = StyleAdapter(get_logger(__name__))
+
 
 # Van der Waals radii from A. Bondi, J. Phys. Chem., 68, 441-452, 1964.
 # https://doi.org/10.1021/j100785a001
@@ -53,31 +59,47 @@ VDW_RADII = {  # in nm
 #VALENCES = {'H': 1, 'C': 4, 'N': 3, 'O': 2, 'S': 6}
 
 
-def bonds_from_distance(system, fudge=1.2):
+def _residue_key_func(node):
     """
-    Creates edges between nodes of molecules in system based on a distance
-    criterion. Nodes in system must have `position` and `element` attributes.
-    The possible distance between nodes is determined by values in
-    `VDW_RADII`.
+    Creates a residue "key" for a node. Keys should be identical only for nodes
+    that are part of the same residue.
+    """
+    attrs = 'mol_idx', 'chain', 'resid', 'resname'
+    return tuple(node.get(attr) for attr in attrs)
 
-    Notes
-    -----
-    Elements that are not in `VDW_RADII` do not make bonds.
+
+def _collect_residues(graph):
+    """
+    Creates groups of indices per residue. 
+    Returns a dict of {<key>: set(indices)}. <key> comes from _residue_key_func.
+    """
+    residues = defaultdict(set)
+    for node_idx in graph:
+        key = _residue_key_func(graph.nodes[node_idx])
+        residues[key].add(node_idx)
+    return dict(residues)
+
+
+def _bonds_from_distance(graph, nodes=None, non_edges=None, fudge=1.0):
+    """Add edges to `graph` between `nodes` based on distance.
+
+    Adds edges to `graph` between nodes in `nodes`, but will never add an edge
+    that is in `non_edges`. Edges are added based on a simple distance
+    criterion. The criterion can be adjusted using `fudge`. Nodes need to have
+    an element attribute that is in VDW_RADII in order to be eligible.
 
     Parameters
     ----------
-    system: :class:`~vermouth.system.System`
-        The system in which to add edges.
-    fudge: :class:`~numbers.Number`
-        Increase the allowed distance by this factor.
-
-    Returns
-    -------
-    :class:`networkx.Graph`
-        A new graph where edges are added between nodes that are within a
-        certain distance from each other. It is probably disconnected.
+    graph: networkx.Graph
+    nodes: collections.abc.Collection[collections.abc.Hashable]
+    non_edges: collections.abc.Container[frozenset[collections.abc.Hashable, collections.abc.Hashable]]
+    fudge: float
     """
-    system = nx.disjoint_union_all(system.molecules)
+    if not nodes:
+        nodes = graph.nodes
+    if not non_edges:
+        non_edges = set()
+
     # We filter out the nodes for which we do not know the radius. Indeed, we
     # consider these nodes cannot make bonds. The filtering is done before we
     # enter the KDTree; we only provide to the KDTree the position of the nodes
@@ -88,43 +110,178 @@ def bonds_from_distance(system, fudge=1.2):
         idx: n
         for idx, n in enumerate(
             subn
-            for subn in system
-            if system.nodes[subn].get('element') in VDW_RADII
+            for subn in graph
+            if subn in nodes and graph.nodes[subn].get('element') in VDW_RADII
         )
     }
+    max_dist = max(VDW_RADII.values()) * fudge
 
-    # We also make a set of all nodes that have gotten bonds from CONECT records
-    # (in case of PDB input). Later on we only make new bonds between pairs of
-    # atoms if at least one of those does *not* have a CONECT record. If both
-    # have CONECT records the bond between them should also have been specified.
-    has_conect = {idx for idx in system if system[idx]}
-    max_dist = max(
-        VDW_RADII[node.get('element')]
-        for node in system.nodes.values()
-        if node.get('element') in VDW_RADII
-    )
     positions = np.array([
-        node['position']
-        for node in system.nodes.values()
-        if node.get('element') in VDW_RADII
+        graph.nodes[node]['position']
+        for node in idx_to_nodenum
     ], dtype=float)
-    tree = KDTree(positions)
-    pairs = tree.sparse_distance_matrix(tree, max_dist * fudge)
+
+    if len(positions):
+        positions = np.atleast_2d(positions)
+        tree = KDTree(positions)
+        pairs = tree.sparse_distance_matrix(tree, max_dist * fudge)
+    else:
+        pairs = {}
 
     for (idx1, idx2), dist in pairs.items():
-        if idx1 >= idx2 or (idx1 in has_conect and idx2 in has_conect):
+        if idx1 >= idx2:
             continue
         node_idx1 = idx_to_nodenum[idx1]
         node_idx2 = idx_to_nodenum[idx2]
-        atom1 = system.nodes[node_idx1]
-        atom2 = system.nodes[node_idx2]
+        atom1 = graph.nodes[node_idx1]
+        atom2 = graph.nodes[node_idx2]
         element1 = atom1['element']
         element2 = atom2['element']
 
+        if frozenset((node_idx1, node_idx2)) in non_edges:
+            continue
+
         bond_distance = 0.5 * (VDW_RADII[element1] + VDW_RADII[element2])
-        if dist <= bond_distance * fudge:
-            system.add_edge(node_idx1, node_idx2, distance=dist)
-    return system
+        if dist <= bond_distance * fudge and not graph.has_edge(node_idx1, node_idx2):
+            LOGGER.debug("Guessed bond between {} and {} based on distance.",
+                         format_atom_string(atom1),
+                         format_atom_string(atom2))
+
+            graph.add_edge(node_idx1, node_idx2, distance=dist)
+
+
+def _bonds_from_names(graph, resname, nodes, force_field):
+    """Add edges between `nodes` in `graph` based on atom names.
+
+    Adds edges to `graph`, assuming the nodes in `nodes` constitute a residue
+    with residue name `resname`, which can be found among the `force_field`
+    blocks. Edges will be added as they are in the reference Block. In addition,
+    all non-edges in the Block will be generated and returned.
+
+    Parameters
+    ----------
+    graph: networkx.Graph
+    resname: str
+    nodes: collections.abc.Iterable[collections.abc.Hashable]
+        Should be node keys in `graph`
+    force_field: vermouth.forcefield.ForceField
+        Force field in which to look for the block with name `resname`
+
+    Raises
+    ------
+    KeyError
+        If `resname` is not one of the blocks known to `force_field`; or when
+        a residue contains duplicate atom names.
+
+    Returns
+    -------
+    Set[Frozenset[collections.abc.Hashable, collections.abc.Hashable]]
+        All non-edges found in the block, with node keys from `graph`.
+    """
+    block = force_field.blocks.get(resname)
+    if not block:
+        raise KeyError("Residue {} is not known to force field {}"
+                       "".format(resname, force_field.name))
+
+    name_to_idx = defaultdict(set)
+    for idx in nodes:
+        if 'atomname' in graph.nodes[idx]:
+            name_to_idx[graph.nodes[idx]['atomname']].add(idx)
+    name_to_idx = dict(name_to_idx)
+    for name, idxs in name_to_idx.items():
+        if len(idxs) > 1:
+            raise KeyError("Residue has multiple atoms with atom name {}"
+                           "".format(name))
+        name_to_idx[name] = name_to_idx[name].pop()
+
+    for idx, jdx in block.edges:
+        idx_name = block.nodes[idx]['atomname']
+        jdx_name = block.nodes[jdx]['atomname']
+        if idx_name in name_to_idx and jdx_name in name_to_idx:
+            graph.add_edge(name_to_idx[idx_name], name_to_idx[jdx_name])
+
+    non_edges = set()
+    for idx, jdx in nx.non_edges(block):
+        idx_name = block.nodes[idx]['atomname']
+        jdx_name = block.nodes[jdx]['atomname']
+        if idx_name in name_to_idx and jdx_name in name_to_idx:
+            non_edges.add(frozenset((name_to_idx[idx_name], name_to_idx[jdx_name])))
+    return non_edges
+
+
+def make_bonds(system, fudge=1.0):
+    """Creates bonds within molecules in the system.
+
+    First, edges will be created based on residue and atom names. Second, edges
+    will be created based on a distance criterion. Nodes in system must have
+    `position` and `element` attributes. The possible distance between nodes is
+    determined by values in `VDW_RADII`. Edges within residues will only be
+    guessed between atoms that are not known in the reference Block.
+    The system will be split into connected components, keeping residues
+    (identified by chain, residue name and residue id) within the same molecule.
+    This does mean that the final molecules can be disconnected.
+
+    Notes
+    -----
+    Edges for residues for which no block can be found will be added based on
+        the distance criterion. A warning will be issued if this is the case.
+    Elements that are not in `VDW_RADII` do not make bonds based on distances.
+
+    Parameters
+    ----------
+    system: :class:`~vermouth.system.System`
+        The system in which to add edges.
+    fudge: :class:`~numbers.Number`
+        Scale the allowed distance by this factor.
+
+    Returns
+    -------
+    List[:class:`~vermouth.molecule.Molecule`]
+        Molecules in system, in which edges have been added based on atom names
+        and possibly distance. The molecules have been split into connected
+        components keeping residues intact. Molecules can be disconnected within
+        residues.
+    """
+    force_field = system.force_field
+
+    # Separate molecules should remain separate molecules, even if they have
+    # poorly chosen chain/resname/resid combinations. So add a mol_idx attribute
+    for mol_idx, molecule in enumerate(system.molecules):
+        nx.set_node_attributes(molecule, mol_idx, 'mol_idx')
+
+    system = nx.disjoint_union_all(system.molecules)
+    non_edges = set()
+
+    residue_groups = _collect_residues(system)
+
+    for ((mol_idx, chain, resid, resname), idxs) in residue_groups.items():
+        try:
+            # Try adding bonds within the residue based on atom names
+            non_edges.update(_bonds_from_names(system, resname, idxs, force_field))
+        except KeyError as error:
+            # ... if that doesn't work, fall back to distance
+            LOGGER.warning("Can't add bonds based on atom names for residue "
+                           "{}-{}{} because {}. Falling back to distance "
+                           "criteria.",
+                           chain, resname, resid, error, force_field.name)
+            _bonds_from_distance(system, idxs, fudge=fudge)
+    # And finally, add edges based on distance, but ignore any edges that would
+    # otherwise have been added by name. So only edges between residues will be
+    # added, and edges involving atoms which are not known to the blocks (PTMs,
+    # termini, ...)
+    _bonds_from_distance(system, non_edges=non_edges, fudge=fudge)
+
+    # Split the system into connected components. We do want to keep residues
+    # together, so make a residue graph (1 node per residue) first, and use that
+    # to find the connected components.
+    residue_graph = nx.quotient_graph(system, residue_groups.values())
+    molecules = []
+    for mol_idxs in nx.connected_components(residue_graph):
+        mol_idxs = set().union(*mol_idxs)
+        mol = Molecule(system.subgraph(mol_idxs))
+        molecules.append(mol)
+
+    return molecules
 
 
 class MakeBonds(Processor):
@@ -132,9 +289,9 @@ class MakeBonds(Processor):
         if not system.molecules:
             # No molecules means nothing to do.
             return
-        mols = bonds_from_distance(system)
-        system.molecules = list(map(Molecule, (mols.subgraph(mol)
-                                               for mol in nx.connected_components(mols))))
+        mols = make_bonds(system)
+        system.molecules = mols
         # Restore the force field in each molecule. Setting the force field
         # at the system level propagates it to all the molecules.
         system.force_field = system.force_field
+        LOGGER.info('{} molecules after guessing bonds', len(system.molecules))

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -225,6 +225,7 @@ def make_bonds(system, fudge=1.0):
     -----
     Edges for residues for which no block can be found will be added based on
         the distance criterion. A warning will be issued if this is the case.
+
     Elements that are not in `VDW_RADII` do not make bonds based on distances.
 
     Parameters

--- a/vermouth/tests/test_make_bonds.py
+++ b/vermouth/tests/test_make_bonds.py
@@ -114,12 +114,51 @@ from vermouth.processors import MakeBonds
     ],
     [
         # Single molecule with four nodes that should not be connected despite
-        # being close enough
+        # being close enough because they're not connected in the block
+        [[
+            {'atomname': 'H1', 'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0]},
+            {'atomname': 'C', 'element': 'C', 'resname': 'GLY', 'position': [0, 0, 0.145]},
+            {'atomname': 'N', 'element': 'N', 'resname': 'GLY', 'position': [0, 0, 0.315]},
+            {'atomname': 'H2', 'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0.460]},
+        ], ],
+        [[(0, 1, {}), (2, 3, {})], ],
+        [{(0, 1): {},
+          (2, 3): {}}],
+    ],
+    [
+        # Single molecule with four nodes that should be connected despite
+        # being far away because they're connected in the block
+        [[
+            {'atomname': 'H1', 'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0]},
+            {'atomname': 'C', 'element': 'C', 'resname': 'GLY', 'position': [0, 0, 0.145]},
+            {'atomname': 'CA', 'element': 'C', 'resname': 'GLY', 'position': [0, 0, 1.315]},
+            {'atomname': 'H2', 'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0.460]},
+        ], ],
+        [[(0, 1, {}), (2, 3, {})], ],
+        [{(0, 1): {},
+          (1, 2): {'distance': pytest.approx(1.17)},
+          (2, 3): {}}],
+    ],
+    [
+        # Single molecule with four nodes that have a resname, but not atomnames
         [[
             {'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0]},
             {'element': 'C', 'resname': 'GLY', 'position': [0, 0, 0.145]},
             {'element': 'N', 'resname': 'GLY', 'position': [0, 0, 0.315]},
             {'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0.460]},
+        ], ],
+        [[(0, 1, {}), (2, 3, {})], ],
+        [{(0, 1): {},
+          (2, 3): {}}],
+    ],
+    [
+        # Single molecule with four nodes that have a resname and duplicate
+        # atomnames
+        [[
+            {'atomname': 'H', 'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0]},
+            {'atomname': 'C', 'element': 'C', 'resname': 'GLY', 'position': [0, 0, 0.145]},
+            {'atomname': 'N', 'element': 'N', 'resname': 'GLY', 'position': [0, 0, 0.315]},
+            {'atomname': 'H', 'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0.460]},
         ], ],
         [[(0, 1, {}), (2, 3, {})], ],
         [{(0, 1): {},

--- a/vermouth/tests/test_make_bonds.py
+++ b/vermouth/tests/test_make_bonds.py
@@ -17,6 +17,7 @@ Test the MakeBonds processor.
 """
 
 import pytest
+from vermouth.forcefield import get_native_force_field
 from vermouth.molecule import Molecule
 from vermouth.system import System
 from vermouth.processors import MakeBonds
@@ -54,7 +55,7 @@ from vermouth.processors import MakeBonds
         [[{'element': 'H', 'position': [0, 0, 0]},
           {'element': 'H', 'position': [0, 0, 0.2]}], ],
         [[], ],
-        [{}, {}],
+        [{}],
     ],
     [
         # Two molecule with one node each that should not be connected
@@ -115,14 +116,14 @@ from vermouth.processors import MakeBonds
         # Single molecule with four nodes that should not be connected despite
         # being close enough
         [[
-            {'element': 'H', 'position': [0, 0, 0]},
-            {'element': 'C', 'position': [0, 0, 0.145]},
-            {'element': 'C', 'position': [0, 0, 0.315]},
-            {'element': 'H', 'position': [0, 0, 0.460]},
+            {'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0]},
+            {'element': 'C', 'resname': 'GLY', 'position': [0, 0, 0.145]},
+            {'element': 'N', 'resname': 'GLY', 'position': [0, 0, 0.315]},
+            {'element': 'H', 'resname': 'GLY', 'position': [0, 0, 0.460]},
         ], ],
         [[(0, 1, {}), (2, 3, {})], ],
-        [{(0, 1): {}},
-         {(2, 3): {}}],
+        [{(0, 1): {},
+          (2, 3): {}}],
     ],
 ))
 def test_make_bonds(nodes, edges, expected_edges):
@@ -135,7 +136,7 @@ def test_make_bonds(nodes, edges, expected_edges):
     expected_edges is a List[Dict[Tuple[Int, Int], Dict]], allowing for
         multiple molecules
     """
-    system = System()
+    system = System(force_field=get_native_force_field('universal'))
     for node_set, edge_set in zip(nodes, edges):
         mol = Molecule()
         mol.add_nodes_from(enumerate(node_set))


### PR DESCRIPTION
Make Bonds will now first use atom names to guess bonds within residues. Secondly, distances will be used to add the edges between residues, and involving atoms that are not known to the reference Blocks. 
Make bonds now splits the system in connected components less aggressively: residues are kept together in the same molecule. Tests adapted to reflect this change.

The underlying idea is that the priority of information is CONECT > atom names > distance; and the user should be able to toggle the use of atom names and distance using the CLI (implementation pending). The fallback/nuclear option for the user is then to create a PDB with all CONECT records (make by e.g. -write-graph, and then curated).