### PR TITLE
Fix doc build failure

### DIFF
--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -56,7 +56,6 @@ class ForceField:
     renamed_residues: dict
     name: str
     variables: dict
-    reference_graphs: dict
     """
 
     def __init__(self, directory=None, name=None):

--- a/vermouth/ismags.py
+++ b/vermouth/ismags.py
@@ -555,8 +555,6 @@ class ISMAGS:
         """
         Does the same as :meth:`find_isomorphisms` if :attr:`graph` and
         :attr:`subgraph` have the same number of nodes.
-
-        .. automethod:: find_isomorphisms
         """
         if len(self.graph) == len(self.subgraph):
             yield from self.subgraph_isomorphisms_iter(symmetry=symmetry)
@@ -564,8 +562,6 @@ class ISMAGS:
     def subgraph_isomorphisms_iter(self, symmetry=True):
         """
         Alternative name for :meth:`find_isomorphisms`.
-
-        .. automethod:: find_isomorphisms
         """
         return self.find_isomorphisms(symmetry)
 

--- a/vermouth/map_parser.py
+++ b/vermouth/map_parser.py
@@ -54,8 +54,6 @@ class Mapping:
         :attr:`blocks_from` to what node key in :attr:`blocks_to` it
         contributes to with what weight.
         ``{node_from: {node_to: weight, ...}, ...}``.
-    reverse_mapping: dict[collections.abc.Hashable, dict[collections.abc.Hashable, float]]
-        .. autoattribute:: reverse_mapping
 
     Note
     ----

--- a/vermouth/map_parser.py
+++ b/vermouth/map_parser.py
@@ -471,15 +471,6 @@ class MappingDirector(SectionLineParser):
 
     Attributes
     ----------
-    RESNAME_NUM_SEP: str
-        The character that separates a resname from a resnumber in shorthand
-        block formats.
-    RESIDUE_ATOM_SET: str
-        The character that separates a residue identifier from an atomname.
-    COMMENT_CHAR: str
-        The character that starts a comment.
-    NO_FETCH_BLOCK: str
-        The character that specifies no block should be fetched automatically.
     builder
         The builder used to build the :class:`Mapping` object. By default
         :class:`MappingBuilder`.
@@ -499,9 +490,16 @@ class MappingDirector(SectionLineParser):
         A dictionary of known macros.
     """
     RESNAME_NUM_SEP = '#'
+    """
+    The character that separates a resname from a resnumber in shorthand block
+    formats.
+    """
     RESIDUE_ATOM_SEP = ':'
+    """The character that separates a residue identifier from an atomname."""
     COMMENT_CHAR = ';'
+    """The character that starts a comment."""
     NO_FETCH_BLOCK = '!'
+    """The character that specifies no block should be fetched automatically."""
     SECTION_ENDS = ['block', 'modification']
 
     def __init__(self, force_fields, builder=None):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -164,16 +164,11 @@ class LinkParameterEffector:
     instance will be validated against that number; else, the user can pass an
     arbitrary number of keys without validation.
 
-    Attributes
-    ----------
-    n_keys_asked: int
-        Class attribute describing the number of keys required.
-
-
     .. automethod:: __call__
     .. automethod:: _apply
     """
     n_keys_asked = None
+    """Class attribute describing the number of keys required."""
 
     def __init__(self, keys, format_spec=None):
         """
@@ -928,11 +923,6 @@ class Block(Molecule):
     ----------
     name: str or None
         The name of the residue. Set to `None` if undefined.
-    atoms: collections.abc.Iterator[dict]
-        The atoms in the residue. Each atom is a dict with *a minima* a key
-        'name' for the name of the atom, and a key 'atype' for the atom type.
-        An atom can also have a key 'charge', 'charge_group', 'comment', or any
-        arbitrary key.
     interactions: dict
         All the known interactions. Each item of the dictionary is a type of
         interaction, with the key being the name of the kind of interaction
@@ -998,6 +988,16 @@ class Block(Molecule):
 
     @property
     def atoms(self):
+        """"
+        The atoms in the residue. Each atom is a dict with *a minima* a key
+        'name' for the name of the atom, and a key 'atype' for the atom type.
+        An atom can also have a key 'charge', 'charge_group', 'comment', or any
+        arbitrary key.
+
+        Returns
+        -------
+        collections.abc.Iterator[dict]
+        """
         for node in self.nodes():
             node_attr = self.nodes[node]
             # In pre-blocks, some nodes correspond to particles in neighboring

--- a/vermouth/parser_utils.py
+++ b/vermouth/parser_utils.py
@@ -152,10 +152,13 @@ class SectionLineParser(LineParser, metaclass=SectionParser):
         The current section.
     macros: dict[str, str]
         A set of subsitution rules as parsed from a `macros` section.
-    METH_DICT: dict[tuple[str], tuple[collections.abc.Callable, dict[str]]]
-        A dict of all known parser methods, mapping section names to the
-        function to be called and the associated keyword arguments.
     """
+    METH_DICT = {}
+    """
+    A dict of all known parser methods, mapping section names to the
+    function to be called and the associated keyword arguments.
+    """
+
     def __init__(self, *args, **kwargs):
         self.macros = {}
         self.section = []


### PR DESCRIPTION
Docs failed due to duplicate description of `reference_graphs` attribute: once in the class docstring, and once in the property docstring.