### PR TITLE
Remove resid from reference blocks in repair graph

### DIFF
--- a/vermouth/processors/repair_graph.py
+++ b/vermouth/processors/repair_graph.py
@@ -324,10 +324,17 @@ def repair_residue(molecule, ref_residue, include_graph):
             node = molecule.nodes[res_idx]
             if include_graph:
                 node['graph'] = molecule.subgraph([res_idx])
-            node.update(reference.nodes[ref_idx])
+            # We're only really interested in correcting the atomname. Obscure
+            # usecases may utilize e.g. charge, mass, atype. Either way, we need
+            # to remove the resid. Resname shouldn't matter since that should
+            # already be correct.
+            ref_node = reference.nodes[ref_idx].copy()
+            if 'resid' in ref_node:
+                del ref_node['resid']
+            node.update(ref_node)
             # Update found as well to keep found and molecule in line. It would
             # be better to try and figure why found is not a reference, but meh
-            found.nodes[res_idx].update(reference.nodes[ref_idx])
+            found.nodes[res_idx].update(ref_node)
         else:
             message = 'Missing atom {}{}:{}'
             args = (resname, resid, reference.nodes[ref_idx]['atomname'])

--- a/vermouth/processors/repair_graph.py
+++ b/vermouth/processors/repair_graph.py
@@ -319,18 +319,19 @@ def repair_residue(molecule, ref_residue, include_graph):
     resname = ref_residue['resname']
     LOGGER.debug('Repairing residue {}{}', resname, resid, type='step')
     for ref_idx in reference:
+        # We're only really interested in correcting the atomname. Obscure
+        # usecases may utilize e.g. charge, mass, atype. Either way, we need
+        # to remove the resid. Resname shouldn't matter since that should
+        # already be correct.
+        ref_node = reference.nodes[ref_idx].copy()
+        if 'resid' in ref_node:
+            del ref_node['resid']
+
         if ref_idx in match:
             res_idx = match[ref_idx]
             node = molecule.nodes[res_idx]
             if include_graph:
                 node['graph'] = molecule.subgraph([res_idx])
-            # We're only really interested in correcting the atomname. Obscure
-            # usecases may utilize e.g. charge, mass, atype. Either way, we need
-            # to remove the resid. Resname shouldn't matter since that should
-            # already be correct.
-            ref_node = reference.nodes[ref_idx].copy()
-            if 'resid' in ref_node:
-                del ref_node['resid']
             node.update(ref_node)
             # Update found as well to keep found and molecule in line. It would
             # be better to try and figure why found is not a reference, but meh
@@ -369,9 +370,13 @@ def repair_residue(molecule, ref_residue, include_graph):
             for key, val in ref_residue.items():
                 # Some attributes are only relevant on a residue level, not on
                 # an atom level.
-                if key not in ('match', 'found', 'reference'):
+                if key not in ('match', 'found', 'reference', 'nnodes',
+                               'nedges', 'density'):
                     node[key] = val
-            node.update(reference.nodes[ref_idx])
+            ref_node = reference.nodes[ref_idx].copy()
+            if 'resid' in ref_node:
+                del ref_node['resid']
+            node.update(ref_node)
             node['atomid'] = res_idx + 1
 
             match[ref_idx] = res_idx


### PR DESCRIPTION
Turns out that when repairing your graph you can't use blocks from ITP files as reference. Those contain resid numbers/attributes, which will overwrite the resids from your (e.g.) PDB file, causing all sorts of chaos.
This should fix it. I'll also add a test.