### PR TITLE
propagate edge attributes in res-graph making

### DIFF
--- a/vermouth/graph_utils.py
+++ b/vermouth/graph_utils.py
@@ -216,7 +216,15 @@ def partition_graph(graph, partitions):
     for idx, jdx in graph.edges:
         if mapping[idx] != mapping[jdx]:
             new_idx, new_jdx = mapping[idx], mapping[jdx]
-            new_graph.add_edge(new_idx, new_jdx)
+            edge_attrs = graph.edges[(idx, jdx)]
+            if new_graph.has_edge(new_idx, new_jdx):
+                old_attrs = new_graph.edges[(new_idx, new_jdx)]
+                new_attrs = {key: old_attrs[key] for key in old_attrs.keys() & edge_attrs.keys()\
+                                                         if old_attrs[key] == edge_attrs[key]}
+                old_attrs.clear()
+                new_graph.add_edge(new_idx, new_jdx, **new_attrs)
+            else:
+                new_graph.add_edge(new_idx, new_jdx, **edge_attrs)
     return new_graph
 
 

--- a/vermouth/tests/test_graph_utils.py
+++ b/vermouth/tests/test_graph_utils.py
@@ -403,6 +403,15 @@ def test_rate_match(nodes1, nodes2, match, expected):
          {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
         {(0, 1): {}}
     ),
+    (
+        [{'chain': 0, 'resid': 2, 'resname': 1, 'attr': 5},
+         {'chain': 0, 'resid': 2, 'resname': 1, 'attr': 6},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(2, 1): {"attr": 1, "other": 2}, (0, 2): {"attr": 1, "other": 2}},
+        [{'chain': 0, 'resid': 2, 'resname': 1},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(0, 1): {"attr": 1, "other": 2}}
+    ),
 ])
 def test_make_residue_graph(nodes1, edges1, nodes2, edges2):
     """

--- a/vermouth/tests/test_graph_utils.py
+++ b/vermouth/tests/test_graph_utils.py
@@ -376,6 +376,33 @@ def test_rate_match(nodes1, nodes2, match, expected):
          {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
         {(0, 1): {}}
     ),
+    (
+        [{'chain': 0, 'resid': 2, 'resname': 1, 'attr': 5},
+         {'chain': 0, 'resid': 2, 'resname': 1, 'attr': 6},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(2, 1): {"attr": 1}},
+        [{'chain': 0, 'resid': 2, 'resname': 1},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(0, 1): {"attr": 1}}
+    ),
+    (
+        [{'chain': 0, 'resid': 2, 'resname': 1, 'attr': 5},
+         {'chain': 0, 'resid': 2, 'resname': 1, 'attr': 6},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(2, 1): {"attr": 1}, (0, 2): {"attr": 1, "other": 2}},
+        [{'chain': 0, 'resid': 2, 'resname': 1},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(0, 1): {"attr": 1}}
+    ),
+    (
+        [{'chain': 0, 'resid': 2, 'resname': 1, 'attr': 5},
+         {'chain': 0, 'resid': 2, 'resname': 1, 'attr': 6},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(2, 1): {"attr": 1}, (0, 2): {"attr": 2, "other": 2}},
+        [{'chain': 0, 'resid': 2, 'resname': 1},
+         {'chain': 0, 'resid': 2, 'resname': 2, 'attr': 7}],
+        {(0, 1): {}}
+    ),
 ])
 def test_make_residue_graph(nodes1, edges1, nodes2, edges2):
     """


### PR DESCRIPTION
this is the left-over of #334. This PR makes sure the res-graph making propagates edge-attributes IF they are somehow given. For polyply I now subclass the ff-parser, which seems the only way to make this work. 