### PR TITLE
Fix/ffinput multiple links

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -106,12 +106,13 @@ class FFDirector(SectionLineParser):
             If the section header is unknown.
         """
                         
-        prev_section = self.section
+        prev_section = None
 
         ended = []
         section = self.section + [line.strip('[ ]').casefold()]
         if tuple(section[-1:]) in self.METH_DICT:
             self.section = section[-1:]
+            prev_section = self.section
         else:
             while (tuple(section) not in self.METH_DICT
                    and len(section) > 1):
@@ -120,7 +121,7 @@ class FFDirector(SectionLineParser):
                           
         result = None
 
-        if len(prev_section) != 0:
+        if prev_section:
             result = self.finalize_section(prev_section, ended)
 
         action = self.header_actions.get(tuple(self.section))

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -33,7 +33,7 @@ from .molecule import (
     ParamDistance, ParamAngle, ParamDihedral, ParamDihedralPhase,
 )
 from .parser_utils import (
-    SectionLineParser, _tokenize, _parse_macro, _substitute_macros,
+    SectionLineParser, _tokenize, _substitute_macros, _parse_macro
 )
 
 # Python 3.4 does not raise JSONDecodeError but ValueError.
@@ -85,7 +85,7 @@ class FFDirector(SectionLineParser):
 
     def parse_header(self, line, lineno=0):
         """
-        Parses a section header with line number `lineno`. Sets :attr:`vermouth.parser_utils.SectionLineParser.section` 
+        Parses a section header with line number `lineno`. Sets :attr:`vermouth.parser_utils.SectionLineParser.section`
         when applicable. Does not check whether `line` is a valid section
         header.
 
@@ -105,20 +105,21 @@ class FFDirector(SectionLineParser):
         KeyError
             If the section header is unknown.
         """
-                        
+
         prev_section = None
 
         ended = []
         section = self.section + [line.strip('[ ]').casefold()]
         if tuple(section[-1:]) in self.METH_DICT:
-            self.section = section[-1:]
             prev_section = self.section
+            self.section = section[-1:]
+
         else:
             while (tuple(section) not in self.METH_DICT
                    and len(section) > 1):
                 ended.append(section.pop(-2))  # [a, b, c, d] -> [a, b, d]
             self.section = section
-                          
+
         result = None
 
         if prev_section:
@@ -136,7 +137,7 @@ class FFDirector(SectionLineParser):
         """
         Called once a section is finished. It appends the current_links list
         to the links and update the block dictionary with current_block. Thereby it
-        finishes the reading a given section. 
+        finishes the reading a given section.
 
         Parameters
         ---------
@@ -146,18 +147,16 @@ class FFDirector(SectionLineParser):
             The sections that have been ended.
         """
 
-        # type comparison is what makes this work!
-        
         if self.current_block is not None:
-           self.current_block.make_edges_from_interactions()
-           self.force_field.blocks[self.current_block.name] =  self.current_block
+            self.current_block.make_edges_from_interactions()
+            self.force_field.blocks[self.current_block.name] = self.current_block
 
         if self.current_link is not None:
-           self.current_link.make_edges_from_interactions()
-           self.force_field.links.append(self.current_link)
+            self.current_link.make_edges_from_interactions()
+            self.force_field.links.append(self.current_link)
 
         if self.current_modification is not None:
-           self.force_field.modifications[self.current_modification.name] = self.current_modification
+            self.force_field.modifications[self.current_modification.name] = self.current_modification
 
     def get_context(self, context_type):
         possible_contexts = {
@@ -279,44 +278,44 @@ class FFDirector(SectionLineParser):
 
     @SectionLineParser.section_parser('moleculetype', 'dihedrals', context_type='block')
     def _dih_interactions(self, line, lineno=0, context_type=''):
-          context = self.get_context(context_type)
-          interaction_name = self.section[-1]
-          delete = False
-          tokens = collections.deque(_tokenize(line))
-          if tokens[0] == '#meta':
-              _parse_meta(
-                  tokens,
-                  context,
-                  context_type=context_type,
-                  section=interaction_name,
-              )
-          else:
-              n_atoms = self.interactions_natoms.get(interaction_name)
-              _base_parser(
-                  tokens,
-                  context,
-                  context_type=context_type,
-                  section=interaction_name,
-                  natoms=n_atoms,
-                  delete=delete,
-              )
-    
+        context = self.get_context(context_type)
+        interaction_name = self.section[-1]
+        delete = False
+        tokens = collections.deque(_tokenize(line))
+        if tokens[0] == '#meta':
+            _parse_meta(
+                tokens,
+                context,
+                context_type=context_type,
+                section=interaction_name,
+            )
+        else:
+            n_atoms = self.interactions_natoms.get(interaction_name)
+            _base_parser(
+                tokens,
+                context,
+                context_type=context_type,
+                section=interaction_name,
+                natoms=n_atoms,
+                delete=delete,
+            )
+
           # Because of how they are described in gromacs, proper and improper
           # dihedral angles are all under the [ dihedrals ] section. However
           # the way they are treated differently in the library, at least on how
           # they generate edges. Here we move the all the impropers into their own
           # [ impropers ] section.
-    
-          propers = []
-          impropers = []
-          for dihedral in self.current_block.interactions.get('dihedrals', []):
-              if dihedral.parameters and dihedral.parameters[0] == '2':
-                  impropers.append(dihedral)
-              else:
-                  propers.append(dihedral)
-    
-          self.current_block.interactions['dihedrals'] = propers
-          self.current_block.interactions['impropers'] = impropers
+
+        propers = []
+        impropers = []
+        for dihedral in self.current_block.interactions.get('dihedrals', []):
+            if dihedral.parameters and dihedral.parameters[0] == '2':
+                impropers.append(dihedral)
+            else:
+                propers.append(dihedral)
+
+        self.current_block.interactions['dihedrals'] = propers
+        self.current_block.interactions['impropers'] = impropers
 
 
     @SectionLineParser.section_parser('moleculetype', 'patterns')
@@ -800,7 +799,7 @@ def _parse_block_atom(tokens, context):
 def _parse_link_atom(tokens, context, defaults=None, treat_prefix=True):
     if len(tokens) > 2:
         raise IOError('Unexpected column in link atom definition.')
-    elif len(tokens) < 2:
+    if len(tokens) < 2:
         raise IOError('Missing column in link atom definition.')
     reference = tokens[0]
     if defaults is None:
@@ -831,7 +830,7 @@ def _parse_link_atom(tokens, context, defaults=None, treat_prefix=True):
 def _parse_link_attribute(tokens, context, section):
     if len(tokens) > 2:
         raise IOError('Unexpected column in section "{}".'.format(section))
-    elif len(tokens) < 2:
+    if len(tokens) < 2:
         raise IOError('Missing column in section "{}".'.format(section))
     key, value = tokens
     if '|' in value:
@@ -873,7 +872,7 @@ def _parse_meta(tokens, context, context_type, section):
         msg = ('Unexpected column when defining meta attributes for section '
                '"{}" of a {}. {} tokens read instead of 2.')
         raise IOError(msg.format(section, context_type, len(tokens)))
-    elif len(tokens) < 2:
+    if len(tokens) < 2:
         msg = 'Missing column when defining meta attributes for section "{}" of a {}.'
         raise IOError(msg.format(section, context_type))
     attributes = json.loads(tokens[-1])
@@ -915,7 +914,7 @@ def _parse_patterns(tokens, context, context_type):
 def _parse_variables(tokens, force_field, section):
     if len(tokens) > 2:
         raise IOError('Unexpected column in section "{}".'.format(section))
-    elif len(tokens) < 2:
+    if len(tokens) < 2:
         raise IOError('Missing column in section "{}".'.format(section))
     key, value = tokens
     try:

--- a/vermouth/tests/test_ff_files.py
+++ b/vermouth/tests/test_ff_files.py
@@ -41,7 +41,7 @@ class TestBlock:
         lines = """
             [ moleculetype ]
             GLY  3
-            
+
             [ moleculetype ]
             VAL 2
             """
@@ -684,26 +684,6 @@ class TestLink:
             ]},
             (),
         ),
-     #  (  # Unknown interaction that does not add an edge
-     #      """
-     #      [link]
-     #      [unknown_interaction]
-     #      BB SC1 SC2
-     #      """,
-     #      (
-     #          ('BB', {'atomname': 'BB', 'order': 0}),
-     #          ('SC1', {'atomname': 'SC1', 'order': 0}),
-     #          ('SC2', {'atomname': 'SC2', 'order': 0}),
-     #      ),
-     #      {'unknown_interaction': [
-     #          vermouth.molecule.Interaction(
-     #              atoms=['BB', 'SC1', 'SC2'],
-     #              parameters=[],
-     #              meta={},
-     #          ),
-     #      ]},
-     #      (),
-     #  ),
         (  # Atom already in the link
             """
             [link]
@@ -802,6 +782,37 @@ class TestLink:
         assert link.interactions == interactions
         assert (set(frozenset(edge) for edge in link.edges)
                 == set(frozenset(edge) for edge in edges))
+
+
+    @staticmethod
+    def test_number_of_links():
+        """
+        Links are stored in a list so unlike blocks
+        they are not overwritten when they are returned
+        from the parsers. Thus we should check not only
+        that the expected links are in but also how many
+        there are.
+        """
+        lines="""
+        [ moleculetype ]
+        GLY 1
+        [ atoms ]
+        1 P4 1 ALA BB 1
+        [ link ]
+        [ bonds ]
+        BB +BB params
+        BB SC1 params
+        [ angles ]
+        BB +BB ++BB params
+        [ link ]
+        [ bonds ]
+        BB SC2 params
+        """
+        lines = textwrap.dedent(lines).splitlines()
+        ff = vermouth.forcefield.ForceField(name='test_ff')
+        vermouth.ffinput.read_ff(lines, ff)
+
+        assert len(ff.links) == 2
 
     @staticmethod
     def test_negative_interactions():
@@ -1293,3 +1304,5 @@ def test_misformed_lines(lines):
     ff = vermouth.forcefield.ForceField(name='test_ff')
     with pytest.raises(IOError):
         vermouth.ffinput.read_ff(lines, ff)
+
+


### PR DESCRIPTION
Fix to issue #243  and some light linting. There are still quite some unused variables and overwritten functions and stuff pylint complains about. But that would require linting all parsers starting with the parser_utilities and then all sub-classes thereof. 

@pckroon Shall I make a separate issue? 