### PR TITLE
Fix for DNA termini modifications

### DIFF
--- a/vermouth/map_parser.py
+++ b/vermouth/map_parser.py
@@ -722,6 +722,21 @@ class MappingDirector(SectionLineParser):
                 fetch = False
             if fetch and attrs.get('resname') is not None:
                 block = getattr(self.force_fields[self.ff[direction]], map_type+'s')[attrs['resname']]
+                if map_type == 'modification':
+                    # Add the modifications to the mapping block_from, so they
+                    # participate in the matching criterion.
+
+                    # Caveat emptor
+                    ###############
+                    # Copying the modification here before modifying it would be
+                    # a *good* idea, but that doesn't work (probably because
+                    # Links don't have a sane copy method). Better than this
+                    # would be to add the modifications attribute at the ff
+                    # parser level. This hack-around (and adding it to the ff
+                    # parser) probably have unintended side effects.
+                    # block = block.copy()
+                    for idx in block.nodes:
+                        block.nodes[idx]['modifications'] = [block]
                 builder_methods[direction](block)
             if direction == 'from':
                 if 'resname' in attrs and isinstance(attrs['resname'], str):

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -139,18 +139,25 @@ def node_should_exist(modification, node_idx):
     return not modification.nodes[node_idx].get('PTM_atom', False)
 
 
-def ptm_resname_match(node1, node2):
+def ptm_resname_match(mol_node, map_node):
     """
     As :func:`node_matcher`, except that empty resname and false PTM_atom
     attributes from `node2` are removed.
     """
-    if 'resname' in node2 and not node2['resname']:
-        node2 = node2.copy()
-        del node2['resname']
-    if 'PTM_atom' in node2 and not node2['PTM_atom']:
-        del node2['PTM_atom']
-    is_equal = node_matcher(node1, node2)
-    return is_equal
+    if 'resname' in map_node and not map_node['resname']:
+        map_node = map_node.copy()
+        del map_node['resname']
+    if 'PTM_atom' in map_node and not map_node['PTM_atom']:
+        map_node = map_node.copy()
+        del map_node['PTM_atom']
+    if 'modifications' in mol_node:
+        map_node = map_node.copy()
+        matching_mod = all(map_mod in mol_node.get('modifications', [])
+                           for map_mod in map_node.pop('modifications', []))
+    else:
+        matching_mod = True
+    is_equal = node_matcher(mol_node, map_node)
+    return is_equal and matching_mod
 
 
 def cover(to_cover, options):

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -269,13 +269,7 @@ def modification_matches(molecule, mappings):
     # define most modifications at the same time get processed first
     for mod_name in sorted(needed_mod_mappings, key=len, reverse=True):
         mod_mapping = known_mod_mappings[mod_name]
-        # TODO: include modifications in matching criterion (just add it to the
-        #       modification from-block).
-        # For now, just make sure the intersection with the modified_nodes is
-        # not empty.
         for mol_to_mod, modification, references in mod_mapping.map(molecule, node_match=ptm_resname_match):
-            if not modified_nodes & set(mol_to_mod):
-                continue
             matches.append((mol_to_mod, modification, references))
             if not set(mol_to_mod) <= modified_nodes:
                 # TODO: better message
@@ -437,7 +431,7 @@ def apply_mod_mapping(match, molecule, graph_out, mol_to_out, out_to_mol):
             # Undefined loop variable is guarded against by the else-raise above
             mod_to_out[mod_idx] = out_idx  # pylint: disable=undefined-loop-variable
             graph_out.nodes[out_idx].update(modification.nodes[mod_idx].get('replace', {})) # pylint: disable=undefined-loop-variable
-        graph_out.nodes[out_idx]['modification'] = modification
+        graph_out.nodes[out_idx]['modifications'] = modification
 
     for mol_idx in mol_to_mod:
         for mod_idx, weight in mol_to_mod[mol_idx].items():
@@ -641,10 +635,8 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=()):
                 LOGGER.warning('The attributes {} for atom {} are going to'
                                ' be garbage.', attrs_not_sane, format_atom_string(graph_out.nodes[out_idx]),
                                type='inconsistent-data')
-
-        if graph_out[out_idx].get('atomname', '') is None:
+        if graph_out.nodes[out_idx].get('atomname', '') is None:
             to_remove.add(out_idx)
-
 
     # We need to add edges between residues. Within residues comes from the
     # blocks.

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -229,7 +229,9 @@ def modification_matches(molecule, mappings):
         A list with the following items:
             Dict describing the correspondence of node keys in `molecule` to
                 node keys in the modification.
+
             The modification.
+
             Dict with all reference atoms, mapping modification nodes to
                 nodes in `molecule`.
     """

--- a/vermouth/processors/repair_graph.py
+++ b/vermouth/processors/repair_graph.py
@@ -86,6 +86,13 @@ def _patch_modification(block, modification):
     anchor_mod_to_block = {val: key for key, val in anchor_block_to_mod.items()}
 
     result = Block(nx.union(block, non_anchor, rename=(None, modification.name+'-')))
+    # Mark the modified atoms with the specified modification, so canonicalize
+    # modifications has an easier job
+    for idx in anchor_block_to_mod:
+        result.nodes[idx]['modifications'] = [modification]
+    for mod_idx in non_anchor_idxs:
+        idx = '{}-{}'.format(modification.name, mod_idx)
+        result.nodes[idx]['modifications'] = [modification]
     for mod_idx, mod_jdx in modification.edges_between(anchor_idxs, non_anchor_idxs):
         if mod_idx in non_anchor_idxs:
             mod_idx, mod_jdx = mod_jdx, mod_idx

--- a/vermouth/processors/repair_graph.py
+++ b/vermouth/processors/repair_graph.py
@@ -89,10 +89,14 @@ def _patch_modification(block, modification):
     # Mark the modified atoms with the specified modification, so canonicalize
     # modifications has an easier job
     for idx in anchor_block_to_mod:
-        result.nodes[idx]['modifications'] = [modification]
+        node_mods = result.nodes[idx].get('modifications', [])
+        if modification not in node_mods:
+            result.nodes[idx]['modifications'] = node_mods + [modification]
     for mod_idx in non_anchor_idxs:
         idx = '{}-{}'.format(modification.name, mod_idx)
-        result.nodes[idx]['modifications'] = [modification]
+        node_mods = result.nodes[idx].get('modifications', [])
+        if modification not in node_mods:
+            result.nodes[idx]['modifications'] = node_mods + [modification]
     for mod_idx, mod_jdx in modification.edges_between(anchor_idxs, non_anchor_idxs):
         if mod_idx in non_anchor_idxs:
             mod_idx, mod_jdx = mod_jdx, mod_idx

--- a/vermouth/tests/test_do_mapping.py
+++ b/vermouth/tests/test_do_mapping.py
@@ -326,40 +326,40 @@ def modifications():
     """
     mods = {}
     mod_a = Link(force_field=FF_UNIVERSAL, name='mA')
-    mod_a.add_node('mA', atomname='mA', PTM_atom=True)
+    mod_a.add_node('mA', atomname='mA', PTM_atom=True, modifications=[mod_a])
     mods['mA'] = mod_a
 
     mod_c = Link(force_field=FF_UNIVERSAL, name='mC')
-    mod_c.add_node('mC', atomname='mC', PTM_atom=True)
+    mod_c.add_node('mC', atomname='mC', PTM_atom=True, modifications=[mod_c])
     mods['mC'] = mod_c
 
     mod_d = Link(force_field=FF_UNIVERSAL, name='mD')
-    mod_d.add_node('mD', atomname='mD', PTM_atom=True)
+    mod_d.add_node('mD', atomname='mD', PTM_atom=True, modifications=[mod_d])
     mods['mD'] = mod_d
 
     mod_fg = Link(force_field=FF_UNIVERSAL, name='mFG')
-    mod_fg.add_node('mF', atomname='mF', PTM_atom=True)
-    mod_fg.add_node('mG', atomname='mG', PTM_atom=True)
+    mod_fg.add_node('mF', atomname='mF', PTM_atom=True, modifications=[mod_fg])
+    mod_fg.add_node('mG', atomname='mG', PTM_atom=True, modifications=[mod_fg])
     mod_fg.add_edge('mF', 'mG')
     mod_fg.add_interaction('bond', ['mF', 'mG'], (3, 4))
     mods['mFG'] = mod_fg
 
     mod_i = Link(force_field=FF_UNIVERSAL, name='mI')
-    mod_i.add_node('mI', atomname='mI', PTM_atom=True)
+    mod_i.add_node('mI', atomname='mI', PTM_atom=True, modifications=[mod_i])
     mods['mI'] = mod_i
     mod_i2 = Link(force_field=FF_UNIVERSAL, name='mI2')
-    mod_i2.add_node('mI2', atomname='mI2', PTM_atom=True)
+    mod_i2.add_node('mI2', atomname='mI2', PTM_atom=True, modifications=[mod_i2])
     mods['mI2'] = mod_i2
 
     mod_j = Link(force_field=FF_UNIVERSAL, name='mJ')
-    mod_j.add_node('mJ', atomname='mJ', PTM_atom=True)
+    mod_j.add_node('mJ', atomname='mJ', PTM_atom=True, modifications=[mod_j])
     mods['mJ'] = mod_j
     mod_j2 = Link(force_field=FF_UNIVERSAL, name='mJ2')
-    mod_j2.add_node('mJ2', atomname='mJ2', PTM_atom=True)
+    mod_j2.add_node('mJ2', atomname='mJ2', PTM_atom=True, modifications=[mod_j2])
     mods['mJ2'] = mod_j2
     mod = Link(name=('mJ', 'mJ2'), force_field=FF_UNIVERSAL)
-    mod.add_nodes_from((['mJ', {'atomname': 'mJ', 'PTM_atom': True}],
-                        ['mJ2', {'atomname': 'mJ2', 'PTM_atom': True}],
+    mod.add_nodes_from((['mJ', {'atomname': 'mJ', 'PTM_atom': True, 'modifications': [mods['mJ']]}],
+                        ['mJ2', {'atomname': 'mJ2', 'PTM_atom': True, 'modifications': [mods['mJ2']]}],
                         ['J', {'atomname': 'J', 'PTM_atom': False}]))
     mod.add_edges_from([('J', 'mJ'), ('J', 'mJ2')])
     mods[('mJ', 'mJ2')] = mod


### PR DESCRIPTION
Paulo found an issue when he tried to make DNA termini modifications. In particular, these modifications did not add any PTM_atoms, breaking several assumptions.
The first commit makes sure that any CLI annotations regarding modifications are picked up by canonicalize_modifications, and later on do_mapping.
The second commit fixes an open TODO in the do_mapping processor, so that the modifications attribute now is a part of the matching criteria. Otherwise I'd have modification mappings applying multiple times.

This is still a draft, since the second commit broke some tests in do_mapping. I'm not sure yet this is harmless, nor how to fix them.