### PR TITLE
Limit the line length for the command in the top

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -686,9 +686,17 @@ def entry():
         LOGGER.debug("Writing molecule {}.", molecule, type='step')
 
     # Write the topology if requested
+    # grompp has a limit in the number of character it can read per line
+    # (due to the size limit of a buffer somewhere in its implementation).
+    # The command line can be longer than this limit and therefore
+    # prevent grompp from reading the topology.
+    gromacs_char_limit = 4000  # the limit is actually 4095, but I play safe
+    command = ' '.join(sys.argv)
+    if len(command) > gromacs_char_limit:
+        command = command[:gromacs_char_limit] + ' ...'
     header = [
         'This file was generated using the following command:',
-        ' '.join(sys.argv),
+        command,
         VERSION,
     ]
     if None not in ss_sequence:


### PR DESCRIPTION
Martinize2 writes the command it has been invoked with in
the header of the TOP file it writes. If that command is too
long, then it can pass the maximum line length that grompp
can read.

This commit truncate the command if it passes the limit.