### PR TITLE
Add the notion of domains in the elastic network

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -43,6 +43,7 @@ from vermouth.map_input import (
     generate_all_self_mappings,
     combine_mappings
 )
+from vermouth.processors.apply_rubber_band import always_true, same_chain
 
 # TODO Since vermouth's __init__.py does some logging (KDTree), this may or may
 # not work as intended. Investigation required.
@@ -366,6 +367,11 @@ def entry():
     rb_group.add_argument('-eb', dest='rb_selection',
                           type=lambda x: x.split(','), default=None,
                           help='Comma separated list of bead names for elastic bonds')
+    rb_group.add_argument('-eunit', dest='rb_unit', default='molecule',
+                          choices=['chain', 'molecule', 'all'],
+                          help=('Establish what is the structural unit for the '
+                                'elastic network. Bonds are only created within'
+                                'a unit.'))
 
     go_group = parser.add_argument_group('Virtual site based GoMartini')
     go_group.add_argument('-govs-includes', action='store_true', default=False,
@@ -427,7 +433,7 @@ def entry():
                                    'CanonicalizeModifications step. The '
                                    'resulting file may contain "nan" '
                                    'coordinates making it unreadable by most '
-                                   'softwares.'))
+                                   'software.'))
     debug_group.add_argument('-v', dest='verbosity', action='count',
                              help='Enable debug logging output. Can be given '
                                   'multiple times.', default=0)
@@ -585,27 +591,9 @@ def entry():
         delete_unknown=True,
     )
 
-    # Apply a rubber band elastic network is required.
-    if args.elastic:
-        LOGGER.info('Setting the rubber bands.', type='step')
-        if args.rb_selection is not None:
-            selector = functools.partial(
-                selectors.proto_select_attribute_in,
-                attribute='atomname',
-                values=args.rb_selection,
-            )
-        else:
-            selector = selectors.select_backbone
-        rubber_band_processor = vermouth.ApplyRubberBand(
-            lower_bound=args.rb_lower_bound,
-            upper_bound=args.rb_upper_bound,
-            decay_factor=args.rb_decay_factor,
-            decay_power=args.rb_decay_power,
-            base_constant=args.rb_force_constant,
-            minimum_force=args.rb_minimum_force,
-            selector=selector,
-        )
-        rubber_band_processor.run_system(system)
+    if args.neutral_termini:
+        LOGGER.info('Making termini neutral.', type='step')
+        vermouth.NeutralTermini(force_field=known_force_fields[args.to_ff]).run_system(system)
 
     # Apply position restraints if required.
     if args.posres != 'none':
@@ -638,6 +626,40 @@ def entry():
                 vermouth.MergeChains(chain_set).run_system(system)
         vermouth.NameMolType(deduplicate=not args.keep_duplicate_itp).run_system(system)
         defines = ()
+
+    # Apply a rubber band elastic network is required.
+    if args.elastic:
+        LOGGER.info('Setting the rubber bands.', type='step')
+        if args.rb_unit == 'molecule':
+            domain_criterion = always_true
+        elif args.rb_unit == 'all':
+            vermouth.MergeAllMolecules().run_system(system)
+            domain_criterion = always_true
+        elif args.rb_unit == 'chain':
+            domain_criterion = same_chain
+        else:
+            message = 'Unknown value for -eunit: "{}".'.format(args.rb_unit)
+            LOGGER.critical(message)
+            raise ValueError(message)
+        if args.rb_selection is not None:
+            selector = functools.partial(
+                selectors.proto_select_attribute_in,
+                attribute='atomname',
+                values=args.rb_selection,
+            )
+        else:
+            selector = selectors.select_backbone
+        rubber_band_processor = vermouth.ApplyRubberBand(
+            lower_bound=args.rb_lower_bound,
+            upper_bound=args.rb_upper_bound,
+            decay_factor=args.rb_decay_factor,
+            decay_power=args.rb_decay_power,
+            base_constant=args.rb_force_constant,
+            minimum_force=args.rb_minimum_force,
+            selector=selector,
+            domain_criterion=domain_criterion,
+        )
+        rubber_band_processor.run_system(system)
 
     LOGGER.info('Writing output.', type='step')
     for molecule in system.molecules:

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -358,7 +358,9 @@ def entry():
     rb_group.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9,
                           help='Elastic bond upper cutoff: F = 0  if rij > up')
     rb_group.add_argument('-ermd', dest='res_min_dist', type=int,
-                          help='the minimum seperation between to residues to have an RB')
+                          help=('the minimum separation between two residues to have an RB'
+                                'the default value is set by the force-field.'),
+                          default=None)
     rb_group.add_argument('-ea', dest='rb_decay_factor', type=float, default=0,
                           help='Elastic bond decay factor a')
     rb_group.add_argument('-ep', dest='rb_decay_power', type=float, default=0,
@@ -372,7 +374,7 @@ def entry():
                           choices=['chain', 'molecule', 'all'],
                           help=('Establish what is the structural unit for the '
                                 'elastic network. Bonds are only created within'
-                                'a unit.'))
+                                ' a unit.'))
 
     go_group = parser.add_argument_group('Virtual site based GoMartini')
     go_group.add_argument('-govs-includes', action='store_true', default=False,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -43,7 +43,6 @@ from vermouth.map_input import (
     generate_all_self_mappings,
     combine_mappings
 )
-from vermouth.processors.apply_rubber_band import always_true, same_chain
 
 # TODO Since vermouth's __init__.py does some logging (KDTree), this may or may
 # not work as intended. Investigation required.
@@ -631,12 +630,12 @@ def entry():
     if args.elastic:
         LOGGER.info('Setting the rubber bands.', type='step')
         if args.rb_unit == 'molecule':
-            domain_criterion = always_true
+            domain_criterion = vermouth.processors.apply_rubber_band.always_true
         elif args.rb_unit == 'all':
             vermouth.MergeAllMolecules().run_system(system)
-            domain_criterion = always_true
+            domain_criterion = vermouth.processors.apply_rubber_band.always_true
         elif args.rb_unit == 'chain':
-            domain_criterion = same_chain
+            domain_criterion = vermouth.processors.apply_rubber_band.same_chain
         else:
             message = 'Unknown value for -eunit: "{}".'.format(args.rb_unit)
             LOGGER.critical(message)

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -358,7 +358,7 @@ def entry():
     rb_group.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9,
                           help='Elastic bond upper cutoff: F = 0  if rij > up')
     rb_group.add_argument('-ermd', dest='res_min_dist', type=int,
-                          help=('the minimum separation between two residues to have an RB'
+                          help=('The minimum separation between two residues to have an RB '
                                 'the default value is set by the force-field.'),
                           default=None)
     rb_group.add_argument('-ea', dest='rb_decay_factor', type=float, default=0,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -357,6 +357,8 @@ def entry():
                           help='Elastic bond lower cutoff: F = Fc if rij < lo')
     rb_group.add_argument('-eu', dest='rb_upper_bound', type=float, default=0.9,
                           help='Elastic bond upper cutoff: F = 0  if rij > up')
+    rb_group.add_argument('-ermd', dest='res_min_dist', type=int,
+                          help='the minimum seperation between to residues to have an RB')
     rb_group.add_argument('-ea', dest='rb_decay_factor', type=float, default=0,
                           help='Elastic bond decay factor a')
     rb_group.add_argument('-ep', dest='rb_decay_power', type=float, default=0,
@@ -657,6 +659,7 @@ def entry():
             minimum_force=args.rb_minimum_force,
             selector=selector,
             domain_criterion=domain_criterion,
+            res_min_dist=args.res_min_dist
         )
         rubber_band_processor.run_system(system)
 

--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -18,6 +18,7 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 
 [ variables ]
 elastic_network_bond_type 1
+res_min_dist 1
 
 ;;; GLYCINE
 

--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -18,7 +18,7 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 
 [ variables ]
 elastic_network_bond_type 1
-res_min_dist 1
+res_min_dist 2
 
 ;;; GLYCINE
 

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -18,6 +18,7 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 
 [ variables ]
 elastic_network_bond_type 1
+res_min_dist 1
 
 ;;; GLYCINE
 

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -18,7 +18,7 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 
 [ variables ]
 elastic_network_bond_type 1
-res_min_dist 1
+res_min_dist 2
 
 ;;; GLYCINE
 

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -18,6 +18,7 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 
 [ variables ]
 elastic_network_bond_type 1
+res_min_dist 1
 
 ;;; GLYCINE
 

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -18,7 +18,7 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 
 [ variables ]
 elastic_network_bond_type 1
-res_min_dist 1
+res_min_dist 2
 
 ;;; GLYCINE
 

--- a/vermouth/data/force_fields/martini22/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22/aminoacids.ff
@@ -16,6 +16,10 @@
 protein_resnames "GLY|ALA|CYS|VAL|LEU|ILE|MET|PRO|HYP|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
 protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
 
+[ variables ]
+elastic_network_bond_type 6
+res_min_dist 3
+
 ;;; GLYCINE
 
 [ moleculetype ]

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -2,6 +2,10 @@
 protein_resnames "GLY|ALA|CYS|VAL|LEU|ILE|MET|PRO|HYP|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
 protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
 
+[ variables ]
+elastic_network_bond_type 6
+res_min_dist 3
+
 ;;; GLYCINE
 
 [ moleculetype ]

--- a/vermouth/data/force_fields/martini30b32/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30b32/aminoacids.ff
@@ -17,6 +17,10 @@ protein_resnames "GLY|ALA|CYS|VAL|LEU|ILE|MET|PRO|HYP|ASN|GLN|ASP|ASP0|GLU|GLU0|
 protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|THR|SER|LYS|LYS0|ARG|ARG0|HIS|HISH|PHE|TYR|TRP"
 prot_default_bb_type P2
 
+[ variables ]
+elastic_network_bond_type 6
+res_min_dist 3
+
 ;;; GLYCINE
 
 [ moleculetype ]

--- a/vermouth/data/force_fields/martini30dev/aminoacids.ff
+++ b/vermouth/data/force_fields/martini30dev/aminoacids.ff
@@ -18,6 +18,10 @@ protein_resnames_non_pro "GLY|ALA|CYS|VAL|LEU|ILE|MET|ASN|GLN|ASP|ASP0|GLU|GLU0|
 prot_default_bb_type P2
 stiff_fc 1000000
 
+[ variables ]
+elastic_network_bond_type 6
+res_min_dist 3
+
 ;;; GLYCINE
 
 [ moleculetype ]

--- a/vermouth/graph_utils.py
+++ b/vermouth/graph_utils.py
@@ -129,16 +129,19 @@ def rate_match(residue, bead, match):
                for rdx, bdx in match.items())
 
 
-def _items_with_common_values(graph, nodes=None):
+def _items_with_common_values(graph, nodes=None, excluded_keys=[]):
     """
     Finds all node attributes of nodes in graph that all have the same values.
-    Returns a dict of node attribute/common value pairs
+    Returns a dict of node attribute/common value pairs. One can exclude specifc
+    keys using the exclude variable.
 
     Parameters
     ----------
     graph: networkx.Graph
     nodes: collections.abc.Iterable or None
         If None, consider all nodes. All nodes must be in graph.
+    exclude:  collections.abc.Iterable
+        keys to exclude from the common value list
 
     Returns
     -------
@@ -150,7 +153,8 @@ def _items_with_common_values(graph, nodes=None):
     common_attrs = defaultdict(list)
     for idx in nodes:
         for key, val in graph.nodes[idx].items():
-            common_attrs[key].append(val)
+            if key not in excluded_keys:
+                common_attrs[key].append(val)
     common_attrs = {key: vals[0] for key, vals in common_attrs.items()
                     if len(vals) == len(nodes) and are_all_equal(vals)}
     return common_attrs
@@ -260,7 +264,7 @@ def make_residue_graph(graph, attrs=('chain', 'resid', 'resname', 'insertion_cod
     # res_graph = nx.quotient_graph(graph, node_equiv, relabel=True)
     for res_idx in res_graph:
         res_node = res_graph.nodes[res_idx]
-        res_node.update(_items_with_common_values(res_node['graph']))
+        res_node.update(_items_with_common_values(res_node['graph'], excluded_keys=['graph']))
     return res_graph
 
 

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -549,7 +549,7 @@ def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=Fals
         Whether charges should be omitted. This is usually a good idea since
         the PDB format can only deal with integer charges.
     nan_missing_pos: bool
-        Wether the writing should fail if an atom does not have a position.
+        Whether the writing should fail if an atom does not have a position.
         When set to `True`, atoms without coordinates will be written
         with 'nan' as coordinates; this will cause the output file to be
         *invalid* for most uses.

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -226,7 +226,7 @@ def _apply_selection(graph, selection=None):
     if selection is None:
         selected_nodes = graph.nodes
     else:
-        selected_nodes = (node for node in graph.nodes if node in selection)
+        selected_nodes = [node for node in graph.nodes if node in selection]
 
     return selected_nodes
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -157,19 +157,16 @@ def build_connectivity_matrix(graph, separation, selection=None):
     return connectivity
 
 
-def build_domain_matrix(graph, are_same_domain, selection):
+def build_pair_matrix(graph, criterion, selection):
     """
-    Build a boolean matrix telling if two nodes belong to the same domain.
-
-    A domain is an ensemble of nodes that can be connected by an elastic
-    network.
+    Build a boolean matrix telling if a pair of nodes fulfil a criterion.
 
     Parameters
     ----------
     graph: networkx.Graph
         The graph/molecule to work on.
-    are_same_domain: Callable
-        A function that determines if two nodes are part of the same domain.
+    criterion: Callable
+        A function that determines if a pair of nodes fulfill the criterion.
         It takes a graph and two node keys as arguments and returns a boolean.
     selection: collections.abc.Collection
         A list of node keys to work on. If this argument is set, then the
@@ -190,7 +187,7 @@ def build_domain_matrix(graph, are_same_domain, selection):
     share_domain = np.zeros((size, size), dtype=bool)
     node_combinations = itertools.combinations(enumerate(selected_nodes), 2)
     for (idx, key_idx), (jdx, key_jdx) in node_combinations:
-        share_domain[idx, jdx] = are_same_domain(graph, key_idx, key_jdx)
+        share_domain[idx, jdx] = criterion(graph, key_idx, key_jdx)
         share_domain[jdx, idx] = share_domain[idx, jdx]
     return share_domain
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -177,7 +177,7 @@ def build_connectivity_matrix(graph, separation, selected_nodes):
     # separation is provided in term of nodes while the path is provided in
     # terms of edges, hence `separation + 1`.
     distance_pairs = nx.all_pairs_shortest_path_length(graph, cutoff=separation + 1)
-    #only gets "positive" entries due to the cutoff argument above
+    # only gets "positive" entries due to the cutoff argument above
     for origin, target_and_distances in distance_pairs:
         for target in target_and_distances:
             connectivity[correspondence[origin], correspondence[target]] = True
@@ -211,29 +211,6 @@ def build_pair_matrix(graph, criterion, selected_nodes):
         share_domain[idx, jdx] = criterion(graph, key_idx, key_jdx)
         share_domain[jdx, idx] = share_domain[idx, jdx]
     return share_domain
-
-
-def _apply_selection(graph, selection=None):
-    """
-    Select nodes from `graph` based on `selection`
-    criterion and return a list of nodes.
-
-    Parameters
-    ----------
-    graph: networkx.Graph
-        The graph/molecule to work on.
-    selection: collections.abc.Collection
-        A list of node keys to work on. If this argument is set, then the
-        matrix is built only for the nodes in the selection. If set to
-        `None` (default), then the matrix is built for all the nodes.
-    """
-    if selection is None:
-        selected_nodes = graph.nodes
-    else:
-        selected_nodes = [node for node in graph.nodes if node in selection]
-
-    return selected_nodes
-
 
 def apply_rubber_band(molecule, selector,
                       lower_bound, upper_bound,
@@ -328,8 +305,7 @@ def apply_rubber_band(molecule, selector,
                                         base_constant, minimum_force)
     # we select the nodes here so the selection list has the same
     # order in build_connectivity_matrix and build_pair matrix
-    selected_nodes = _apply_selection(molecule, selection=selection)
-    print(selected_nodes)
+    selected_nodes = selection
     connected = build_connectivity_matrix(molecule, res_min_dist,
                                           selected_nodes=selected_nodes)
     same_domain = build_pair_matrix(molecule, domain_criterion,

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -94,7 +94,7 @@ def build_connectivity_matrix(graph, separation, selection=None):
     """
     Build a connectivity matrix based on the separation between nodes in a graph.
 
-    The connectivity matrix is a symetric boolean matrix where cells contain
+    The connectivity matrix is a symmetric boolean matrix where cells contain
     ``True`` if the corresponding atoms are connected in the graph and
     separated by less or as much nodes as the given 'separation' argument.
 
@@ -130,9 +130,9 @@ def build_connectivity_matrix(graph, separation, selection=None):
         raise ValueError('Separation has to be null or positive.')
     if separation == 0:
         # The connectivity matrix with a separation of 1 is the adjacency
-        # matrix. Thanksfully, networkx can directly give it to us a a numpy
+        # matrix. Thankfully, networkx can directly give it to us a a numpy
         # array.
-        return nx.to_numpy_matrix(graph, nodelist=selection).astype(bool)
+        return np.asarray(nx.to_numpy_matrix(graph, nodelist=selection).astype(bool))
     subgraph = graph.subgraph(selection)
     connectivity = np.zeros((len(subgraph), len(subgraph)), dtype=bool)
     for (idx, key_idx), (jdx, key_jdx) in itertools.combinations(enumerate(subgraph.nodes), 2):
@@ -157,7 +157,7 @@ def apply_rubber_band(molecule, selector,
     r"""
     Adds a rubber band elastic network to a molecule.
 
-    The eleastic network is applied as bounds between the atoms selected by the
+    The elastic network is applied as bounds between the atoms selected by the
     function declared with the 'selector' argument. The equilibrium length for
     the bonds is measured from the coordinates in the molecule, the force
     constant is computed from the base force constant and an optional decay
@@ -200,7 +200,7 @@ def apply_rubber_band(molecule, selector,
         If 'decay_factor' or 'decay_power' is set to 0, then it will be the
         used force constant.
     minimum_force: float
-        Minimum force constat in :math:`kJ.mol^{-1}.nm^{-2}` under which bonds
+        Minimum force constant in :math:`kJ.mol^{-1}.nm^{-2}` under which bonds
         are not kept.
     bond_type: int
         Gromacs bond function type to apply to the elastic network bonds.
@@ -232,7 +232,7 @@ def apply_rubber_band(molecule, selector,
     # Set the force constant to 0 for pairs that are connected. `connectivity`
     # is a matrix of booleans that is True when a pair is connected. Because
     # booleans acts as 0 or 1 in operation, we multiply the force constant
-    # matrix by the oposite (OR) of the connectivity matrix.
+    # matrix by the opposite (OR) of the connectivity matrix.
     constants *= ~connectivity
     distance_matrix = distance_matrix.round(5)  # For compatibility with legacy
     for from_idx, to_idx in zip(*np.triu_indices_from(constants)):

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -21,7 +21,6 @@ import networkx as nx
 
 from .processor import Processor
 from .. import selectors
-from .. import Molecule  # for references in the documentation
 
 DEFAULT_BOND_TYPE = 6
 
@@ -256,7 +255,7 @@ def apply_rubber_band(molecule, selector,
 
     Parameters
     ----------
-    molecule: Molecule
+    molecule: vermouth.molecule.Molecule
         The molecule to which apply the elastic network. The molecule is
         modified in-place.
     selector: collections.abc.Callable
@@ -284,7 +283,7 @@ def apply_rubber_band(molecule, selector,
         Function to establish if two atoms are part of the same domain. Elastic
         bonds are only added within a domain. By default, all the atoms in
         the molecule are considered part of the same domain. The function
-        expects a graph (e.g. a :class:`Molecule`) and two atom node keys as
+        expects a graph (e.g. a :class:`~vermouth.molecule.Molecule`) and two atom node keys as
         argument and returns ``True`` if the two atoms are part of the same
         domain; returns ``False`` otherwise.
     res_min_dist: int

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -169,8 +169,11 @@ def build_connectivity_matrix(graph, separation, selection=None):
         # matrix. Thankfully, networkx can directly give it to us a a numpy
         # matrix.
         return np.asarray(nx.to_numpy_matrix(graph, nodelist=selection).astype(bool))
-    criterion = functools.partial(are_connected, separation=separation)
-    connectivity = build_pair_matrix(graph, criterion, selection)
+    if selection is None:
+        selection = slice(None, None, None)
+    distances = np.asarray(nx.floyd_warshall_numpy(graph))[:, selection][selection] - 1
+    connectivity = distances <= separation
+    np.fill_diagonal(connectivity, False)
     return connectivity
 
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -170,7 +170,7 @@ def build_domain_matrix(graph, are_same_domain, selection):
         The graph/molecule to work on.
     are_same_domain: Callable
         A function that determines if two nodes are part of the same domain.
-        It takes the two nde dictionary as arguments and returns a boolean.
+        It takes a graph and two node keys as arguments and returns a boolean.
     selection: collections.abc.Collection
         A list of node keys to work on. If this argument is set, then the
         matrix is built only for the nodes in the selection. If set to
@@ -190,9 +190,7 @@ def build_domain_matrix(graph, are_same_domain, selection):
     share_domain = np.zeros((size, size), dtype=bool)
     node_combinations = itertools.combinations(enumerate(selected_nodes), 2)
     for (idx, key_idx), (jdx, key_jdx) in node_combinations:
-        share_domain[idx, jdx] = are_same_domain(
-            graph.nodes[key_idx], graph.nodes[key_jdx]
-        )
+        share_domain[idx, jdx] = are_same_domain(graph, key_idx, key_jdx)
         share_domain[jdx, idx] = share_domain[idx, jdx]
     return share_domain
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -280,7 +280,7 @@ def apply_rubber_band(molecule, selector,
         are not kept.
     bond_type: int
         Gromacs bond function type to apply to the elastic network bonds.
-    domain_criterion: Callback
+    domain_criterion: Callable
         Function to establish if two atoms are part of the same domain. Elastic
         bonds are only added within a domain. By default, all the atoms in
         the molecule are considered part of the same domain. The function

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -192,7 +192,7 @@ def build_pair_matrix(graph, criterion, selection):
     ----------
     graph: networkx.Graph
         The graph/molecule to work on.
-    criterion: Callable
+    criterion: collections.abc.Callable
         A function that determines if a pair of nodes fulfill the criterion.
         It takes a graph and two node keys as arguments and returns a boolean.
     selection: collections.abc.Collection
@@ -280,7 +280,7 @@ def apply_rubber_band(molecule, selector,
         are not kept.
     bond_type: int
         Gromacs bond function type to apply to the elastic network bonds.
-    domain_criterion: Callable
+    domain_criterion: collections.abc.Callable
         Function to establish if two atoms are part of the same domain. Elastic
         bonds are only added within a domain. By default, all the atoms in
         the molecule are considered part of the same domain. The function

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -15,13 +15,13 @@
 Provides a processor that adds a rubber band elastic network.
 """
 import itertools
-import functools
 
 import numpy as np
 import networkx as nx
 
 from .processor import Processor
 from .. import selectors
+from .. import Molecule  # for references in the documentation
 
 DEFAULT_BOND_TYPE = 6
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -270,6 +270,13 @@ def apply_rubber_band(molecule, selector,
         are not kept.
     bond_type: int
         Gromacs bond function type to apply to the elastic network bonds.
+    domain_criterion: Callback
+        Function to establish if two atoms are part of the same domain. Elastic
+        bonds are only added within a domain. By default, all the atoms in
+        the molecule are considered part of the same domain. The function
+        expects a graph (e.g. a :class:`Molecule`) and two atom node keys as
+        argument and returns ``True`` if the two atoms are part of the same
+        domain; returns ``False`` otherwise.
     res_min_dist: int
         Minimum separation between two atoms for a bond to be kept.
         Bonds are kept is the separation is greater or equal to the value

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -329,6 +329,32 @@ def always_true(*args, **kwargs):
     return True
 
 
+def same_chain(graph, left, right):
+    """
+    Returns ``True`` is the nodes are part of the same chain.
+
+    Nodes are considered part of the same chain if they both have the same value
+    under the "chain" attribute, or if none of the 2 nodes have that attribute.
+
+    Parameters
+    ----------
+    graph: networkx.Graph
+        A graph the nodes are part of.
+    left:
+        A node key in 'graph'.
+    right:
+        A node key in 'graph'.
+
+    Returns
+    -------
+    bool
+        ``True`` if the nodes are part of the same chain.
+    """
+    node_left = graph.nodes[left]
+    node_right = graph.nodes[right]
+    return node_left.get('chain') == node_right.get('chain')
+
+
 class ApplyRubberBand(Processor):
     def __init__(self, lower_bound, upper_bound, decay_factor, decay_power,
                  base_constant, minimum_force,

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -55,8 +55,6 @@ def disconnected_graph():
     return graph
 
 
-
-
 @pytest.mark.parametrize('separation', (0, 1, 2, 3, 7))
 @pytest.mark.parametrize('selection', (
     list(range(16)),  # Use all the nodes, explicitly
@@ -140,3 +138,47 @@ def test_apply_section(disconnected_graph, selection):
     if selection == None:
        selection = disconnected_graph.nodes
     assert set(selected_nodes) == set(selection)
+
+@pytest.mark.parametrize('nodes, edges, outcome', (
+    ([1, 2, 3],
+     [(1, 2), (2, 3)],
+     True),
+    ([1, 2, 3],
+     [(2, 3)],
+     False)
+))
+def test_are_connected(nodes, edges, outcome):
+    graph = nx.Graph()
+    graph.add_nodes_from(nodes)
+    graph.add_edges_from(edges)
+    assert are_connected(graph, 1, 2, 1) == outcome
+
+@pytest.mark.parametrize('nodes, edges, chain, outcome', (
+    ([1, 2, 3],
+     {1:"A", 2:"A", 3:"C"},
+     [(1, 2), (2, 3)],
+     True),
+    ([1, 2, 3],
+     {1:"A", 2:"B", 3:"C"},
+     [(1, 2), (2, 3)],
+     False)
+))
+def test_same_chain(nodes, edges, chain, outcome):
+    graph = nx.Graph()
+    graph.add_nodes_from(nodes)
+    graph.add_edges_from(edges)
+    nx.set_node_attributes(graph, chain, "chain")
+    assert same_chain(graph, 1, 1) == outcome
+
+def test_compute_force_constants():
+     compute_force_constants(distance_matrix, lower_bound, upper_bound,
+                             decay_factor, decay_power, base_constant,
+                            minimum_force)
+
+
+def test_self_distance_matrix(coordinates):
+     self_distance_matrix(coordinates)
+
+
+def test_compute_decay():
+    compute_decay(distance, shift, rate, power)

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -37,7 +37,9 @@ def disconnected_graph():
      |         |    |
     12 - 13 - 14 - 15
     """
-    graph = nx.Graph([
+    graph = nx.Graph()
+    graph.add_nodes_from(range(16))
+    graph.add_edges_from([
         # First connected component
         [0, 1], [1, 2], [2, 3], [3, 7], [4, 5], [5, 6], [6, 7],
         # Second connected component

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -100,10 +100,11 @@ def test_build_connectivity_matrix(disconnected_graph, separation, selection):
         list(range(0, 16, 2)),  # Every other nodes
 ))
 @pytest.mark.parametrize('extra_edges', ([], [(7, 10)]))
-def test_build_domain_matrix(disconnected_graph, selection, extra_edges):
+def test_build_pair_matrix(disconnected_graph, selection, extra_edges):
     """
-    The detection of domains works as expected.
+    The creation of a pair matrix works as expected.
 
+    Here, the criterion is ``True`` when nodes belong to the same domain.
     The graph is defined as having two domains: one per chain. The extra edges
     allow to make sure the connectivity does not impact the domain detection.
     """
@@ -118,6 +119,6 @@ def test_build_domain_matrix(disconnected_graph, selection, extra_edges):
         expected = expected[:, selection][selection]
 
     disconnected_graph.add_edges_from(extra_edges)
-    domains = apply_rubber_band.build_domain_matrix(
+    domains = apply_rubber_band.build_pair_matrix(
         disconnected_graph, have_same_chain, selection)
     assert np.all(domains == expected)

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -107,8 +107,8 @@ def test_build_domain_matrix(disconnected_graph, selection, extra_edges):
     The graph is defined as having two domains: one per chain. The extra edges
     allow to make sure the connectivity does not impact the domain detection.
     """
-    def have_same_chain(left, right):
-        return left['chain'] == right['chain']
+    def have_same_chain(graph, left, right):
+        return graph.nodes[left]['chain'] == graph.nodes[right]['chain']
 
     expected = np.zeros((16, 16), dtype=bool)
     expected[:8, :8] = True

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -55,9 +55,10 @@ def disconnected_graph():
     return graph
 
 
+
+
 @pytest.mark.parametrize('separation', (0, 1, 2, 3, 7))
 @pytest.mark.parametrize('selection', (
-    None,  # Use all the nodes, implicitly
     list(range(16)),  # Use all the nodes, explicitly
     list(range(8)),  # Only the first component
     list(range(8, 16)),  # Only the second component
@@ -95,7 +96,6 @@ def test_build_connectivity_matrix(disconnected_graph, separation, selection):
 
 
 @pytest.mark.parametrize('selection', (
-        None,  # Use all the nodes, implicitly
         list(range(16)),  # Use all the nodes, explicitly
         list(range(8)),  # Only the first component
         list(range(8, 16)),  # Only the second component
@@ -117,10 +117,26 @@ def test_build_pair_matrix(disconnected_graph, selection, extra_edges):
     expected[:8, :8] = True
     expected[8:, 8:] = True
     np.fill_diagonal(expected, False)
-    if selection is not None:
-        expected = expected[:, selection][selection]
+    expected = expected[:, selection][selection]
 
     disconnected_graph.add_edges_from(extra_edges)
     domains = apply_rubber_band.build_pair_matrix(
         disconnected_graph, have_same_chain, selection)
     assert np.all(domains == expected)
+
+@pytest.mark.parametrize('selection', (
+        None, # Use all nodes
+        list(range(16)),  # Use all the nodes, explicitly
+        list(range(8)),  # Only the first component
+        list(range(8, 16)),  # Only the second component
+        list(range(0, 16, 2)),  # Every other nodes
+))
+def test_apply_section(disconnected_graph, selection):
+    """
+    Test if the selection criterion and the default for
+    None is applied correctly.
+    """
+    selected_nodes = apply_rubber_band._apply_selection(disconnected_graph, selection)
+    if selection == None:
+       selection = disconnected_graph.nodes
+    assert set(selected_nodes) == set(selection)

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -14,15 +14,18 @@
 """
 Test the ApplyRubberBand processor and the related functions.
 """
-import pytest
 import functools
+import pytest
 import numpy as np
 import networkx as nx
 import vermouth
 import vermouth.forcefield
-from vermouth import selectors, molecule
+from vermouth import selectors
 from vermouth.processors import apply_rubber_band
-from vermouth.processors.apply_rubber_band import same_chain, are_connected, build_connectivity_matrix
+from vermouth.processors.apply_rubber_band import (same_chain,
+                                                   are_connected,
+                                                   build_connectivity_matrix)
+
 
 @pytest.fixture
 def disconnected_graph():
@@ -56,11 +59,12 @@ def disconnected_graph():
             node['chain'] = 'B'
     return graph
 
+
 @pytest.mark.parametrize('selection', (
-        list(range(16)),  # Use all the nodes, explicitly
-        list(range(8)),  # Only the first component
-        list(range(8, 16)),  # Only the second component
-        list(range(0, 16, 2)),  # Every other nodes
+    list(range(16)),  # Use all the nodes, explicitly
+    list(range(8)),  # Only the first component
+    list(range(8, 16)),  # Only the second component
+    list(range(0, 16, 2)),  # Every other nodes
 ))
 @pytest.mark.parametrize('extra_edges', ([], [(7, 10)]))
 def test_build_pair_matrix(disconnected_graph, selection, extra_edges):
@@ -81,39 +85,46 @@ def test_build_pair_matrix(disconnected_graph, selection, extra_edges):
     expected = expected[:, selection][selection]
 
     disconnected_graph.add_edges_from(extra_edges)
-    idx_to_node = {idx: node for idx, node in enumerate(disconnected_graph.nodes) }
+    idx_to_node = {idx: node for idx,
+                   node in enumerate(disconnected_graph.nodes)}
     domains = apply_rubber_band.build_pair_matrix(
         disconnected_graph, have_same_chain, idx_to_node, selection)
     assert np.all(domains == expected)
 
-@pytest.mark.parametrize('separation, outcome',(
-         (1, [[0, 2], [2, 6], [4, 6], [8, 12], [8, 10],
-             [10, 14], [12, 14]]),
-         (2, [[0, 2], [2, 6], [4, 6], [0, 6], [2, 4],
-              [8, 12], [8, 10], [10, 14], [12, 14],
-              [8, 14], [10, 12]])
-         ))
+
+@pytest.mark.parametrize('separation, outcome', (
+    (1, [[0, 2], [2, 6], [4, 6], [8, 12], [8, 10],
+         [10, 14], [12, 14]]),
+    (2, [[0, 2], [2, 6], [4, 6], [0, 6], [2, 4],
+         [8, 12], [8, 10], [10, 14], [12, 14],
+         [8, 14], [10, 12]])
+))
 # this only tests connectivity matrix in terms of connection
 # and separation in residue space. selection is tested at the
 # end with a more integral test
 def test_build_connectivity_matrix(disconnected_graph, separation, outcome):
-    idx_to_node = {idx: node for idx, node in enumerate(disconnected_graph.nodes)}
+    idx_to_node = {idx: node for idx,
+                   node in enumerate(disconnected_graph.nodes)}
     selection = list(range(0, 16, 2))
     resid_attr = {0: 1, 1: 1, 2: 2, 3: 2, 4: 3, 5: 3, 6: 4, 7: 4,
                   8: 5, 9: 5, 10: 6, 11: 6, 12: 7, 13: 7, 14: 8, 15: 8}
     nx.set_node_attributes(disconnected_graph, resid_attr, 'resid')
-    connected = build_connectivity_matrix(disconnected_graph, separation, idx_to_node, selection)
-    pairs=[]
+    connected = build_connectivity_matrix(disconnected_graph,
+                                          separation,
+                                          idx_to_node,
+                                          selection)
+    pairs = []
     for from_idx, to_idx in zip(*np.triu_indices_from(connected)):
         if connected[from_idx, to_idx]:
-           idxs = [selection[from_idx], selection[to_idx]]
-           idxs.sort()
-           pairs.append(idxs)
+            idxs = [selection[from_idx], selection[to_idx]]
+            idxs.sort()
+            pairs.append(idxs)
 
     for pair in outcome:
         assert pair in pairs
 
     assert len(pairs) == len(outcome)
+
 
 @pytest.mark.parametrize('nodes, edges, outcome', (
     ([1, 2, 3],
@@ -129,13 +140,14 @@ def test_are_connected(nodes, edges, outcome):
     graph.add_edges_from(edges)
     assert are_connected(graph, 1, 2, 1) == outcome
 
+
 @pytest.mark.parametrize('nodes, chain, edges, outcome', (
     ([1, 2, 3],
-     {1:"A", 2:"A", 3:"C"},
+     {1: "A", 2: "A", 3: "C"},
      [(1, 2), (2, 3)],
      True),
     ([1, 2, 3],
-     {1:"A", 2:"B", 3:"C"},
+     {1: "A", 2: "B", 3: "C"},
      [(1, 2), (2, 3)],
      False)
 ))
@@ -146,8 +158,9 @@ def test_same_chain(nodes, edges, chain, outcome):
     nx.set_node_attributes(graph, chain, "chain")
     assert same_chain(graph, 1, 2) == outcome
 
+
 @pytest.fixture
-def molecule():
+def test_molecule():
     """
     Molecule with the following connectivity and atom-naming:
 
@@ -165,18 +178,27 @@ def molecule():
     molecule.meta['test'] = True
     # The node keys should not be in a sorted order as it would mask any issue
     # due to the keys being accidentally sorted.
-    molecule.add_node(2, atomname='SC2', position=np.array([0., 1.0, 0.0]), resid=1)
-    molecule.add_node(0, atomname='BB', position=np.array([0., 0., 0.]), resid=1)
-    molecule.add_node(1, atomname='SC1', position=np.array([0., 0.5, 0.0]), resid=1)
+    molecule.add_node(2, atomname='SC2',
+                      position=np.array([0., 1.0, 0.0]), resid=1)
+    molecule.add_node(0, atomname='BB',
+                      position=np.array([0., 0., 0.]), resid=1)
+    molecule.add_node(1, atomname='SC1',
+                      position=np.array([0., 0.5, 0.0]), resid=1)
 
-    molecule.add_node(3, atomname='BB', position=np.array([0.5, 0.0, 0.0]), resid=2)
-    molecule.add_node(4, atomname='SC1', position=np.array([0.5, 0.5, 0.0]), resid=2)
+    molecule.add_node(3, atomname='BB', position=np.array(
+        [0.5, 0.0, 0.0]), resid=2)
+    molecule.add_node(4, atomname='SC1', position=np.array(
+        [0.5, 0.5, 0.0]), resid=2)
 
-    molecule.add_node(5, atomname='BB', position=np.array([1.0, 0.0, 0.0]), resid=3)
+    molecule.add_node(5, atomname='BB', position=np.array(
+        [1.0, 0.0, 0.0]), resid=3)
 
-    molecule.add_node(6, atomname='BB', position=np.array([1.5, 0.0, 0.0]), resid=4)
-    molecule.add_node(7, atomname='SC1', position=np.array([1.5, 0.5, 0.0]), resid=4)
-    molecule.add_node(8, atomname='SC2', position=np.array([1.5, 1.0, 0.0]), resid=4)
+    molecule.add_node(6, atomname='BB', position=np.array(
+        [1.5, 0.0, 0.0]), resid=4)
+    molecule.add_node(7, atomname='SC1', position=np.array(
+        [1.5, 0.5, 0.0]), resid=4)
+    molecule.add_node(8, atomname='SC2', position=np.array(
+        [1.5, 1.0, 0.0]), resid=4)
 
     molecule.add_edge(0, 1)
     molecule.add_edge(0, 2)
@@ -189,67 +211,95 @@ def molecule():
 
     return molecule
 
-@pytest.mark.parametrize('chain_attribute, atom_names, res_min_dist, outcome',
-                        (({0: 'A', 1: 'A', 2: 'A',
-                          3: 'A', 4: 'A', 5: 'A',
-                          6: 'A', 7: 'A', 8: 'A'},
-                         ['BB'],
-                          2,
-                         [vermouth.molecule.Interaction(atoms=(0, 6), meta={'group': 'Rubber band'}, parameters=[6, 1.5, 1000])]
-                         ),
-                        # different min_res
-                        ({0: 'A', 1: 'A', 2: 'A',
-                          3: 'A', 4: 'A', 5: 'A',
-                          6: 'A', 7: 'A', 8: 'A'},
-                         ['BB'],
-                          1,
-                         [vermouth.molecule.Interaction(atoms=(0, 5), meta={'group': 'Rubber band'}, parameters=[6, 1.0, 1000]),
-                          vermouth.molecule.Interaction(atoms=(0, 6), meta={'group': 'Rubber band'}, parameters=[6, 1.5, 1000]),
-                          vermouth.molecule.Interaction(atoms=(3, 6), meta={'group': 'Rubber band'}, parameters=[6, 1.0, 1000])]
-                         ),
-                        # select more than only BB atoms
-                        ({0: 'A', 1: 'A', 2: 'A',
-                          3: 'A', 4: 'A', 5: 'A',
-                          6: 'A', 7: 'A', 8: 'A'},
-                         ['BB', 'SC1'],
-                          2,
-                         [vermouth.molecule.Interaction(atoms=(0, 6), meta={'group': 'Rubber band'}, parameters=[6, 1.5, 1000]),
-                          vermouth.molecule.Interaction(atoms=(0, 7), meta={'group': 'Rubber band'}, parameters=[6, 1.58114, 1000]),
-                          vermouth.molecule.Interaction(atoms=(1, 6), meta={'group': 'Rubber band'}, parameters=[6, 1.58114, 1000]),
-                          vermouth.molecule.Interaction(atoms=(1, 7), meta={'group': 'Rubber band'}, parameters=[6, 1.5, 1000])]
-                         ),
-                        # change chain identifier
-                        ({0: 'A', 1: 'A', 2: 'A',
-                          3: 'B', 4: 'B', 5: 'B',
-                          6: 'B', 7: 'B', 8: 'B'},
-                         ['BB'],
-                          1,
-                         [vermouth.molecule.Interaction(atoms=(3, 6), meta={'group': 'Rubber band'}, parameters=[6, 1.0, 1000])]
-                         )))
 
-def test_apply_rubber_bands(molecule, chain_attribute, atom_names, res_min_dist, outcome):
+@pytest.mark.parametrize('chain_attribute, atom_names, res_min_dist, outcome',
+                         (({0: 'A', 1: 'A', 2: 'A',
+                            3: 'A', 4: 'A', 5: 'A',
+                            6: 'A', 7: 'A', 8: 'A'},
+                           ['BB'],
+                           2,
+                           [vermouth.molecule.Interaction(
+                               atoms=(0, 6),
+                               meta={'group': 'Rubber band'},
+                               parameters=[6, 1.5, 1000])]
+                           ),
+                          # different min_res
+                          ({0: 'A', 1: 'A', 2: 'A',
+                            3: 'A', 4: 'A', 5: 'A',
+                            6: 'A', 7: 'A', 8: 'A'},
+                           ['BB'],
+                           1,
+                           [vermouth.molecule.Interaction(
+                               atoms=(0, 5),
+                               meta={'group': 'Rubber band'},
+                               parameters=[6, 1.0, 1000]),
+                            vermouth.molecule.Interaction(
+                                atoms=(0, 6),
+                                meta={'group': 'Rubber band'},
+                                parameters=[6, 1.5, 1000]),
+                            vermouth.molecule.Interaction(
+                                atoms=(3, 6),
+                                meta={'group': 'Rubber band'},
+                                parameters=[6, 1.0, 1000])]
+                           ),
+                          # select more than only BB atoms
+                          ({0: 'A', 1: 'A', 2: 'A',
+                            3: 'A', 4: 'A', 5: 'A',
+                            6: 'A', 7: 'A', 8: 'A'},
+                           ['BB', 'SC1'],
+                           2,
+                           [vermouth.molecule.Interaction(
+                               atoms=(0, 6),
+                               meta={'group': 'Rubber band'},
+                               parameters=[6, 1.5, 1000]),
+                            vermouth.molecule.Interaction(
+                                atoms=(0, 7),
+                                meta={'group': 'Rubber band'},
+                                parameters=[6, 1.58114, 1000]),
+                            vermouth.molecule.Interaction(
+                                atoms=(1, 6),
+                                meta={'group': 'Rubber band'},
+                                parameters=[6, 1.58114, 1000]),
+                            vermouth.molecule.Interaction(
+                                atoms=(1, 7),
+                                meta={'group': 'Rubber band'},
+                                parameters=[6, 1.5, 1000])]
+                           ),
+                          # change chain identifier
+                          ({0: 'A', 1: 'A', 2: 'A',
+                            3: 'B', 4: 'B', 5: 'B',
+                            6: 'B', 7: 'B', 8: 'B'},
+                           ['BB'],
+                           1,
+                           [vermouth.molecule.Interaction(
+                               atoms=(3, 6),
+                               meta={'group': 'Rubber band'},
+                               parameters=[6, 1.0, 1000])]
+                           )))
+def test_apply_rubber_bands(test_molecule, chain_attribute, atom_names, res_min_dist, outcome):
     """
     Takes molecule and sets the chain attributes. Based on chain, minimum distance
     between residues, and atom names elagible it is tested if rubber bands are applied
     for the correct atoms in molecule.
     """
     selector = functools.partial(
-                selectors.proto_select_attribute_in,
-                attribute='atomname',
-                values=atom_names)
+        selectors.proto_select_attribute_in,
+        attribute='atomname',
+        values=atom_names)
 
     domain_criterion = vermouth.processors.apply_rubber_band.same_chain
-    nx.set_node_attributes(molecule, chain_attribute, 'chain')
+    nx.set_node_attributes(test_molecule, chain_attribute, 'chain')
 
-    process = vermouth.processors.apply_rubber_band.ApplyRubberBand(selector=selector,
-                                                                    lower_bound=0.0,
-                                                                    upper_bound=10.,
-                                                                    decay_factor=0,
-                                                                    decay_power=0.,
-                                                                    base_constant=1000,
-                                                                    minimum_force=1,
-                                                                    bond_type=6,
-                                                                    domain_criterion=domain_criterion,
-                                                                    res_min_dist=res_min_dist)
-    process.run_molecule(molecule)
-    assert molecule.interactions['bonds'] == outcome
+    process = vermouth.processors.apply_rubber_band.ApplyRubberBand(
+        selector=selector,
+        lower_bound=0.0,
+        upper_bound=10.,
+        decay_factor=0,
+        decay_power=0.,
+        base_constant=1000,
+        minimum_force=1,
+        bond_type=6,
+        domain_criterion=domain_criterion,
+        res_min_dist=res_min_dist)
+    process.run_molecule(test_molecule)
+    assert test_molecule.interactions['bonds'] == outcome

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -19,6 +19,7 @@ import functools
 import numpy as np
 import networkx as nx
 import vermouth
+import vermouth.forcefield
 from vermouth import selectors, molecule
 from vermouth.processors import apply_rubber_band
 from vermouth.processors.apply_rubber_band import same_chain, are_connected, build_connectivity_matrix
@@ -158,7 +159,9 @@ def molecule():
            -------------
     resid: 1   2   3   4  column wise
     """
-    molecule = vermouth.molecule.Molecule()
+
+    force_field = vermouth.forcefield.ForceField("test")
+    molecule = vermouth.molecule.Molecule(force_field=force_field)
     molecule.meta['test'] = True
     # The node keys should not be in a sorted order as it would mask any issue
     # due to the keys being accidentally sorted.
@@ -238,10 +241,15 @@ def test_apply_rubber_bands(molecule, chain_attribute, atom_names, res_min_dist,
     domain_criterion = vermouth.processors.apply_rubber_band.same_chain
     nx.set_node_attributes(molecule, chain_attribute, 'chain')
 
-    vermouth.processors.apply_rubber_band.apply_rubber_band(molecule=molecule, selector=selector,
-                                  lower_bound=0.0, upper_bound=10.,
-                                  decay_factor=0, decay_power=0.,
-                                  base_constant=1000, minimum_force=1,
-                                  bond_type=6, domain_criterion=domain_criterion,
-                                  res_min_dist=res_min_dist)
+    process = vermouth.processors.apply_rubber_band.ApplyRubberBand(selector=selector,
+                                                                    lower_bound=0.0,
+                                                                    upper_bound=10.,
+                                                                    decay_factor=0,
+                                                                    decay_power=0.,
+                                                                    base_constant=1000,
+                                                                    minimum_force=1,
+                                                                    bond_type=6,
+                                                                    domain_criterion=domain_criterion,
+                                                                    res_min_dist=res_min_dist)
+    process.run_molecule(molecule)
     assert molecule.interactions['bonds'] == outcome

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -1,0 +1,92 @@
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test the ApplyRubberBand processor and the related functions.
+"""
+import pytest
+import numpy as np
+import networkx as nx
+from vermouth.processors import apply_rubber_band
+
+
+@pytest.fixture
+def disconnected_graph():
+    """
+    A graph with two connected components.
+
+    The node keys are integers from 0 to 15 (included). The name of each node
+    is its key as a string. The first component is labelled as chain A while
+    the second is labelled as chain B.
+
+    0 - 1 - 2 - 3
+                |
+    4 - 5 - 6 - 7
+
+     8 -  9 - 10 - 11
+     |         |    |
+    12 - 13 - 14 - 15
+    """
+    graph = nx.Graph([
+        # First connected component
+        [0, 1], [1, 2], [2, 3], [3, 7], [4, 5], [5, 6], [6, 7],
+        # Second connected component
+        [8, 9], [8, 12], [8, 9], [9, 10], [10, 14], [10, 11], [11, 15],
+        [12, 13], [13, 14], [14, 15],
+    ])
+    for key, node in graph.nodes.items():
+        node['name'] = str(key)
+        if key < 8:
+            node['chain'] = 'A'
+        else:
+            node['chain'] = 'B'
+    return graph
+
+
+@pytest.mark.parametrize('separation', (0, 1, 2, 3, 7))
+@pytest.mark.parametrize('selection', (
+    None,  # Use all the nodes, implicitly
+    list(range(16)),  # Use all the nodes, explicitly
+    list(range(8)),  # Only the first component
+    list(range(8, 16)),  # Only the second component
+    list(range(0, 16, 2)),  # Every other nodes
+))
+def test_build_connectivity_matrix(disconnected_graph, separation, selection):
+    connectivity = apply_rubber_band.build_connectivity_matrix(
+        disconnected_graph, separation, selection)
+    other_component = [np.inf] * 8
+    distance = np.array([
+        #0  1  2  3  4  5  6  7    8 to 15
+        [0, 0, 1, 2, 6, 5, 4, 3] + other_component,  # 0
+        [0, 0, 0, 1, 5, 4, 3, 2] + other_component,  # 1
+        [1, 0, 0, 0, 4, 3, 2, 1] + other_component,  # 2
+        [2, 1, 0, 0, 3, 2, 1, 0] + other_component,  # 3
+        [6, 5, 4, 3, 0, 0, 1, 2] + other_component,  # 4
+        [5, 4, 3, 2, 0, 0, 0, 1] + other_component,  # 5
+        [4, 3, 2, 1, 1, 0, 0, 0] + other_component,  # 6
+        [3, 2, 1, 0, 2, 1, 0, 0] + other_component,  # 7
+        # 0 to 7           8  9 10 11 12 13 14 15
+        other_component + [0, 0, 1, 2, 0, 1, 2, 3],  # 8
+        other_component + [0, 0, 0, 1, 1, 2, 1, 2],  # 9
+        other_component + [1, 0, 0, 0, 2, 1, 0, 1],  # 10
+        other_component + [2, 1, 0, 0, 3, 2, 1, 0],  # 11
+        other_component + [0, 1, 2, 3, 0, 0, 1, 2],  # 12
+        other_component + [1, 2, 1, 2, 0, 0, 0, 1],  # 13
+        other_component + [2, 1, 0, 1, 1, 0, 0, 0],  # 14
+        other_component + [3, 2, 1, 0, 2, 1, 0, 0],  # 15
+    ])
+    np.fill_diagonal(distance, np.inf)
+    expected_connectivity = (distance <= separation)
+    if selection is not None:
+        expected_connectivity = expected_connectivity[:, selection][selection]
+    assert np.all(connectivity == expected_connectivity)

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -80,8 +80,9 @@ def test_build_pair_matrix(disconnected_graph, selection, extra_edges):
     expected = expected[:, selection][selection]
 
     disconnected_graph.add_edges_from(extra_edges)
+    idx_to_node = {idx: node for idx, node in enumerate(disconnected_graph.nodes) }
     domains = apply_rubber_band.build_pair_matrix(
-        disconnected_graph, have_same_chain, selection)
+        disconnected_graph, have_same_chain, idx_to_node, selection)
     assert np.all(domains == expected)
 
 


### PR DESCRIPTION
Fixes #221 
Fixes #267 

* Add the notion of elastic network domains. Bonds are only added within a domain.
* Add the `-eunit` option to the CLI to specify what the domains are. The valid options are 'all', 'chain', and 'molecule'.

In the future, `-eunit` could accept an index file or a domElnedyn input file. Having that working would mostly mean writing a function that can be use as argument for the `domain_criterion` argument of the processor.