### PR TITLE
Unflake hypothesis tests

### DIFF
--- a/vermouth/tests/molecule_strategies.py
+++ b/vermouth/tests/molecule_strategies.py
@@ -21,6 +21,13 @@ from vermouth.molecule import Interaction, Molecule, Block, Link, DeleteInteract
 
 # pylint: disable=no-value-for-parameter
 
+# This is a strategy that creates "sane" names. It's currently used to generate
+# interaction type names, and molecule names. The produced strings will not
+# contain characters from the unicode categories C and Z, which contain
+# control characters and separators, respectively.
+SANE_NAME_STRATEGY = st.text(st.characters(blacklist_categories=('C', 'Z')), min_size=1)
+
+
 @st.composite
 def attribute_dict(draw, min_size=0, max_size=None, max_depth=1):
     """
@@ -148,7 +155,7 @@ def interaction_collection(draw, graph,
     ninteraction_types = draw(st.integers(min_value=0, max_value=2))
     for _ in range(ninteraction_types):
         ninteractions = draw(st.integers(min_value=0, max_value=2))
-        type_name = draw(st.text())
+        type_name = draw(SANE_NAME_STRATEGY)
         if type_name not in result:
             result[type_name] = []
         for _ in range(ninteractions):

--- a/vermouth/tests/test_molecule.py
+++ b/vermouth/tests/test_molecule.py
@@ -24,7 +24,8 @@ import vermouth.molecule
 import vermouth.forcefield
 from vermouth.molecule import Interaction, Molecule
 
-from .molecule_strategies import random_molecule, random_block, random_link
+from .molecule_strategies import (random_molecule, random_block, random_link,
+                                  SANE_NAME_STRATEGY,)
 
 # pylint: disable=redefined-outer-name, no-value-for-parameter
 
@@ -1229,7 +1230,13 @@ def test_interaction_sort(interactions, expected):
     assert vermouth.molecule.Molecule.sort_interactions(interactions) == expected
 
 
-@hypothesis.given(moltype=st.one_of(st.none(), st.text()), mol=random_molecule())
+@hypothesis.given(
+    moltype=st.one_of(
+        st.none(),
+        SANE_NAME_STRATEGY,
+    ),
+    mol=random_molecule()
+)
 def test_str_method(mol, moltype):
     """
     Test Molecule.__str__


### PR DESCRIPTION
Restrict hypothesis strategies generating interaction types and molecule names from using characters in the unicode classes Z (separators) and C (control characters).
This should resolve some intermittent test failures, for example the one in #328 