### PR TITLE
add newline after writing gro file

### DIFF
--- a/vermouth/gmx/gro.py
+++ b/vermouth/gmx/gro.py
@@ -159,3 +159,5 @@ def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0)
                 out.write(line + '\n')
         # Box
         out.write(' '.join(str(value) for value in box))
+        # to appease VMD which cannot read the file otherwise.
+        out.write('\n')

--- a/vermouth/tests/gmx/test_gro.py
+++ b/vermouth/tests/gmx/test_gro.py
@@ -206,6 +206,7 @@ def write_ref_gro(outfile, velocities=False, box='10.0 10.0 10.0'):
         outfile.write(('{}{:8.3f}{:8.3f}{:8.3f}' + velocity_fmt + '\n')
                       .format(atom, *itertools.chain(coords, vels)))
     outfile.write(box)
+    outfile.write('\n')
 
 
 def build_ref_molecule(velocities=False):


### PR DESCRIPTION
I added as default behavior that the gro file has a newline after the box line. This will make sure VMD can directly open the file. Note that we will however not be able to trajectory files. But I think we don't do trajectories anyways.