### PR TITLE
Fix mistakes in martini22p and elnedyn data files

### DIFF
--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -529,7 +529,9 @@ TRP                1
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
    1     2    3       2   142.000   30.0 
-   1     2    5       2   143.000   30.0  
+   1     2    5       2   143.000   20.0
+   1     2    4       2   104.000   50.0
+
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.

--- a/vermouth/data/force_fields/elnedyn/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn/aminoacids.ff
@@ -605,25 +605,3 @@ resname "CYS"
 SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
-
-;; Protein terminii. These links should be applied last.
-[ link ]
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qd", "charge": 1}}
-[ non-edges ]
-BB -BB
-
-[ link ]
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qa", "charge": -1}}
-[ non-edges ]
-BB +BB
-

--- a/vermouth/data/force_fields/elnedyn/modifications.ff
+++ b/vermouth/data/force_fields/elnedyn/modifications.ff
@@ -1,0 +1,24 @@
+[ modification ]
+C-ter
+[ atoms ]
+BB {"replace": {"atype": "Qa", "charge": -1}}
+
+[ modification ]
+N-ter
+[ atoms ]
+BB {"replace": {"atype": "Qd", "charge": 1}}
+
+[ modification ]
+zwitter
+[ atoms ]
+BB {"replace": {"atype": "Qda"}}
+
+[ modification ]
+COOH-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}
+
+[ modification ]
+NH2-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -604,25 +604,3 @@ resname "CYS"
 SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
-
-;; Protein terminii. These links should be applied last.
-[ link ]
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qd", "charge": 1}}
-[ non-edges ]
-BB -BB
-
-[ link ]
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qa", "charge": -1}}
-[ non-edges ]
-BB +BB
-

--- a/vermouth/data/force_fields/elnedyn22/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22/aminoacids.ff
@@ -529,7 +529,8 @@ TRP                1
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
    1     2    3       2   142.000   30.0 
-   1     2    5       2   143.000   30.0  
+   1     2    5       2   143.000   20.0
+   1     2    4       2   104.000   50.0
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.

--- a/vermouth/data/force_fields/elnedyn22/modifications.ff
+++ b/vermouth/data/force_fields/elnedyn22/modifications.ff
@@ -1,0 +1,24 @@
+[ modification ]
+C-ter
+[ atoms ]
+BB {"replace": {"atype": "Qa", "charge": -1}}
+
+[ modification ]
+N-ter
+[ atoms ]
+BB {"replace": {"atype": "Qd", "charge": 1}}
+
+[ modification ]
+zwitter
+[ atoms ]
+BB {"replace": {"atype": "Qda"}}
+
+[ modification ]
+COOH-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}
+
+[ modification ]
+NH2-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -667,24 +667,3 @@ SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 
-;; Protein terminii. These links should be applied last.
-[ link ]
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qd", "charge": 1}}
-[ non-edges ]
-BB -BB
-
-[ link ]
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qa", "charge": -1}}
-[ non-edges ]
-BB +BB
-

--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -591,7 +591,8 @@ TRP                1
 #meta {"group": "Side chain angles"}
 ;  i     j    k     funct   angle  force.c.
    1     2    3       2   142.000   30.0 
-   1     2    5       2   143.000   30.0  
+   1     2    5       2   143.000   20.0
+   1     2    4       2   104.000   50.0
 
 [dihedrals]
 ;  i     j    k    l   funct   angle  force.c.

--- a/vermouth/data/force_fields/elnedyn22p/modifications.ff
+++ b/vermouth/data/force_fields/elnedyn22p/modifications.ff
@@ -1,0 +1,24 @@
+[ modification ]
+C-ter
+[ atoms ]
+BB {"replace": {"atype": "Qa", "charge": -1}}
+
+[ modification ]
+N-ter
+[ atoms ]
+BB {"replace": {"atype": "Qd", "charge": 1}}
+
+[ modification ]
+zwitter
+[ atoms ]
+BB {"replace": {"atype": "Qda"}}
+
+[ modification ]
+COOH-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}
+
+[ modification ]
+NH2-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -884,29 +884,6 @@ SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 
-;; Protein terminii. These links should be applied last.
-[ link ]
-resname $protein_resnames
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qd", "charge": 1}}
-[ non-edges ]
-BB -BB
-
-[ link ]
-resname $protein_resnames
-[ molmeta ]
-neutral_termini not(true)
-[ features ]
-neutral_termini
-[ atoms ]
-BB {"replace": {"atype": "Qa", "charge": -1}}
-[ non-edges ]
-BB +BB
-
 ; Exclusions between the charged terminii and the charge dummies
 [ link ]
 resname $protein_resnames

--- a/vermouth/data/force_fields/martini22p/modifications.ff
+++ b/vermouth/data/force_fields/martini22p/modifications.ff
@@ -1,0 +1,24 @@
+[ modification ]
+C-ter
+[ atoms ]
+BB {"replace": {"atype": "Qa", "charge": -1}}
+
+[ modification ]
+N-ter
+[ atoms ]
+BB {"replace": {"atype": "Qd", "charge": 1}}
+
+[ modification ]
+zwitter
+[ atoms ]
+BB {"replace": {"atype": "Qda"}}
+
+[ modification ]
+COOH-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}
+
+[ modification ]
+NH2-ter
+[ atoms ]
+BB {"replace": {"atype": "P5", "charge": 0}}

--- a/vermouth/data/mappings/elnedyn/elnedyn22/modifications.mapping
+++ b/vermouth/data/mappings/elnedyn/elnedyn22/modifications.mapping
@@ -1,0 +1,107 @@
+[ modification ]
+[ from ]
+universal
+[ to ]
+elnedyn22
+
+[ from blocks ]
+C-ter
+[ to blocks ]
+C-ter
+
+[ from nodes ]
+N
+HN
+
+[ from edges ]
+HN N
+N CA
+
+[ mapping ]
+CA BB
+C  BB 0
+O  BB 0
+OXT BB 0
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+elnedyn22
+[ from blocks ]
+N-ter
+[ to blocks ]
+N-ter
+
+[ from nodes ]
+C
+O
+
+[ from edges ]
+C O
+CA C
+
+[ mapping ]
+HN1 BB 0
+HN2 BB 0
+HN3 BB 0
+N   BB 0
+CA  BB
+C   BB 0
+O   BB 0
+
+[ modification ]
+[ from ]
+universal
+[ to ]
+elnedyn22
+
+[ from blocks ]
+COOH-ter
+[ to blocks ]
+COOH-ter
+
+[ from nodes ]
+N
+HN
+
+[ from edges ]
+HN N
+N CA
+
+[ mapping ]
+HN BB 0
+N BB 0
+CA BB
+C  BB 0
+O  BB 0
+HO BB 0
+OXT BB 0
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+elnedyn22
+[ from blocks ]
+NH2-ter
+[ to blocks ]
+NH2-ter
+
+[ from nodes ]
+C
+O
+
+[ from edges ]
+C O
+CA C
+
+[ mapping ]
+HN1 BB 0
+HN2 BB 0
+N   BB 0
+CA  BB
+C   BB 0
+O   BB 0

--- a/vermouth/data/mappings/elnedyn/elnedyn22p/modifications.mapping
+++ b/vermouth/data/mappings/elnedyn/elnedyn22p/modifications.mapping
@@ -1,0 +1,107 @@
+[ modification ]
+[ from ]
+universal
+[ to ]
+elnedyn22p
+
+[ from blocks ]
+C-ter
+[ to blocks ]
+C-ter
+
+[ from nodes ]
+N
+HN
+
+[ from edges ]
+HN N
+N CA
+
+[ mapping ]
+CA BB
+C  BB 0
+O  BB 0
+OXT BB 0
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+elnedyn22p
+[ from blocks ]
+N-ter
+[ to blocks ]
+N-ter
+
+[ from nodes ]
+C
+O
+
+[ from edges ]
+C O
+CA C
+
+[ mapping ]
+HN1 BB 0
+HN2 BB 0
+HN3 BB 0
+N   BB 0
+CA  BB
+C   BB 0
+O   BB 0
+
+[ modification ]
+[ from ]
+universal
+[ to ]
+elnedyn22p
+
+[ from blocks ]
+COOH-ter
+[ to blocks ]
+COOH-ter
+
+[ from nodes ]
+N
+HN
+
+[ from edges ]
+HN N
+N CA
+
+[ mapping ]
+HN BB 0
+N BB 0
+CA BB
+C  BB 0
+O  BB 0
+HO BB 0
+OXT BB 0
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+elnedyn22p
+[ from blocks ]
+NH2-ter
+[ to blocks ]
+NH2-ter
+
+[ from nodes ]
+C
+O
+
+[ from edges ]
+C O
+CA C
+
+[ mapping ]
+HN1 BB 0
+HN2 BB 0
+N   BB 0
+CA  BB
+C   BB 0
+O   BB 0

--- a/vermouth/data/mappings/elnedyn/modifications.mapping
+++ b/vermouth/data/mappings/elnedyn/modifications.mapping
@@ -1,0 +1,107 @@
+[ modification ]
+[ from ]
+universal
+[ to ]
+elnedyn
+
+[ from blocks ]
+C-ter
+[ to blocks ]
+C-ter
+
+[ from nodes ]
+N
+HN
+
+[ from edges ]
+HN N
+N CA
+
+[ mapping ]
+CA BB
+C  BB 0
+O  BB 0
+OXT BB 0
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+elnedyn
+[ from blocks ]
+N-ter
+[ to blocks ]
+N-ter
+
+[ from nodes ]
+C
+O
+
+[ from edges ]
+C O
+CA C
+
+[ mapping ]
+HN1 BB 0
+HN2 BB 0
+HN3 BB 0
+N   BB 0
+CA  BB
+C   BB 0
+O   BB 0
+
+[ modification ]
+[ from ]
+universal
+[ to ]
+elnedyn
+
+[ from blocks ]
+COOH-ter
+[ to blocks ]
+COOH-ter
+
+[ from nodes ]
+N
+HN
+
+[ from edges ]
+HN N
+N CA
+
+[ mapping ]
+HN BB 0
+N BB 0
+CA BB
+C  BB 0
+O  BB 0
+HO BB 0
+OXT BB 0
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+elnedyn
+[ from blocks ]
+NH2-ter
+[ to blocks ]
+NH2-ter
+
+[ from nodes ]
+C
+O
+
+[ from edges ]
+C O
+CA C
+
+[ mapping ]
+HN1 BB 0
+HN2 BB 0
+N   BB 0
+CA  BB
+C   BB 0
+O   BB 0

--- a/vermouth/data/mappings/elnedyn/thr.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/thr.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+THR
+
 [ martini ]
 BB SC1
 
@@ -21,9 +24,6 @@ universal
 [to]
 elnedyn
 elnedyn22
-
-[ molecule ]
-THR
 
 [ mapping ]
 charmm27 charmm36

--- a/vermouth/data/mappings/elnedyn/val.charmm36.map
+++ b/vermouth/data/mappings/elnedyn/val.charmm36.map
@@ -12,6 +12,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+[ molecule ]
+VAL
+
 [from]
 universal
 
@@ -19,9 +22,6 @@ universal
 elnedyn
 elnedyn22
 elnedyn22p
-
-[ molecule ]
-VAL
 
 [ martini ]
 BB SC1
@@ -38,17 +38,3 @@ charmm27 charmm36
    12   CG2   SC1
    16    C    !BB
    17    O    !BB
-
-[ chiral ]
-  CB     CA    N    C
-  HB     CA    N    C
-
-[ chiral ]
-  HA     CA    N    CB    C ; L-Val
-; HA     CA    N    C    CB ; D-Val
-
-[ out ]
-  CG2  CB CG1 CA
-  HG21 CB CG1 CA
-  HG22 CB CG1 CA
-  HG23 CB CG1 CA

--- a/vermouth/data/mappings/modifications.mapping
+++ b/vermouth/data/mappings/modifications.mapping
@@ -105,3 +105,101 @@ N   BB
 CA  BB
 C   BB
 O   BB
+
+;################
+;# Martini 2.2p #
+;################
+
+[ modification ]
+[ from ]
+universal
+[ to ]
+martini22p
+[ from blocks ]
+C-ter
+[ to blocks ]
+C-ter
+[ from nodes ]
+N
+HN
+[ from edges ]
+HN N
+N CA
+[ mapping ]
+CA BB
+C  BB
+O  BB
+OXT BB
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+martini22p
+[ from blocks ]
+N-ter
+[ to blocks ]
+N-ter
+[ from nodes ]
+C
+O
+[ from edges ]
+C O
+CA C
+[ mapping ]
+HN1 BB
+HN2 BB
+HN3 BB
+N   BB
+CA  BB
+C   BB
+O   BB
+
+[ modification ]
+[ from ]
+universal
+[ to ]
+martini22p
+[ from blocks ]
+COOH-ter
+[ to blocks ]
+COOH-ter
+[ from nodes ]
+N
+HN
+[ from edges ]
+HN N
+N CA
+[ mapping ]
+HN BB
+N BB
+CA BB
+C  BB
+O  BB
+HO BB
+OXT BB
+
+
+[modification]
+[ from ]
+universal
+[ to ]
+martini22p
+[ from blocks ]
+NH2-ter
+[ to blocks ]
+NH2-ter
+[ from nodes ]
+C
+O
+[ from edges ]
+C O
+CA C
+[ mapping ]
+HN1 BB
+HN2 BB
+N   BB
+CA  BB
+C   BB
+O   BB


### PR DESCRIPTION
These fixes come from the integration tests branch, and fix a few mistakes in the martini22p and elnedyn data files. In particular, it moves termini to be modifications (+ associated mappings), fixes the mappings for elnedyn thr and val, and corrects a sidechain angle for elnedyn trp.

Fixes #264
Fixes #265