### PR TITLE
fix dihedral treatment

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -360,14 +360,14 @@ class FFDirector(SectionLineParser):
 
         propers = []
         impropers = []
-        for dihedral in self.current_block.interactions.get('dihedrals', []):
+        for dihedral in context.interactions.get('dihedrals', []):
             if dihedral.parameters and dihedral.parameters[0] == '2':
                 impropers.append(dihedral)
             else:
                 propers.append(dihedral)
 
-        self.current_block.interactions['dihedrals'] = propers
-        self.current_block.interactions['impropers'] = impropers
+        context.interactions['dihedrals'] = propers
+        context.interactions['impropers'] = impropers
 
 
     @SectionLineParser.section_parser('moleculetype', 'patterns')


### PR DESCRIPTION
Yet another parser issue. Link dihedrals are added to the last block in addition to themselves instead of as dihedrals and impropers to the link interaction. I fixed it. As far as I can tell it works now. But we really should compare some protein itps to previous versions. This issue only exists since the last fix and reshuffling of the dihedral treatment that is PR #251 .