### PR TITLE
Identify and fix edge case in ISMAGS symmetry detection

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -119,6 +119,7 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
     vermouth.MergeNucleicStrands().run_system(canonicalized)
     if write_graph is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True)
+        DeferredFileWriter().write()
 
     LOGGER.debug('Annotating required mutations and modifications.', type='step')
     vermouth.AnnotateMutMod(modifications, mutations).run_system(canonicalized)
@@ -127,11 +128,13 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
     if write_repair is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_repair),
                                omit_charges=True, nan_missing_pos=True)
+        DeferredFileWriter().write()
     LOGGER.info('Dealing with modifications.', type='step')
     vermouth.CanonicalizeModifications().run_system(canonicalized)
     if write_canon is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_canon),
                                omit_charges=True, nan_missing_pos=True)
+        DeferredFileWriter().write()
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
     vermouth.SortMoleculeAtoms().run_system(canonicalized) # was system
     return canonicalized

--- a/vermouth/ismags.py
+++ b/vermouth/ismags.py
@@ -868,7 +868,18 @@ class ISMAGS:
         else:
             cosets = cosets.copy()
 
-        assert all(len(t_p) == len(b_p) for t_p, b_p in zip(top_partitions, bottom_partitions))
+        if not all(len(t_p) == len(b_p) for t_p, b_p in zip(top_partitions, bottom_partitions)):
+            # This used to be an assertion, but it gets tripped in rare cases:
+            # 5 - 4 \     / 12 - 13
+            #        0 - 3
+            # 9 - 8 /     \ 16 - 17
+            # Assume 0 and 3 are coupled and no longer equivalent. At that point
+            # {4, 8} and {12, 16} are no longer equivalent, and neither are
+            # {5, 9} and {13, 17}. Coupling 4 and refinement results in 5 and 9
+            # getting their own partitions, *but not 13 and 17*. Further
+            # iterations will attempt to couple 5 to {13, 17}, which cannot
+            # result in more symmetries?
+            return [], cosets
 
         # BASECASE
         if all(len(top) == 1 for top in top_partitions):

--- a/vermouth/map_parser.py
+++ b/vermouth/map_parser.py
@@ -35,24 +35,24 @@ class Mapping:
 
     Attributes
     ----------
-    blocks_from: networkx.Graph
+    block_from: networkx.Graph
         The graph which this :class:`Mapping` object can transform.
-    blocks_to: vermouth.molecule.Block
+    block_to: vermouth.molecule.Block
         The :class:`vermouth.molecule.Block` we can transform to.
     references: collections.abc.Mapping
-        A mapping of node keys in :attr:`blocks_to` to node keys in
-        :attr:`blocks_from` that describes which node in blocks_from should be
+        A mapping of node keys in :attr:`block_to` to node keys in
+        :attr:`block_from` that describes which node in blocks_from should be
         taken as a reference when determining node attributes for nodes in
-        blocks_to.
+        block_to.
     ff_from: vermouth.forcefield.ForceField
-        The forcefield of :attr:`blocks_from`.
+        The forcefield of :attr:`block_from`.
     ff_to: vermouth.forcefield.ForceField
-        The forcefield of :attr:`blocks_to`.
+        The forcefield of :attr:`block_to`.
     names: tuple[str]
         The names of the mapped blocks.
     mapping: dict[collections.abc.Hashable, dict[collections.abc.Hashable, float]]
         The actual mapping that describes for every node key in
-        :attr:`blocks_from` to what node key in :attr:`blocks_to` it
+        :attr:`block_from` to what node key in :attr:`block_to` it
         contributes to with what weight.
         ``{node_from: {node_to: weight, ...}, ...}``.
 
@@ -63,9 +63,9 @@ class Mapping:
     Parameters
     ----------
     block_from: networkx.Graph
-        As per :attr:`blocks_from`.
+        As per :attr:`block_from`.
     block_to: vermouth.molecule.Block
-        As per :attr:`blocks_to`.
+        As per :attr:`block_to`.
     mapping: dict[collections.abc.Hashable, dict[collections.abc.Hashable, float]]
         As per :attr:`mapping`.
     references: collections.abc.Mapping
@@ -75,7 +75,7 @@ class Mapping:
     ff_to: vermouth.forcefield.ForceField
         As per :attr:`ff_to`.
     extra: tuple
-        Extra information to be attached to :attr:`blocks_to`.
+        Extra information to be attached to :attr:`block_to`.
     normalize_weights: bool
         Whether the weights should be normalized such that the sum of the
         weights of nodes mapping to something is 1.
@@ -120,11 +120,11 @@ class Mapping:
         """
         Performs the partial mapping described by this object on `graph`. It
         first find the induced subgraph isomorphisms between `graph` and
-        :attr:`blocks_from`, after which it will process the found isomorphisms
+        :attr:`block_from`, after which it will process the found isomorphisms
         according to :attr:`mapping`.
 
         None of the yielded dictionaries will refer to node keys of
-        :attr:`blocks_from`. Instead, those will be translated to node keys of
+        :attr:`block_from`. Instead, those will be translated to node keys of
         `graph` based on the found isomorphisms.
 
         Note
@@ -152,9 +152,9 @@ class Mapping:
         ------
         dict[collections.abc.Hashable, dict[collections.abc.Hashable, float]]
             the correspondence between nodes in `graph` and nodes in
-            :attr:`blocks_to`, with the associated weights.
+            :attr:`block_to`, with the associated weights.
         vermouth.molecule.Block
-            :attr:`blocks_to`.
+            :attr:`block_to`.
         dict
             :attr:`references` on which :attr:`mapping` has been applied.
         """
@@ -170,8 +170,8 @@ class Mapping:
         """
         # 1 Find subgraph isomorphism between blocks_from and graph
         # 2 Translate found match ({graph idx: blocks from idx}) to indices in
-        #   blocks_to using self.mapping
-        # 3 Return found matches and blocks_to?
+        #   block_to using self.mapping
+        # 3 Return found matches and block_to?
         # PS. I don't really like this, because this object is becoming too
         # intelligent by also having to do the isomorphism. On the other hand,
         # it makes sense from the maths point of view.

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -99,7 +99,7 @@ def node_matcher(node1, node2):
     bool
     """
     return attributes_match(node1, node2,
-                            ignore_keys=('atype', 'charge', 'charge_group',
+                            ignore_keys=('atype', 'charge', 'charge_group', 'mass',
                                          'resid', 'replace', '_old_atomname'))
 
 

--- a/vermouth/tests/test_ismags.py
+++ b/vermouth/tests/test_ismags.py
@@ -82,6 +82,16 @@ def basic_molecule(node_data, edge_data=None):
         [],
         nx.petersen_graph().edges,
     ),
+    (
+        # Gnarly edgecase from Fabian. Coupling node 4 to 8 mean that 5 and 9
+        # are no longer equivalent, pushing them in their own partitions.
+        # However, {5, 9} was considered equivalent to {13, 17}, which is *not*
+        # taken into account in the second refinement, tripping a (former)
+        # assertion failure. Note that this is actually the minimal failing
+        # example.
+        [],
+        [(0, 3), (0, 4), (4, 5), (0, 8), (8, 9), (3, 12), (12, 13), (3, 16), (16, 17),]
+    )
 ])
 def graphs(request):
     """


### PR DESCRIPTION
Fabian found an edge case in the ISMAGS symmetry detection. This should fix it. I'll also see about pushing a fix to the networkx version at some point.
Note that I'd like this reviewed by both of you.

```
5 - 4 \     / 12 - 13
       0 - 3
9 - 8 /     \ 16 - 17
```
Assume 0 and 3 are coupled and no longer equivalent. At that point {4, 8} and {12, 16} are no longer equivalent, and neither are {5, 9} and {13, 17}. Coupling 4 and refinement results in 5 and 9 getting their own partitions, *but not 13 and 17*. Further iterations will attempt to couple 5 to {13, 17}, which cannot result in more symmetries?