### PR TITLE
First round of optimizations

### DIFF
--- a/vermouth/graph_utils.py
+++ b/vermouth/graph_utils.py
@@ -242,10 +242,13 @@ def make_residue_graph(graph, attrs=('chain', 'resid', 'resname', 'insertion_cod
     # Create partitions. These will contain all nodes, even those without e.g.
     # a resname, since those will get resname None
     residue_idxs = collect_residues(graph, attrs)
+    res_graph = partition_graph(graph, residue_idxs.values())
+    # Alternatively we can use nx.quotient_graph, but that slows down the
+    # program for large-ish molecules, since quotient_graph scales as O(N^2).
+    # Our partition_graph scales much better, as O(E*N) (number of edges, nodes)
     # res_graph = nx.quotient_graph(graph,
     #                               sorted(residue_idxs.values(), key=min),
     #                               relabel=True)
-    res_graph = partition_graph(graph, residue_idxs.values())
     # Using this equivalence function rather than the preformed partitions
     # Creates an equivalent graph, but the node indices are numbered
     # differently. At the very least it would require a change in the tests.

--- a/vermouth/graph_utils.py
+++ b/vermouth/graph_utils.py
@@ -179,7 +179,7 @@ def get_attrs(node, attrs):
 def partition_graph(graph, partitions):
     """
     Create a new graph based on `graph`, where nodes are aggregated based on
-    `partitions`, similar to :func:`~networkx.algorithm.minors.quotient_graph`,
+    `partitions`, similar to :func:`~networkx.algorithms.minors.quotient_graph`,
     except that it only accepts pre-made partitions, and edges are not given
     a 'weight' attribute. Much fast than the quotient_graph, since it creates
     edges based on existing edges rather than trying all possible combinations.

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -109,18 +109,19 @@ def _bonds_from_distance(graph, nodes=None, non_edges=None, fudge=1.0):
     else:
         pairs = {}
 
+    nodes = graph.nodes
     for (idx1, idx2), dist in pairs.items():
         if idx1 >= idx2:
             continue
         node_idx1 = idx_to_nodenum[idx1]
         node_idx2 = idx_to_nodenum[idx2]
-        atom1 = graph.nodes[node_idx1]
-        atom2 = graph.nodes[node_idx2]
-        element1 = atom1['element']
-        element2 = atom2['element']
 
         if frozenset((node_idx1, node_idx2)) in non_edges:
             continue
+        atom1 = nodes[node_idx1]
+        atom2 = nodes[node_idx2]
+        element1 = atom1['element']
+        element2 = atom2['element']
 
         bond_distance = 0.5 * (VDW_RADII[element1] + VDW_RADII[element2])
         if dist <= bond_distance * fudge and not graph.has_edge(node_idx1, node_idx2):

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -94,7 +94,11 @@ def _bonds_from_distance(graph, nodes=None, non_edges=None, fudge=1.0):
             if subn in nodes and graph.nodes[subn].get('element') in VDW_RADII
         )
     }
-    max_dist = max(VDW_RADII.values()) * fudge
+    if idx_to_nodenum:
+        max_dist = max(VDW_RADII[graph.nodes[idx]['element']] for idx in idx_to_nodenum.values())
+    else:
+        max_dist = 0
+    max_dist *= fudge
 
     positions = np.array([
         graph.nodes[node]['position']

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -94,6 +94,8 @@ def _bonds_from_distance(graph, nodes=None, non_edges=None, fudge=1.0):
             if subn in nodes and graph.nodes[subn].get('element') in VDW_RADII
         )
     }
+    # Guard against the case where there are no atoms with known elements, which
+    # max does *not* like.
     if idx_to_nodenum:
         max_dist = max(VDW_RADII[graph.nodes[idx]['element']] for idx in idx_to_nodenum.values())
     else:

--- a/vermouth/tests/test_graph_utils.py
+++ b/vermouth/tests/test_graph_utils.py
@@ -365,7 +365,7 @@ def test_rate_match(nodes1, nodes2, match, expected):
         {(0, 1): {}},
         [{'chain': 0, 'resid': 2, 'resname': 1, 'attr': 5},
          {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
-        {(0, 1): {'weight': 1}}
+        {(0, 1): {}}
     ),
     (
         [{'chain': 0, 'resid': 2, 'resname': 1, 'attr': 5},
@@ -374,7 +374,7 @@ def test_rate_match(nodes1, nodes2, match, expected):
         {(2, 1): {}},
         [{'chain': 0, 'resid': 2, 'resname': 1},
          {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
-        {(0, 1): {'weight': 1}}
+        {(0, 1): {}}
     ),
 ])
 def test_make_residue_graph(nodes1, edges1, nodes2, edges2):


### PR DESCRIPTION
This PR reduces runtime from >6 minutes to <1 minute on my laptop, using the protein from #256. 
Currently the slowest thing is the isomorphism in do_mapping. We can probably do something clever there as well, by checking whether any of the mappings cross residue boundaries, and simplifying the problem from there (per residue isomorphism, or even mapping by atom name). But that's significantly more work. 