### PR TITLE
Processor multiprocessing

### DIFF
--- a/vermouth/processors/processor.py
+++ b/vermouth/processors/processor.py
@@ -22,7 +22,9 @@ class Processor:
     """
     An abstract base class for processors. Subclasses must implement a
     `run_molecule` method.
+    Has nproc attribute that is changed by a CLI flag
     """
+    nproc = 1
     def run_system(self, system):
         """
         Process `system`.

--- a/vermouth/processors/processor.py
+++ b/vermouth/processors/processor.py
@@ -17,7 +17,6 @@
 Provides an abstract base class for processors.
 """
 import multiprocessing
-import functools
 
 class Processor:
     """
@@ -33,13 +32,9 @@ class Processor:
         system: vermouth.system.System
             The system to process. Is modified in-place.
         """
-        if self.nproc and self.nproc > 1:
+        if hasattr(self, 'nproc') and self.nproc > 1:
             pool = multiprocessing.Pool(self.nproc)
-            partial_run_molecule = functools.partial(self.run_molecule, force_field=system.force_field,
-                                    allow_name=self.allow_name,
-                                    allow_dist=self.allow_dist,
-                                    fudge=self.fudge)
-            system.molecules = pool.map(partial_run_molecule, system.molecules)
+            system.molecules = pool.map(self.run_molecule, system.molecules)
         else:
             mols = []
             for molecule in system.molecules:

--- a/vermouth/tests/test_make_bonds.py
+++ b/vermouth/tests/test_make_bonds.py
@@ -181,7 +181,19 @@ def test_make_bonds(nodes, edges, expected_edges):
         mol.add_nodes_from(enumerate(node_set))
         mol.add_edges_from(edge_set)
         system.add_molecule(mol)
+    system_mp = system.copy()
+
     MakeBonds().run_system(system)
+    # Make sure number of connected components is the same
+    assert len(system.molecules) == len(expected_edges)
+    # Make sure that for every molecule found, the edges are correct
+    for found_mol, ref_edges in zip(system.molecules, expected_edges):
+        assert dict(found_mol.edges) == ref_edges
+
+    # Also test making bonds with multiprocessing
+    mb = MakeBonds()
+    mb.nproc = 2
+    mb.run_system(system)
     # Make sure number of connected components is the same
     assert len(system.molecules) == len(expected_edges)
     # Make sure that for every molecule found, the edges are correct


### PR DESCRIPTION
This is what i came up with for multiprocessing in the base run_system method.
It will always fall back to the old method if `nproc` is not set.
So far it seems to work fine in combination with my changed make_bonds function in #234 .