### PR TITLE
Bugfix system sorting in pdb_to_universal

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -121,7 +121,7 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
         vermouth.pdb.write_pdb(canonicalized, str(write_canon),
                                omit_charges=True, nan_missing_pos=True)
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
-    vermouth.SortMoleculeAtoms().run_system(system)
+    vermouth.SortMoleculeAtoms().run_system(canonicalized) # was system
     return canonicalized
 
 


### PR DESCRIPTION
Sorting was done on the old system object and not on the canonicalized copy object that is actually returned and used everywhere.
I got an error with DSSP before, probably because the system wasn't sorted properly.
This change fixed my issue and my system is now coarse grained properly.