### PR TITLE
Fix 354

### DIFF
--- a/vermouth/processors/canonicalize_modifications.py
+++ b/vermouth/processors/canonicalize_modifications.py
@@ -276,6 +276,9 @@ def fix_ptm(molecule):
         resid_to_idxs[residx].append(n_idx)
     resid_to_idxs = dict(resid_to_idxs)
 
+    # Keep track of all nodes that get removed due to unknown PTMs
+    removed = set()
+
     known_ptms = molecule.force_field.modifications
 
     for resids, res_ptms in itertools.groupby(ptm_atoms, key_func):
@@ -299,7 +302,7 @@ def fix_ptm(molecule):
             n_idxs.update(resid_to_idxs[resid])
         # TODO: Maybe use graph_utils.make_residue_graph? Or rewrite that
         #       function?
-        residue = molecule.subgraph(n_idxs)
+        residue = molecule.subgraph(n_idxs - removed)
         options = allowed_ptms(residue, res_ptms, known_ptms)
         options = sorted(options,
                          key=lambda opt: len([n for n in opt[0]
@@ -318,6 +321,7 @@ def fix_ptm(molecule):
             for idxs in res_ptms:
                 for idx in idxs[0]:
                     molecule.remove_node(idx)
+                    removed.add(idx)
             continue
 
         # Why this mess? There can be multiple PTMs for a single (set of)

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -36,8 +36,11 @@ LOGGER = StyleAdapter(get_logger(__name__))
 # https://doi.org/10.1021/j100785a001
 # For hydrogen, we use R.S. Rowland & R. Taylor, J.Phys.Chem., 100, 7384-7391, 1996.
 # https://doi.org/10.1021/jp953141
+# For Deuterium we use the same as hydrogen, which is probably wrong/slightly
+# too large.
 VDW_RADII = {  # in nm
     'H': 0.120,
+    'D': 0.120,
     'He': 0.140,
     'C': 0.170,
     'N': 0.155,


### PR DESCRIPTION
From #354, which this fixes, tested on 2zwb:

> Element D is unknown to make_bonds, which results in very strange "modifications" that have no anchor, since they get no bonds. Fixed by teaching make_bonds about 'D'. A better solution might be to check for the absence of anchors when canonicalizing modifications?

Note that I took the same value for the radius as for H, which is probably a little bit too big.

> The real issue: if a residue contains 2 (or more) modifications, and the first is not known. Once the first modification gets IDed as 'unknown' the relevant atoms get removed from the molecule. When the second modification comes around the processor tries to create a subgraph of the complete residue (based on bookkeeping done earlier), resulting in the KeyError. Fixed by keeping track of which atoms got removed.

Fixes #354 