### PR TITLE
Remove 'HN'/'HN1' from N-terminal modifications for proline

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -199,9 +199,9 @@ intersphinx_mapping = {
 # to the VF2 isomorphism module instead.
 # See https://github.com/networkx/networkx/issues/3239
 intersphinx_aliases = {
-    ('py:class', 'networkx.classes.graph.Graph'): ('py:class', 'networkx.Graph'),
+    #('py:class', 'networkx.classes.graph.Graph'): ('py:class', 'networkx.Graph'),
     #('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'): ('py:class', 'networkx.isomorphism.GraphMatcher'),
-    ('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'): ('py:module', 'networkx.algorithms.isomorphism.isomorphvf2'),
+    #('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'): ('py:module','networkx.algorithms.isomorphism.isomorphvf2'),
     ('py:class', 'networkx.isomorphism.GraphMatcher'): ('py:module', 'networkx.algorithms.isomorphism.isomorphvf2')
 }
 

--- a/vermouth/data/force_fields/universal/modifications.ff
+++ b/vermouth/data/force_fields/universal/modifications.ff
@@ -29,12 +29,10 @@ N-ter
 [ atoms ]
 CA {"element": "C"}
 N {"element": "N"}
-HN {"element": "H", "replace": {"atomname": "HN1"}}
 HN2 {"element": "H", "PTM_atom": true, "replace": {"atomname": "HN2"}}
 HN3 {"element": "H", "PTM_atom": true, "replace": {"atomname": "HN3"}}
 [ edges ]
 N CA
-N HN
 N HN2
 N HN3
 
@@ -43,11 +41,9 @@ NH2-ter
 [ atoms ]
 CA {"element": "C"}
 N {"element": "N"}
-HN {"element": "H", "replace": {"atomname": "HN1"}}
 HN2 {"element": "H", "PTM_atom": true, "replace": {"atomname": "HN2"}}
 [ edges ]
 N CA
-N HN
 N HN2
 
 [ modification ]

--- a/vermouth/data/mappings/elnedyn/elnedyn22/modifications.mapping
+++ b/vermouth/data/mappings/elnedyn/elnedyn22/modifications.mapping
@@ -43,7 +43,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB 0
 HN2 BB 0
 HN3 BB 0
 N   BB 0
@@ -99,7 +98,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB 0
 HN2 BB 0
 N   BB 0
 CA  BB

--- a/vermouth/data/mappings/elnedyn/elnedyn22p/modifications.mapping
+++ b/vermouth/data/mappings/elnedyn/elnedyn22p/modifications.mapping
@@ -43,7 +43,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB 0
 HN2 BB 0
 HN3 BB 0
 N   BB 0
@@ -99,7 +98,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB 0
 HN2 BB 0
 N   BB 0
 CA  BB

--- a/vermouth/data/mappings/elnedyn/modifications.mapping
+++ b/vermouth/data/mappings/elnedyn/modifications.mapping
@@ -43,7 +43,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB 0
 HN2 BB 0
 HN3 BB 0
 N   BB 0
@@ -99,7 +98,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB 0
 HN2 BB 0
 N   BB 0
 CA  BB

--- a/vermouth/data/mappings/martini30/martini3001/modifications.mapping
+++ b/vermouth/data/mappings/martini30/martini3001/modifications.mapping
@@ -43,7 +43,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB
 HN2 BB
 HN3 BB
 N   BB
@@ -99,7 +98,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB
 HN2 BB
 N   BB
 CA  BB

--- a/vermouth/data/mappings/martini30/modifications.mapping
+++ b/vermouth/data/mappings/martini30/modifications.mapping
@@ -43,7 +43,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB
 HN2 BB
 HN3 BB
 N   BB
@@ -93,7 +92,6 @@ O
 C O
 CA C
 [ mapping ]
-HN1 BB
 HN2 BB
 HN3 BB
 N   BB
@@ -117,7 +115,6 @@ HN
 HN N
 N CA
 [ mapping ]
-HN BB
 N BB
 CA BB
 C  BB
@@ -142,7 +139,6 @@ O
 C O
 CA C
 [ mapping ]
-HN1 BB
 HN2 BB
 N   BB
 CA  BB

--- a/vermouth/data/mappings/modifications.mapping
+++ b/vermouth/data/mappings/modifications.mapping
@@ -43,7 +43,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB
 HN2 BB
 HN3 BB
 N   BB
@@ -99,7 +98,6 @@ C O
 CA C
 
 [ mapping ]
-HN1 BB
 HN2 BB
 N   BB
 CA  BB
@@ -148,7 +146,6 @@ O
 C O
 CA C
 [ mapping ]
-HN1 BB
 HN2 BB
 HN3 BB
 N   BB
@@ -197,7 +194,6 @@ O
 C O
 CA C
 [ mapping ]
-HN1 BB
 HN2 BB
 N   BB
 CA  BB

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -403,10 +403,6 @@ class Molecule(nx.Graph):
     def atoms(self):
         """
         All atoms in this molecule. Alias for `nodes`.
-
-        See Also
-        --------
-        :meth:`networkx.Graph.nodes`
         """
         # TODO: should just be an alias for nodes. If you need the attributes,
         #       do g.nodes(data=<attr>) or g.nodes(data=True)


### PR DESCRIPTION
This is a WIP PR to see if we can make the Nter modification match both prolines and other residues.

Fixes #141 (?)