### PR TITLE
Docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx.ext.autosectionlabel',
     'sphinxcontrib.apidoc',
 ]
 
@@ -204,6 +205,8 @@ intersphinx_aliases = {
     #('py:class', 'networkx.algorithms.isomorphism.vf2userfunc.GraphMatcher'): ('py:module','networkx.algorithms.isomorphism.isomorphvf2'),
     ('py:class', 'networkx.isomorphism.GraphMatcher'): ('py:module', 'networkx.algorithms.isomorphism.isomorphvf2')
 }
+
+autosectionlabel_prefix_document = True
 
 def add_intersphinx_aliases_to_inv(app):
     from sphinx.ext.intersphinx import InventoryAdapter

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -38,7 +38,7 @@ containing all atoms and interactions, and where all atom names are correct.
 A block should be a single connected component, and atom names within a block
 are assumed to be unique.
 
-Blocks can be defined through Gromacs' ``.itp`` and ``.rtp`` files.
+Blocks can be defined through Gromacs' ``.itp`` and ``.rtp`` file formats.
 
 :class:`Blocks <vermouth.molecule.Block>` define a few notable convenience
 methods:
@@ -95,6 +95,11 @@ A :class:`force field <vermouth.forcefield.ForceField>` is a collection of
 :ref:`Modifications <data:Modification>`. Force fields are identified by their
 :attr:`~vermouth.forcefield.ForceField.name`, which should be unique. Within a
 force field blocks and modifications should also have unique names.
+
+Note that this is only a subset of a force field in the MD sense: a VerMoUTH
+:class:`force field <vermouth.forcefield.ForceField>` does not include e.g.
+non-bonded parameters (only the particle types are included), or functional
+forms.
 
 The ``universal`` force field deserves special mention. If not overridden with
 the ``-from`` flag this force field is used. This force field does not define

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,19 +1,20 @@
 Data
 ====
-VerMoUTH knows several data structures, most of which describe MD particles
-(such as atoms or CG beads) and connections between those. As such, these are
-modelled as mathematical graphs, where the nodes describe the particles, and
-edges the bonds between these. In addition, these data structures describe the
-MD parameters and interactions, such as bonds, atom types, angles, etc.
+VerMoUTH knows several data structures, most of which describe atoms (or CG
+beads) and connections between those. As such, these are modelled as
+mathematical graphs, where the nodes describe the particles, and edges the bonds
+between these. In addition, these data structures describe the MD parameters and
+interactions, such as bonds, atom types, angles, etc.
 
 Molecule
 --------
 A :class:`~vermouth.molecule.Molecule` is a :class:`~networkx.Graph` where nodes
-are MD particles, and edges are the connections between theses (i.e. bonds, but
-note that not every edge has to correspond to a bond and vice versa).
-Generally, molecules are a single connected components (i.e. there is a path
-from any atom to any other atom in the molecule). Interactions are accessible
-through the :attr:`~vermouth.molecule.Molecule.interactions` attribute.
+are atoms/beads, and edges are the connections between theses (i.e. bonds [#]_)
+Generally, molecules are a single connected components [#]_. Interactions are
+accessible through the :attr:`~vermouth.molecule.Molecule.interactions`
+attribute. Non-bonded parameters are not fully defined: nodes have an 'atype'
+attribute describing the particle type to be used in an MD simulation, but we
+don't store the associated e.g. Lennard-Jones parameters.
 
 :class:`Molecules <vermouth.molecule.Molecule>` define a few notable convenience
 methods:
@@ -26,6 +27,9 @@ methods:
  - :meth:`~vermouth.molecule.Molecule.make_edges_from_interactions`: To generate
    edges from bond, angle, dihedral, cmap and constraint interactions. This is
    the only way interactions and their parameters are interpreted in vermouth.
+
+.. [#] But note that not every edge has to correspond to a bond and vice versa.
+.. [#] I.e. there is a path from any node to any other node in the molecule.
 
 Block
 -----

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -96,6 +96,11 @@ A :class:`force field <vermouth.forcefield.ForceField>` is a collection of
 :attr:`~vermouth.forcefield.ForceField.name`, which should be unique. Within a
 force field blocks and modifications should also have unique names.
 
+The ``universal`` force field deserves special mention. If not overridden with
+the ``-from`` flag this force field is used. This force field does not define
+any MD parameters, but this is fine. Instead, this force field defines only atom
+names and the associated connections.
+
 Mapping
 -------
 A :class:`~vermouth.map_parser.Mapping` describes how molecular fragments can

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,20 +1,104 @@
 Data
 ====
+VerMoUTH knows several data structures, most of which describe MD particles
+(such as atoms or CG beads) and connections between those. As such, these are
+modelled as mathematical graphs, where the nodes describe the particles, and
+edges the bonds between these. In addition, these data structures describe the
+MD parameters and interactions, such as bonds, atom types, angles, etc.
 
 Molecule
 --------
+A :class:`~vermouth.molecule.Molecule` is a :class:`~networkx.Graph` where nodes
+are MD particles, and edges are the connections between theses (i.e. bonds, but
+note that not every edge has to correspond to a bond and vice versa).
+Generally, molecules are a single connected components (i.e. there is a path
+from any atom to any other atom in the molecule). Interactions are accessible
+through the :attr:`~vermouth.molecule.Molecule.interactions` attribute.
+
+:class:`Molecules <vermouth.molecule.Molecule>` define a few notable convenience
+methods:
+
+ - :meth:`~vermouth.molecule.Molecule.merge_molecule`: Add all atoms and
+   interactions from a molecule to this one. Note that this can also be used to
+   add a :class:`vermouth.molecule.Block` to a molecule! This way you can
+   incrementally build polymers from monomers. This method will always produce
+   a disconnected graph, so be sure to add the appropriate edges afterwards.
+ - :meth:`~vermouth.molecule.Molecule.make_edges_from_interactions`: To generate
+   edges from bond, angle, dihedral, cmap and constraint interactions. This is
+   the only way interactions and their parameters are interpreted in vermouth.
 
 Block
 -----
+A :class:`~vermouth.molecule.Block` can be seen as a canonical residue
+containing all atoms and interactions, and where all atom names are correct.
+A block should be a single connected component, and atom names within a block
+are assumed to be unique.
+
+Blocks can be defined through Gromacs' ``.itp`` and ``.rtp`` files.
+
+:class:`Blocks <vermouth.molecule.Block>` define a few notable convenience
+methods:
+
+ - :meth:`~vermouth.molecule.Block.guess_angles`: Generate all possible angles
+   based on the edges.
+ - :meth:`~vermouth.molecule.Block.guess_dihedrals`: Generate all possible
+   dihedral angles based on the edges.
+ - :meth:`~vermouth.molecule.Block.to_molecule`: Create a new
+   :class:`~vermouth.molecule.Molecule` based on this block.
 
 Link
 ----
+A :class:`~vermouth.molecule.Link` is used to describe interactions *between*
+residues. As such, it consists of nodes and edges describing the molecular
+fragment it should apply to, as well as the associated changes in MD parameters.
+For example, a link can describe the addition, change or removal of specific
+interactions or node attributes. They can also be used to remove nodes. Although
+it is possible to generate *all* MD parameters and interactions using Links,
+rather than taking them from constituent blocks, this is not the preferred
+method. The approach where links only affect the parameters where they depend on
+the local structure makes it easier to reason about how the final topology is
+constructed, and the performance is better.
+
+Besides nodes, edges and interactions links also describe non-edges, patterns
+and removed interactions. Non-edges and patterns are used when matching the link
+to a molecule. Where there is a non-edge in the link there cannot be an edge in
+the molecule, and the atoms involved do not need to be present in the molecule.
+Patterns provide a concise way where either one of multiple conditions must be
+met. For example two neighbouring 'BB' beads, where one must have a helical
+secondary structure, and the other should be a coil.
+
+Links can be defined through :ref:`.ff files <file_formats:.ff file format>`.
+See also: :ref:`Apply Links <martinize2_workflow:4) Apply Links>`.
 
 Modification
 ------------
+A :class:`~vermouth.molecule.Modification` describes how a residue deviates from
+its associated :class:`~vermouth.molecule.Block`, such as non-standard
+protonation states and termini. Modifications differentiate between
+atoms/particles that should already be described by the block and atoms that are
+only described by the modification.
 
-Mapping
--------
+A modification can add or remove nodes, change node attributes, and add, change,
+or remove interactions; much like a `Link`_.
+
+Modifications can be defined through :ref:`.ff files <file_formats:.ff file format>`.
+See also: :ref:`Identify modifications <martinize2_workflow:Identify modifications>`.
 
 ForceField
 ----------
+A :class:`force field <vermouth.forcefield.ForceField>` is a collection of
+:ref:`Blocks <data:Block>`, :ref:`Links <data:Link>` and
+:ref:`Modifications <data:Modification>`. Force fields are identified by their
+:attr:`~vermouth.forcefield.ForceField.name`, which should be unique. Within a
+force field blocks and modifications should also have unique names.
+
+Mapping
+-------
+A :class:`~vermouth.map_parser.Mapping` describes how molecular fragments can
+be transformed from one force field to another.
+
+Mappings can be provided through [backward]_ style ``.map`` files, or the more
+powerful (but verbose) :ref:`.mapping <file_formats:.mapping file format>` format.
+See also: :ref:`Resolution transformation <martinize2_workflow:3) Resolution transformation>`.
+
+.. [backward] T.A. Wassenaar, K. Pluhackova, R.A. Böckmann, S.J. Marrink, D.P. Tieleman, Going Backward: A Flexible Geometric Approach to Reverse Transformation from Coarse Grained to Atomistic Models, J. Chem. Theory Comput. 10 (2014) 676–690. doi:10.1021/ct400617g.

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -88,8 +88,8 @@ or remove interactions; much like a `Link`_.
 Modifications can be defined through :ref:`.ff files <file_formats:.ff file format>`.
 See also: :ref:`Identify modifications <martinize2_workflow:Identify modifications>`.
 
-ForceField
-----------
+Force Field
+-----------
 A :class:`force field <vermouth.forcefield.ForceField>` is a collection of
 :ref:`Blocks <data:Block>`, :ref:`Links <data:Link>` and
 :ref:`Modifications <data:Modification>`. Force fields are identified by their

--- a/doc/source/file_formats.rst
+++ b/doc/source/file_formats.rst
@@ -1,10 +1,23 @@
 File formats
 ============
-Here we will, at a later date, explain the exact syntax and semantics of the
-file formats.
+VerMoUTH introduces two new file formats. The ``.ff`` format for defining
+:ref:`blocks <data:block>`, :ref:`links <data:link>` and :
+ref:`modifications <data:modification>`. Note that you can also define blocks
+(and basic links) with Gromacs ``.itp`` and ``.rtp`` files. The ``.mapping``
+format can be used to define :ref:`mappings <data:mapping>`. Mappings that don't
+cross residue boundaries can also be defined using ``.map`` files.
+
+These file formats are still not finalized and subject to change. Therefore
+these file formats are not yet documented. If you need to implement (mappings
+for) your own residues you'll need to reverse engineer the format from the
+existing files.
 
 .ff file format
 ---------------
+Used for defining :ref:`blocks <data:block>`, :ref:`links <data:link>` and
+:ref:`modifications <data:modification>`.
 
 .mapping file format
 --------------------
+Used for defining :ref:`mappings <data:mapping>` for single blocks,
+modifications, and block mappings that cross residue boundaries.

--- a/doc/source/general_overview.rst
+++ b/doc/source/general_overview.rst
@@ -19,7 +19,7 @@ for the [Martini3]_ force field.
 
 Installation instructions
 -------------------------
-Vermouth and martinize2 are distribute through pypi and can be installed using
+Vermouth and martinize2 are distributed through pypi and can be installed using
 pip.
 
 .. code-block:: bash
@@ -47,7 +47,7 @@ used as a drop-in replacement. For example:
 
 This will read an atomistic ``lysozyme.pdb`` and produce a Martini3_ compatible
 structure and topology at ``cg_protein.pdb`` and ``topol.top`` respectively. It
-will use the program DSSP to determine the proteins secondary structure (which
+will use the program [DSSP]_ to determine the proteins secondary structure (which
 influences the topology), and produce an elastic network. See ``martinize2 -h``
 for more options! Note that if ``martinize2`` runs into problems where the
 produced topology might be invalid it will issue warnings. If this is the case
@@ -55,25 +55,29 @@ it won't write any output files, but also see the ``-maxwarn`` flag.
 
 General layout
 --------------
-In VerMoUTH a force field is defined as a collection of Blocks, Links and
-Modifications. Each of these is a graph, where nodes describe atoms (or
-coarse-grained beads) and edges describe bonds between these. Blocks describe
-idealized residues/monomeric repeat units and their MD parameters and
-interactions. Links are molecular fragments that describe MD parameters and
-interactions *between* residues/monomeric repeat units. Modifications are
-molecular fragments that describe *deviations* from Blocks, such as
-post-translational modifications and protonation states. Mappings describe how
-molecular fragments can be converted between force fields.
+In VerMoUTH a :ref:`force field <data:Force Field>` is defined as a collection
+of :ref:`Blocks <data:Block>`, :ref:`Links <data:Link>` and
+:ref:`Modifications <data:Modification>`. Each of these is a graph, where nodes
+describe atoms (or coarse-grained beads) and edges describe bonds between these.
+:ref:`Blocks <data:Block>` describe idealized residues/monomeric repeat units
+and their MD parameters and interactions. :ref:`Links <data:Link>` are molecular
+fragments that describe MD parameters and interactions *between*
+residues/monomeric repeat units. :ref:`Modifications <data:Modification>` are
+molecular fragments that describe *deviations* from :ref:`Blocks <data:Block>`,
+such as post-translational modifications and protonation states.
+:ref:`Mappings <data:Mapping>` describe how molecular fragments can be converted
+between force fields.
 
-Finally, martinize2 is a pipeline that is built up from Processors, which are
-defined by VerMoUTH. Processors are isolated steps which function on either the
-complete system, or single molecules.
+Finally, martinize2 is a pipeline that is built up from
+:ref:`Processors <processors:Processor>`, which are defined by VerMoUTH.
+Processors are isolated steps which function on either the complete system, or
+single molecules.
 
 Martinize2 identifies atoms mostly based on their *connectivity*. We read the
 bonds present in the input file (as ``CONECT`` records), and besides that we
-guess bonds based on atom names (within residues) and on distances (between
-residues, using the same criteria as [VMD]_). This means that your input structure
-must be reasonable.
+:ref:`guess bonds <martinize2_workflow:Make bonds>` based on atom names (within
+residues) and on distances (between residues, using the same criteria as
+[VMD]_). This means that your input structure must be reasonable.
 
 Citing
 ------
@@ -87,3 +91,5 @@ References
 ----------
 .. [Martini3] P.C.T. Souza, R. Alessandri, J. Barnoud, S. Thallmair, I. Faustino, F. Grünewald, et al., Martini 3: a general purpose force field for coarse-grained molecular dynamics, Nat. Methods. 18 (2021) 382–388. doi:10.1038/s41592-021-01098-3.
 .. [VMD] W. Humphrey, A. Dalke and K. Schulten, "VMD - Visual Molecular Dynamics", J. Molec. Graphics, 1996, vol. 14, pp. 33-38. http://www.ks.uiuc.edu/Research/vmd/.
+.. [DSSP] - W.G. Touw, C. Baakman, J. Black, T.A.H. te Beek, E. Krieger, R.P. Joosten, et al., A series of PDB-related databanks for everyday needs, Nucleic Acids Res. 43 (2015) D364–D368. doi:10.1093/nar/gku1028.
+   - W. Kabsch, C. Sander, Dictionary of protein secondary structure: pattern recognition of hydrogen-bonded and geometrical features., Biopolymers. 22 (1983) 2577–637. doi:10.1002/bip.360221211.

--- a/doc/source/general_overview.rst
+++ b/doc/source/general_overview.rst
@@ -27,8 +27,13 @@ pip.
     pip install vermouth
 
 The behavior of the ``pip`` command can vary depending of the specificity of your
-python installation. See the `documentation on installing a python
-package <https://packaging.python.org/tutorials/installing-packages/#installing-packages>`_ to learn more.
+python installation. See the `documentation on installing a python package
+<https://packaging.python.org/tutorials/installing-packages/#installing-packages>`_
+to learn more.
+
+Vermouth has `SciPy <https://scipy.org>`_ as *optional* dependency. If available
+it will be used to accelerate the distance calculations when `making bonds
+<martinize2_workflow:Make bonds>`_
 
 Quickstart
 ----------

--- a/doc/source/general_overview.rst
+++ b/doc/source/general_overview.rst
@@ -1,10 +1,10 @@
 General Overview
 ================
-VerMoUTH and martinize2 are tools for setting up molecular dynamics (MD)
-simulations starting from atomistic coordinates, with a special focus on
-polymeric systems (including proteins and DNA). Existing tools that do this
-are generally limited to strictly linear polymers, while VerMoUTH and
-martinize2 make *no* assumptions regarding polymer structure. VerMoUTH is a
+VerMoUTH and martinize2 are tools for setting up starting structures for
+molecular dynamics (MD) simulations starting from atomistic coordinates, with a
+special focus on polymeric systems (including proteins and DNA). Existing tools
+that do this are generally limited to strictly linear polymers, while VerMoUTH
+and martinize2 make *no* assumptions regarding polymer structure. VerMoUTH is a
 python library that can be used programmatically. Martinize2 is a command line
 tool build on top of that.
 
@@ -26,7 +26,7 @@ pip.
 
     pip install vermouth
 
-The behavior of the ``pip`` command can vary depending of the specificity of your
+The behavior of the ``pip`` command can vary depending on the specificity of your
 python installation. See the `documentation on installing a python package
 <https://packaging.python.org/tutorials/installing-packages/#installing-packages>`_
 to learn more.

--- a/doc/source/general_overview.rst
+++ b/doc/source/general_overview.rst
@@ -1,25 +1,74 @@
 General Overview
 ================
+VerMoUTH and martinize2 are tools for setting up molecular dynamics (MD)
+simulations starting from atomistic coordinates, with a special focus on
+polymeric systems (including proteins and DNA). Existing tools that do this
+are generally limited to strictly linear polymers, while VerMoUTH and
+martinize2 make *no* assumptions regarding polymer structure. VerMoUTH is a
+python library that can be used programmatically. Martinize2 is a command line
+tool build on top of that.
 
-How, what, why
+VerMoUTH and martinize2 are also capable of dealing with structures where atom
+names are not provided, and to some extent with incomplete structures where
+atoms are missing from the input structure due to e.g. experimental limitations.
+There is also support for post-translational modifications.
 
-Vermouth versus Martinize 2
+VerMoUTH and martinize2 can be used to generate both atomistic and
+coarse-grained topologies and are the preferred method of generating topologies
+for the [Martini3]_ force field.
 
 Installation instructions
 -------------------------
-How to install vermouth and martinize2
+Vermouth and martinize2 are distribute through pypi and can be installed using
+pip.
 
 .. code-block:: bash
 
     pip install vermouth
 
+The behavior of the ``pip`` command can vary depending of the specificity of your
+python installation. See the `documentation on installing a python
+package <https://packaging.python.org/tutorials/installing-packages/#installing-packages>`_ to learn more.
+
 Quickstart
 ----------
-How to run Martinize 2 for the simple cases
+The CLI of martinize2 is very similar to that of martinize1, and can often be
+used as a drop-in replacement. For example:
+
+.. code-block:: bash
+
+    martinize2 -f lysozyme.pdb -x cg_protein.pdb -o topol.top
+        -ff martini3001 -dssp -elastic
+
+This will read an atomistic ``lysozyme.pdb`` and produce a Martini3_ compatible
+structure and topology at ``cg_protein.pdb`` and ``topol.top`` respectively. It
+will use the program DSSP to determine the proteins secondary structure (which
+influences the topology), and produce an elastic network. See ``martinize2 -h``
+for more options! Note that if ``martinize2`` runs into problems where the
+produced topology might be invalid it will issue warnings. If this is the case
+it won't write any output files, but also see the ``-maxwarn`` flag.
 
 General layout
 --------------
-Processors, Blocks, Links, Modifications, Force fields, Mappings
+In VerMoUTH a force field is defined as a collection of Blocks, Links and
+Modifications. Each of these is a graph, where nodes describe atoms (or
+coarse-grained beads) and edges describe bonds between these. Blocks describe
+idealized residues/monomeric repeat units and their MD parameters and
+interactions. Links are molecular fragments that describe MD parameters and
+interactions *between* residues/monomeric repeat units. Modifications are
+molecular fragments that describe *deviations* from Blocks, such as
+post-translational modifications and protonation states. Mappings describe how
+molecular fragments can be converted between force fields.
+
+Finally, martinize2 is a pipeline that is built up from Processors, which are
+defined by VerMoUTH. Processors are isolated steps which function on either the
+complete system, or single molecules.
+
+Martinize2 identifies atoms mostly based on their *connectivity*. We read the
+bonds present in the input file (as ``CONECT`` records), and besides that we
+guess bonds based on atom names (within residues) and on distances (between
+residues, using the same criteria as [VMD]_). This means that your input structure
+must be reasonable.
 
 Citing
 ------
@@ -28,3 +77,8 @@ For now, please cite the relevant chapter from the thesis of Peter C Kroon:
 
 Kroon, P.C. (2020). Martinize 2 -- VerMoUTH. *Aggregate, automate, assemble* (pp. 16-53). ISBN:
 978-94-034-2581-8.
+
+References
+----------
+.. [Martini3] P.C.T. Souza, R. Alessandri, J. Barnoud, S. Thallmair, I. Faustino, F. Grünewald, et al., Martini 3: a general purpose force field for coarse-grained molecular dynamics, Nat. Methods. 18 (2021) 382–388. doi:10.1038/s41592-021-01098-3.
+.. [VMD] W. Humphrey, A. Dalke and K. Schulten, "VMD - Visual Molecular Dynamics", J. Molec. Graphics, 1996, vol. 14, pp. 33-38. http://www.ks.uiuc.edu/Research/vmd/.

--- a/doc/source/graph_algorithms.rst
+++ b/doc/source/graph_algorithms.rst
@@ -61,6 +61,10 @@ equivalent nodes not connected in :math:`G` are not connected in :math:`H`:
 We denote :math:`H` being induced subgraph isomorphic to :math:`G` as
 :math:`H \precsim G`.
 
+It is important to note that a path graph is *not* subgraph isomorphic
+to the corresponding cycle graph of the same size. For example, n-propane is not
+subgraph isomorphic to cyclopropane!
+
 Maximum common induced subgraph
 +++++++++++++++++++++++++++++++
 The maximum common induced subgraph between :math:`G` and :math:`H` is the
@@ -70,3 +74,58 @@ Commonly the answer is given as a general mapping between :math:`G` and
 
 Isomorphism
 -----------
+Vermouth and martinize2 identify atoms by connectivity, generally combined with
+a constraint on element or atom name. We do this using either a
+:ref:`graph_algorithms:maximum common induced subgraph` (during the
+:ref:`martinize2_workflow:Repair graph` step) or a
+:ref:`graph_algorithms:induced subgraph isomorphism` (the other steps). In all
+these cases we effectively find how nodes in the molecule we're working on match
+with nodes in our reference graphs, such as :ref:`blocks <data:block>`.
+
+During the :ref:`martinize2_workflow:Repair graph` step there are two, related,
+complications: 1) we need a "best" overlay, where as many atom names match as
+possible; and 2) There can be very many (equivalent) possible
+overlays/isomorphisms. Let's address the second concern first. As example we'll
+look at the automorphisms (= self-isomorphism, i.e. how does a graph fit on
+itself) of propane (``CH3-CH2-CH3``).
+
+There are 2 isomorphisms for the carbons:
+:math:`C_\alpha-C_\beta-C_\gamma \mapsto C_\alpha-C_\beta-C_\gamma` and
+:math:`C_\alpha-C_\beta-C_\gamma \mapsto C_\gamma-C_\beta-C_\alpha`. Similarly,
+there are 2 isomorphisms for the central methylene group:
+:math:`H_1-C_\beta-H_2 \mapsto H_1-C_\beta-H_2` and
+:math:`H_1-C_\beta-H_2 \mapsto H_2-C_\beta-H_1`. Each terminal methyl group
+however, has 6 unique isomorphisms!
+
+.. math::
+   H_1H_2H_3 \mapsto (H_1H_2H_3, H_1H_3H_2, H_2H_1H_3, H_3H_1H_2, H_2H_3H_1, H_3H_2H_1)
+
+This means that in total, propane, a molecule consisting of 11 atoms, has
+:math:`2 (carbons) \times 2 (methylene) \times 6 (methyl) \times 6 (methyl) = 144`
+automorphisms! Now imagine how this scales for a lipid. Clearly this spirals out
+of control very quickly, and it is generally unfeasible to generate all possible
+isomorphisms [#]_.
+
+Luckily for us however, we're not interested in finding all these isomorphisms,
+since we can consider most of these to be equivalent. For our use case it
+doesn't matter whether :math:`H_1` maps to :math:`H_1` or :math:`H_2` so long as
+:math:`H_1` and :math:`H_2` are equivalent. There is one catch however: we need
+to find the isomorphism where most atom names match. We can achieve this by
+preferentially using nodes with a lower index [#]_ when given a choice between
+symmetry equivalent nodes. The [ISMAGS]_ algorithm does exactly this: it
+calculates symmetry unique isomorphisms preferentially using nodes with a
+smaller index.
+
+Note that this problem only comes up when your graphs are (very) symmetric. In
+all other steps we constrain the isomorphism such that nodes are only considered
+equal if their atom names match. Since atom names are generally unique, this
+means that this problem is sidestepped completely. The only place where we
+cannot do this is during the :ref:`martinize2_workflow:Repair graph` step, since
+at that point we cannot assume that the atoms names in our molecule are correct.
+
+.. [#] This problem gets *even* worse when trying to find the
+   :ref:`graph_algorithms:maximum common induced subgraph`.
+.. [#] In other words, we impose an ordering on the nodes in the graph. We do
+   this by ordering the nodes based on whether there is a node with a
+   corresponding atom name in the reference and subsequently sorting by atom name.
+.. [ISMAGS] M. Houbraken, S. Demeyer, T. Michoel, P. Audenaert, D. Colle, M. Pickavet, The Index-Based Subgraph Matching Algorithm with General Symmetries (ISMAGS): Exploiting Symmetry for Faster Subgraph Enumeration, PLoS One. 9 (2014) e97896. doi:10.1371/journal.pone.0097896.

--- a/doc/source/graph_algorithms.rst
+++ b/doc/source/graph_algorithms.rst
@@ -1,8 +1,72 @@
 Graph algorithms
 ================
+Vermouth describes molecules and molecular fragments as graphs where atoms are
+nodes and connections between them (e.g. bonds) are edges. This allows us to use
+the *connectivity* to identify which atom is which, meaning we are no longer
+dependent on atom names.
 
 Definitions
 -----------
+Graph
++++++
+A graph :math:`G = (V, E)` is a collection of nodes (:math:`V`) connected by
+edges (:math:`E`): :math:`e_{ij} = (v_i, v_j) \in E`. In undirected graphs
+:math:`e_{ij} = e_{ji}`. Unless we specify otherwise all graphs used in vermouth
+are undirected. The size of a graph is equal to the number of nodes:
+:math:`|G| = |V|`.
+
+Subgraph
+++++++++
+Graph :math:`H = (W, F)` is a subgraph of graph :math:`G = (V, E)` if:
+
+.. math::
+   |H| &< |G|\\
+   W &\subset V\\
+   e_{ij} &\in F \quad \forall e_{ij} \in E\\
+   e_{ij} &\notin F \quad \forall e_{ij} \notin E\\
+
+This means that all nodes in :math:`H` are in :math:`G`, and that nodes are
+connected in :math:`H` if and only if they are connected in :math:`G`.
+
+Graph isomorphism
++++++++++++++++++
+A graph isomorphism :math:`m` between graphs :math:`H = (W, F)` and
+:math:`G = (V, E)` is a bijective mapping :math:`m: V \mapsto W` such that the
+following conditions hold:
+
+.. math::
+   |H| &= |G|\\
+   m(v) &\simeq v \quad &\forall v \in V\\
+   (m(v_i), m(v_j)) &\simeq (v_i, v_j) \quad &: (m(v_i), m(v_j)) \in F \enspace \forall (v_i, v_j) \in E
+
+This means that every node in :math:`G` maps to exactly one node in :math:`H`
+such that all connected nodes in :math:`G` are connected in :math:`H`. Note that
+labels/attributes on nodes and edges (such as element or atom name) can affect
+the equivalence criteria.
+
+Subgraph isomorphism
+++++++++++++++++++++
+A subgraph isomorphism is a :ref:`graph_algorithms:graph isomorphism`, but
+without the constraint that :math:`|H| = |G|`. Instead, :math:`|H| <= |G|` if
+:math:`H` is subgraph isomorphic to :math:`G`.
+
+Induced subgraph isomorphism
+++++++++++++++++++++++++++++
+As :ref:`graph_algorithms:subgraph isomorphism` with the added constraint that
+equivalent nodes not connected in :math:`G` are not connected in :math:`H`:
+
+.. math::
+   (m(v_i), m(v_j)) \notin F \quad \forall (v_i, v_j) \notin E
+
+We denote :math:`H` being induced subgraph isomorphic to :math:`G` as
+:math:`H \precsim G`.
+
+Maximum common induced subgraph
++++++++++++++++++++++++++++++++
+The maximum common induced subgraph between :math:`G` and :math:`H` is the
+largest graph :math:`J` such that :math:`J \precsim G` and :math:`J \precsim H`.
+Commonly the answer is given as a general mapping between :math:`G` and
+:math:`H`.
 
 Isomorphism
 -----------

--- a/doc/source/martinize2_workflow.rst
+++ b/doc/source/martinize2_workflow.rst
@@ -60,12 +60,11 @@ such as PDB ``CONECT`` records. Beyond that, edges are added by
 added based on atom names and distances, but this behaviour can be changed via
 the CLI option ``-bonds-from``.
 
-To add edges based on atom names the :class:`~vermouth.molecule.Block` from the
-input force field is used as reference for every residue in the input structure
-where possible. This is not possible when a residue contains multiple atoms with
-the same name, nor when there is no :class:`~vermouth.molecule.Block`
-corresponding to the residue. Note that this will only ever create edges
-*within* residues.
+To add edges based on atom names the :ref:`data:Block` from the input force
+field is used as reference for every residue in the input structure where
+possible. This is not possible when a residue contains multiple atoms with the
+same name, nor when there is no :ref:`data:Block` corresponding to the residue
+[#]_. Note that this will only ever create edges *within* residues.
 
 Edges will be added based on distance when they are close enough together,
 except for a few exceptions (below). Atoms will be considered close enough based
@@ -74,9 +73,9 @@ name [#]_). The distance threshold is multiplied by ``-bonds-fudge`` to allow
 for conformations that are slightly out-of-equilibrium. Edges will not be added
 from distances in two cases: 1) if edges could be added based on atom names no
 edges will be added between atoms that are not bonded in the reference
-:class:`~vermouth.molecule.Block`. 2) No edges will be added between residues
-if one of the atoms involved is a hydrogen atom. Edges added this way are logged
-as debug output.
+:ref:`data:Block`. 2) No edges will be added between residues if one of the
+atoms involved is a hydrogen atom. Edges added this way are logged as debug
+output.
 
 If your input structure is far from equilibrium and adding edges based on
 distance is likely to produce erroneous results, make sure to provide ``CONECT``
@@ -93,6 +92,7 @@ strategic ``TER`` records in your PDB file.
 
 Relevant CLI options: ``-bond-from``; ``-bonds-fudge``
 
+.. [#] Based on residue name.
 .. [#] The method for deriving the element from an atom name is extremely
    simplistic: the first letter is used. This will go wrong for two-letter
    elements such as 'Fe', 'Cl', and 'Cu'. In those cases, make sure your PDB
@@ -138,9 +138,9 @@ modifications such as PTMs.
 Repair graph
 ------------
 The first step is to complete the graph so that it contains all atoms described
-by the reference :class:`Blocks <vermouth.molecule.Block>`, and that all atoms have
-the correct names. These blocks are taken from the input force field based on
-residue names (taking any mutations and modifications into account).
+by the reference :ref:`data:Block`, and that all atoms have the correct names.
+These blocks are taken from the input force field based on residue names (taking
+any mutations and modifications into account).
 :class:`~vermouth.processors.repair_graph.RepairGraph` takes care of all this.
 
 To identify atoms in a residue we consider the largest common induced subgraph
@@ -170,13 +170,13 @@ atoms it did not recognise, and those are processed by
 :class:`~vermouth.processors.canonicalize_modifications.CanonicalizeModifications`.
 
 This is done by finding the solution where all unknown atoms are covered by the
-atoms of exactly one :class:`~vermouth.molecule.Modification`, where the
-modification must be an induced subgraph of the molecule. Every modification
-must contain at least one "anchoring" atom, which is an atom that is also
-described by a :class:`~vermouth.molecule.Block`. Unknown atoms are considered
-to be equal if their element is equal; anchor atoms are considered equal if
-their atom name is equal. Because modifications must be induced subgraphs of the
-input structure there can be no missing atoms!
+atoms of exactly one :ref:`data:Modification`, where the modification must be an
+induced subgraph of the molecule. Every modification must contain at least one
+"anchoring" atom, which is an atom that is also described by a
+:ref:`data:Block`. Unknown atoms are considered to be equal if their element is
+equal; anchor atoms are considered equal if their atom name is equal. Because
+modifications must be induced subgraphs of the input structure there can be no
+missing atoms!
 
 After this step all atoms will have correct atom names, and any residues that
 are include modifications will be labelled. This information is later used
@@ -237,17 +237,17 @@ Relevant CLI options: ``-ff``, ``-map-dir``
    defined must match. Not all attributes (such as 'mass') are defined in all
    cases, depending on the source of the mappings. Note that we also take into
    account that atom names might have changed due to modifications: we use the
-   atom name as it is defined by the Block.
+   atom name as it is defined by the :ref:`data:Block`.
 
 4) Apply Links
 ==============
 Next interactions *between* residues are added by
 :class:`~vermouth.processors.do_links.DoLinks`. We do this based on the concept
-of :class:`Links <vermouth.molecule.Link>`, which are molecular fragments that
-describe interactions, and which atoms they should apply to. Links are very
-powerful and flexible tools, and we use them to generate all interactions that
-depend on the local structure of the polymer. For example, all interactions that
-depend on the protein sequence or secondary structure are defined by Links.
+of :ref:`Links <data:Link>`, which are molecular fragments that describe
+interactions, and which atoms they should apply to. Links are very powerful and
+flexible tools, and we use them to generate all interactions that depend on the
+local structure of the polymer. For example, all interactions that depend on the
+protein sequence or secondary structure are defined by :ref:`Links <data:Link>`.
 
 Links can both add, change and remove interactions and nodes. Because of this,
 the order in which links are applied matters for the final topology. We apply
@@ -272,7 +272,7 @@ might be useful.
 ==================
 There can be any number of post processing steps. For example to add an elastic
 network, or to generate Go virtual sites. We will not describe their function
-here in detail. Instead, see
+here in detail. Instead, see for example
 :class:`~vermouth.processors.apply_rubber_band.ApplyRubberBand` and
 :class:`~vermouth.processors.go_vs_includes.GoVirtIncludes`.
 

--- a/doc/source/martinize2_workflow.rst
+++ b/doc/source/martinize2_workflow.rst
@@ -128,6 +128,8 @@ Relevant CLI options: ``-mutate``, ``-modify``, ``-nter``, ``-cter``, ``-nt``
 .. [#] N- and C-termini are defined as residues with 1 neighbour and having a
    higher or lower residue number than the neighbour, respectively. Note that
    this does not include zwitterionic amino acids!
+   This also means that if your protein has a chain break you'll end up with
+   more termini than you would otherwise expect.
 
 2) Repair the input graph
 =========================

--- a/doc/source/martinize2_workflow.rst
+++ b/doc/source/martinize2_workflow.rst
@@ -143,15 +143,15 @@ These blocks are taken from the input force field based on residue names (taking
 any mutations and modifications into account).
 :class:`~vermouth.processors.repair_graph.RepairGraph` takes care of all this.
 
-To identify atoms in a residue we consider the largest common induced subgraph
-between the residue and its reference since the residue can be both too small
-(atoms missing in the input) and too large (atoms from PTMs) at the same time.
-Unfortunately, this is a very expensive operation which scales exponentially
-with the size of the residue. So if you know beforehand that your structure
-contains (very) large PTMs, such as lipidations, consider specifying those as
-separate residues.
+To identify atoms in a residue we consider the
+:ref:`graph_algorithms:maximum common induced subgraph` between the residue and
+its reference since the residue can be both too small (atoms missing in the
+input) and too large (atoms from PTMs) at the same time. Unfortunately, this is
+a very expensive operation which scales exponentially with the size of the
+residue. So if you know beforehand that your structure contains (very) large
+PTMs, such as lipidations, consider specifying those as separate residues.
 
-The largest common induced subgraph is found using
+The maximum common induced subgraph is found using
 :class:`~vermouth.ismags.ISMAGS`, where nodes are considered equal if their
 elements are equal. Beforehand, the atoms in the residue will be sorted such
 that the isomorphism where most atom names correspond with the reference is
@@ -171,12 +171,13 @@ atoms it did not recognise, and those are processed by
 
 This is done by finding the solution where all unknown atoms are covered by the
 atoms of exactly one :ref:`data:Modification`, where the modification must be an
-induced subgraph of the molecule. Every modification must contain at least one
-"anchoring" atom, which is an atom that is also described by a
-:ref:`data:Block`. Unknown atoms are considered to be equal if their element is
-equal; anchor atoms are considered equal if their atom name is equal. Because
-modifications must be induced subgraphs of the input structure there can be no
-missing atoms!
+:ref:`induced subgraph <graph_algorithms:Induced subgraph isomorphism>` of the
+molecule. Every modification must contain at least one "anchoring" atom, which
+is an atom that is also described by a :ref:`data:Block`. Unknown atoms are
+considered to be equal if their element is equal; anchor atoms are considered
+equal if their atom name is equal. Because modifications must be
+:ref:`induced subgraphs <graph_algorithms:Induced subgraph isomorphism>` of the
+input structure there can be no missing atoms!
 
 After this step all atoms will have correct atom names, and any residues that
 are include modifications will be labelled. This information is later used

--- a/doc/source/martinize2_workflow.rst
+++ b/doc/source/martinize2_workflow.rst
@@ -1,35 +1,290 @@
 Martinize 2 workflow
 ####################
-Martinize 2 is the main command line interface entry point for vermouth.
-It does many interesting things which will be explained here later, and in the
-end you should end up with a topology for your system.
-Graph central in atom recognition/identification
-
 Pipeline
 ========
+Martinize 2 is the main command line interface entry point for vermouth.
+It effectively consists of 6 stages:
+
+1) reading input files
+2) repairing the input molecule
+3) mapping the input molecule to the desired output force field and resolution
+4) applying Links to generate inter-residue interactions
+5) post-processing, such as building an elastic network
+6) writing output files
+
+We'll describe each stage in more detail here. It is good to bear in mind
+however that in all stages the recognition/identification of atoms/particles is
+based on their *connectivity* in addition to any atom properties.
+
+Throughout this document, when we refer to an 'edge' we mean a connection
+between two nodes in a graph. With 'bonds' we mean a chemical connection
+including the corresponding simulation parameters. Similarly, with 'molecule' we
+mean a connected graph consisting of atoms and edges. Note that this is not
+necessarily the same as a protein chain, since these could be connected through
+e.g. a disulphide bridge.
+
+If martinize2 at some point encounters a situation that might result in an
+incorrect topology it will issue a warning, and refuse to write output files so
+that you are forced to examine the situation, but also see the ``-maxwarn`` CLI
+option. The options ``-v`` and ``-vv`` can be used to print more debug output,
+while the options ``-write-graph``, ``-write-repair`` and ``-write-canon`` can
+be used to write out the system after `Make bonds`_, `Repair graph`_ and
+`Identify modifications`_, respectively. All of these can help you track down
+what's going wrong where.
+
+1) Read input files
+===================
+
+Martinize2 can currently read input structures from .gro and .pdb files. .pdb
+files are preferred however, since they contain more information, such as chain
+identifiers, and ``TER`` and ``CONECT`` records.
+
+Reading PDB files
+-----------------
+Reading PDB files is done by :class:`~vermouth.processors.pdb_reader.PDBInput`.
+We take into account the following PDB records: ``MODEL`` and ``ENDMDL`` to
+determine which model to parse; ``ATOM`` and ``HETATM``; ``TER``, which can be
+used to separate molecules; ``CONECT``, which is used to add edges; and ``END``.
+
+Will issue a ``pdb-alternate`` warning if any atoms in the PDB file have an
+alternate conformation that is not 'A', since those will always be ignored.
+
+Relevant CLI options: ``-f``; ``-model``; ``-ignore``; ``-ignh``.
 
 Make bonds
 ----------
-:class:`~vermouth.processors.make_bonds.MakeBonds`
+Since atom identification is governed by their connectivity we need to generate
+bonds in the input structure. Where possible we get them from the input file
+such as PDB ``CONECT`` records. Beyond that, edges are added by
+:class:`~vermouth.processors.make_bonds.MakeBonds`. By default edges will be
+added based on atom names and distances, but this behaviour can be changed via
+the CLI option ``-bonds-from``.
+
+To add edges based on atom names the :class:`~vermouth.molecule.Block` from the
+input force field is used as reference for every residue in the input structure
+where possible. This is not possible when a residue contains multiple atoms with
+the same name, nor when there is no :class:`~vermouth.molecule.Block`
+corresponding to the residue. Note that this will only ever create edges
+*within* residues.
+
+Edges will be added based on distance when they are close enough together,
+except for a few exceptions (below). Atoms will be considered close enough based
+on their element (taken from either the PDB file directly, or deduced from atom
+name [#]_). The distance threshold is multiplied by ``-bonds-fudge`` to allow
+for conformations that are slightly out-of-equilibrium. Edges will not be added
+from distances in two cases: 1) if edges could be added based on atom names no
+edges will be added between atoms that are not bonded in the reference
+:class:`~vermouth.molecule.Block`. 2) No edges will be added between residues
+if one of the atoms involved is a hydrogen atom. Edges added this way are logged
+as debug output.
+
+If your input structure is far from equilibrium and adding edges based on
+distance is likely to produce erroneous results, make sure to provide ``CONECT``
+records describing at least the edges between residues, and between atoms
+involved in modifications, such as termini and PTMs.
+
+Will issue a ``general`` warning when it is requested to add edges based on atom
+names, but this cannot be done for some reason. This commonly happens when your
+input structure is a homo multimer without ``TER`` record and identical residue
+numbers and chain identifiers across the monomers. In this case martinize2
+cannot distinguish the atom "N", residue ALA1, chain "A" from the atom "N",
+residue ALA1, chain "A" in the next monomer. The easiest solution is to place
+strategic ``TER`` records in your PDB file.
+
+Relevant CLI options: ``-bond-from``; ``-bonds-fudge``
+
+.. [#] The method for deriving the element from an atom name is extremely
+   simplistic: the first letter is used. This will go wrong for two-letter
+   elements such as 'Fe', 'Cl', and 'Cu'. In those cases, make sure your PDB
+   file specified the correct element. See also:
+   :func:`~vermouth.graph_utils.add_element_attr`
+
+Annotate mutations and modifications
+------------------------------------
+As a last step martinize2 allows you to make some changes to your input
+structure from the CLI, for example to perform point mutations, or to apply
+PTMs and termini. This is done in part by
+:class:`~vermouth.processors.annotate_mut_mod.AnnotateMutMod`, and completed by
+`Repair graph`_.
+
+The ``-mutate`` option can be used to change the residue name of one or more
+residues. For example, you can specify ``-mutate PHE42:ALA`` to mutate all
+residues with residue name "PHE" and residue number 42 to "ALA". Or change all
+"HSE" residues to "HIS": ``-mutate HSE:HIS``. Mutations can be specified in a
+similar way.
+
+The specifications ``nter`` and ``cter`` can be used to quickly refer to all N-
+and C-terminal residues respectively [#]_. In addition, the CLI options
+``-nter`` and ``-cter`` can be used to change the N- and C-termini. By default
+martinize2 will try to apply charged protein termini ('N-ter' and 'C-ter'). If
+this is not what you want, for example because your molecule is not a protein,
+be sure to provide the appropriate ``-nter`` and ``-cter`` options. You can
+specify the modification ``none`` to specify that a residue should not have any
+modifications. Note that if you use this for the termini you may end up with
+chemically invalid, uncapped, termini.
+
+Relevant CLI options: ``-mutate``, ``-modify``, ``-nter``, ``-cter``, ``-nt``
+
+.. [#] N- and C-termini are defined as residues with 1 neighbour and having a
+   higher or lower residue number than the neighbour, respectively. Note that
+   this does not include zwitterionic amino acids!
+
+2) Repair the input graph
+=========================
+Depending on the origin of your input structure, there may be atoms missing, or
+atoms may have non-standard names. In addition, some residues may include
+modifications such as PTMs.
 
 Repair graph
 ------------
-:class:`~vermouth.processors.repair_graph.RepairGraph`
+The first step is to complete the graph so that it contains all atoms described
+by the reference :class:`Blocks <vermouth.molecule.Block>`, and that all atoms have
+the correct names. These blocks are taken from the input force field based on
+residue names (taking any mutations and modifications into account).
+:class:`~vermouth.processors.repair_graph.RepairGraph` takes care of all this.
 
-:class:`~vermouth.processors.canonicalize_modifications.CanonicalizeModifications`
+To identify atoms in a residue we consider the largest common induced subgraph
+between the residue and its reference since the residue can be both too small
+(atoms missing in the input) and too large (atoms from PTMs) at the same time.
+Unfortunately, this is a very expensive operation which scales exponentially
+with the size of the residue. So if you know beforehand that your structure
+contains (very) large PTMs, such as lipidations, consider specifying those as
+separate residues.
 
-Resolution transformation
--------------------------
-:class:`~vermouth.processors.do_mapping.DoMapping`
+The largest common induced subgraph is found using
+:class:`~vermouth.ismags.ISMAGS`, where nodes are considered equal if their
+elements are equal. Beforehand, the atoms in the residue will be sorted such
+that the isomorphism where most atom names correspond with the reference is
+found. This sorting also speeds up the calculation significantly, so if you're
+working with a system containing large residues consider correcting some of the
+atom names.
 
-Apply Links
------------
-:class:`~vermouth.processors.do_links.DoLinks`
+Will issue an ``unknown-residue`` warning if no Block can be retrieved for a
+given residue name. In this case the entire molecule will be removed from the
+system.
 
-Post processing
----------------
-:class:`~vermouth.processors.apply_rubber_band.ApplyRubberBand`
+Identify modifications
+----------------------
+Secondly, all modifications are identified. `Repair graph`_ will also tag all
+atoms it did not recognise, and those are processed by
+:class:`~vermouth.processors.canonicalize_modifications.CanonicalizeModifications`.
 
-Important command line options
-==============================
-Martinize2 CLI options
+This is done by finding the solution where all unknown atoms are covered by the
+atoms of exactly one :class:`~vermouth.molecule.Modification`, where the
+modification must be an induced subgraph of the molecule. Every modification
+must contain at least one "anchoring" atom, which is an atom that is also
+described by a :class:`~vermouth.molecule.Block`. Unknown atoms are considered
+to be equal if their element is equal; anchor atoms are considered equal if
+their atom name is equal. Because modifications must be induced subgraphs of the
+input structure there can be no missing atoms!
+
+After this step all atoms will have correct atom names, and any residues that
+are include modifications will be labelled. This information is later used
+during the :ref:`resolution transformation <martinize2_workflow:3) Resolution transformation>`
+
+An ``unknown-input`` warning will be issued if a modification cannot be
+identified. In this case the atoms involved will be removed from the system.
+
+Rebuild coordinates for missing atoms
+-------------------------------------
+Currently martinize2 is not capable of rebuilding coordinates for missing atoms.
+
+3) Resolution transformation
+============================
+The resolution transformation is done by
+:class:`~vermouth.processors.do_mapping.DoMapping`. This processor will produce
+your molecules at the target resolution, based on the available mappings. These
+mappings are read from the ``.map`` and ``.mapping`` files available in the
+library [#]_. See also :ref:`file_formats:File formats`. In essence these
+mappings describe how molecular fragments (atoms and bonds) correspond to a
+block in the target force field. We find all the ways these mappings can fit
+onto the input molecule, and add the corresponding blocks and modifications to
+the resulting molecule.
+
+For a molecular fragment to match the input molecule the atom and residue names
+need to match [#]_. This is why we first :ref:`repair <martinize2_workflow:2) Repair the input graph>`
+the input molecule so that you only need to consider the canonical atom names
+when adding mappings. Mappings defined by ``.mapping`` files can also cross
+residue boundaries (where specified).
+
+Edges and interactions within the blocks will come from the target force field.
+Edges between the blocks will be generated based on the connectivity of the
+input molecule, i.e. if atoms A and B are connected in the input molecule, the
+particles they map to in the output force field will also be connected.
+Interactions across separate blocks will be added in the next step.
+
+The processor will do some sanity checking on the resulting molecule, and issue
+an ``unmapped-atom`` warning if there are modifications in the input molecule
+for which no mapping can be found. In addition, this warning will also be issued
+if there are any non-hydrogen atoms that are not mapped to the output molecule.
+A more serious ``inconsistent-data`` warning will be issued for the following
+cases:
+
+- there are multiple modification mappings, which overlap
+- there are multiple block mappings, which overlap
+- there is an output particle that is constructed from multiple input atoms,
+  and some "residue level" attributes (such as residue name and number) are not
+  consistent between the constructing atoms.
+- there is an atom which maps to multiple particles in the output, but these
+  particles are disconnected
+- there is an interaction that is being set by multiple mappings
+
+Relevant CLI options: ``-ff``, ``-map-dir``
+
+.. [#] When ``-ff`` (target force field) and ``-from`` (original force field)
+   are the same the mappings will be generated automatically.
+.. [#] This is only mostly true. All attributes except a few that are not always
+   defined must match. Not all attributes (such as 'mass') are defined in all
+   cases, depending on the source of the mappings. Note that we also take into
+   account that atom names might have changed due to modifications: we use the
+   atom name as it is defined by the Block.
+
+4) Apply Links
+==============
+Next interactions *between* residues are added by
+:class:`~vermouth.processors.do_links.DoLinks`. We do this based on the concept
+of :class:`Links <vermouth.molecule.Link>`, which are molecular fragments that
+describe interactions, and which atoms they should apply to. Links are very
+powerful and flexible tools, and we use them to generate all interactions that
+depend on the local structure of the polymer. For example, all interactions that
+depend on the protein sequence or secondary structure are defined by Links.
+
+Links can both add, change and remove interactions and nodes. Because of this,
+the order in which links are applied matters for the final topology. We apply
+them in the order in which they are defined in the force field files. Therefore
+it is important to define links in the order of most general to most specific. A
+link is applied in all the places where it fits onto the molecule produced by
+:ref:`the mapping step <martinize2_workflow:3) Resolution transformation>`.
+
+For a link to match all its node attributes must match, where the 'order'
+attribute is a special case. The order attributes are translated to a
+difference in residue numbers, so that nodes 'BB' and '+BB' must have a
+difference in residue number of exactly 1 [#]_. Due to the reliance on residue
+numbers this can cause complications for non-linear polymers. For those cases
+order specifications such as '>' (greater than) and '*' (different from) [#]_
+might be useful.
+
+.. [#] Also '-BB' and 'BB', '+BB' and '++BB', etc.
+.. [#] Remember that links can overlap! The link ``BB *BB`` will be applied both
+   forwards and backwards!
+
+5) Post processing
+==================
+There can be any number of post processing steps. For example to add an elastic
+network, or to generate Go virtual sites. We will not describe their function
+here in detail. Instead, see
+:class:`~vermouth.processors.apply_rubber_band.ApplyRubberBand` and
+:class:`~vermouth.processors.go_vs_includes.GoVirtIncludes`.
+
+Relevant CLI options: ``-elastic``, ``-ef``, ``-el``, ``-eu``, ``-ermd``,
+``-ea``, ``-ep``, ``-em``, ``-eb``, ``-eunit``, ``-govs-include``,
+``-govs-moltype``
+
+6) Write output
+===============
+Finally, the topology and conformation are written to files (if no warnings were
+encountered along the way). Currently martinize2 and VerMoUTH can only write
+Gromacs itp files. Martinize2 will write a separate itp file for every unique
+molecule in the system.
+
+Relevant CLI options: ``-x``, ``-o``, ``-sep``, ``-merge``

--- a/doc/source/processors.rst
+++ b/doc/source/processors.rst
@@ -1,2 +1,2 @@
-Processors
-==========
+Processor
+=========

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -27,7 +27,7 @@ import copy
 import numbers
 import json
 from .molecule import (
-    Block, Link,
+    Block, Link, Modification,
     Interaction, DeleteInteraction,
     Choice, NotDefinedOrNot,
     ParamDistance, ParamAngle, ParamDihedral, ParamDihedralPhase,
@@ -194,7 +194,7 @@ class FFDirector(SectionLineParser):
         self.current_link = Link(force_field=self.force_field)
 
     def _new_modification(self):
-        self.current_modification = Link(force_field=self.force_field)
+        self.current_modification = Modification(force_field=self.force_field)
 
     @SectionLineParser.section_parser('variables')
     def _variables(self, line, lineno=0):

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -1299,6 +1299,10 @@ class Link(Block):
                     return False
         return True
 
+class Modification(Link):
+    """
+    A modification which describes deviations from a :class:`Block`.
+    """
 
 def attributes_match(attributes, template_attributes, ignore_keys=()):
     """

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -328,6 +328,23 @@ class Molecule(nx.Graph):
     determines in what order atoms will be written in the output. Same goes for
     the interactions within an interaction type. The order of edges is not
     guaranteed anywhere in the code, and they are not writen in the output.
+
+    Attributes
+    ----------
+    meta: dict
+    nrexcl: int
+    interactions: dict[str, list[Interaction]]
+        All the known interactions. Each item of the dictionary is a type of
+        interaction, with the key being the name of the kind of interaction
+        using Gromacs itp/rtp conventions ('bonds', 'angles', ...) and the
+        value being a list of all the interactions of that type in the residue.
+        An interaction is a dict with a key 'atoms' under which is stored the
+        list of the atoms involved (referred by their name), a key 'parameters'
+        under which is stored an arbitrary list of non-atom parameters as
+        written in a RTP file, and arbitrary keys to store custom metadata. A
+        given interaction can have a comment under the key 'comment'.
+    citations: set[str]
+        The citation keys associated with this molecule.
     """
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.
@@ -980,16 +997,6 @@ class Block(Molecule):
     ----------
     name: str or None
         The name of the residue. Set to `None` if undefined.
-    interactions: dict
-        All the known interactions. Each item of the dictionary is a type of
-        interaction, with the key being the name of the kind of interaction
-        using Gromacs itp/rtp conventions ('bonds', 'angles', ...) and the
-        value being a list of all the interactions of that type in the residue.
-        An interaction is a dict with a key 'atoms' under which is stored the
-        list of the atoms involved (referred by their name), a key 'parameters'
-        under which is stored an arbitrary list of non-atom parameters as
-        written in a RTP file, and arbitrary keys to store custom metadata. A
-        given interaction can have a comment under the key 'comment'.
     """
     # As the particles are stored as nodes, we want the nodes to stay
     # ordered.

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -426,9 +426,11 @@ def read_pdb(file_name, exclude=('SOL',), ignh=False, modelidx=1):
 
     Returns
     -------
-    vermouth.molecule.Molecule
+    list[vermouth.molecule.Molecule]
         The parsed molecules. Will only contain edges if the PDB file has
-        CONECT records. Either way, might be disconnected.
+        CONECT records. Either way, the molecules might be disconnected. Entries
+        separated by TER, ENDMDL, and END records will result in separate
+        molecules.
     """
     parser = PDBParser(exclude, ignh, modelidx)
     with open(str(file_name)) as file_handle:

--- a/vermouth/processors/annotate_mut_mod.py
+++ b/vermouth/processors/annotate_mut_mod.py
@@ -226,6 +226,19 @@ def annotate_modifications(molecule, modifications, mutations):
 
 
 class AnnotateMutMod(Processor):
+    """
+    Annotates residues to have the required 'modification' and 'mutation'
+    attributes on all nodes.
+
+    Attributes
+    ----------
+    modifications: list[tuple[dict, str]]
+    mutations: list[tuple[dict, str]]
+
+    See also
+    --------
+    :func:`annotate_modifications`
+    """
     def __init__(self, modifications=None, mutations=None):
         if not modifications:
             modifications = []

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -367,6 +367,61 @@ def same_chain(graph, left, right):
 
 
 class ApplyRubberBand(Processor):
+    """
+    Add an elastic network to a system between particles fulfilling the
+    following criteria:
+
+    - They must be close enough together in space
+    - They must be separated far enough in graph space
+    - They must be either in the same chain/molecule/system
+    - They must be selected by :attr:`selector`
+    - The resulting elastic bond must be stiff enough
+
+    Attributes
+    ----------
+    selector: collections.abc.Callable
+        Selection function.
+    lower_bound: float
+        The minimum length for a bond to be added, expressed in
+        nanometers.
+    upper_bound: float
+        The maximum length for a bond to be added, expressed in
+        nanometers.
+    decay_factor: float
+        Parameter for the decay function.
+    decay_power: float
+        Parameter for the decay function.
+    base_constant: float
+        The base force constant for the bonds in :math:`kJ.mol^{-1}.nm^{-2}`.
+        If 'decay_factor' or 'decay_power' is set to 0, then it will be the
+        used force constant.
+    minimum_force: float
+        Minimum force constant in :math:`kJ.mol^{-1}.nm^{-2}` under which bonds
+        are not kept.
+    bond_type: int or None
+        Gromacs bond function type to apply to the elastic network bonds.
+    bond_type_variable: str
+        If bond_type is not given, it will be taken from the force field, using
+        this variable name.
+    domain_criterion: collections.abc.Callable
+        Function to establish if two atoms are part of the same domain. Elastic
+        bonds are only added within a domain. By default, all the atoms in
+        the molecule are considered part of the same domain. The function
+        expects a graph (e.g. a :class:`~vermouth.molecule.Molecule`) and two
+        atom node keys as argument and returns ``True`` if the two atoms are
+        part of the same domain; returns ``False`` otherwise.
+    res_min_dist: int or None
+        Minimum separation between two atoms for a bond to be kept.
+        Bonds are kept is the separation is greater or equal to the value
+        given.
+    res_min_dist_variable: str
+        If res_min_dist is not given it will be taken from the force field using
+        this variable name.
+
+    See Also
+    --------
+    :func:`apply_rubber_band`
+    """
     def __init__(self, lower_bound, upper_bound, decay_factor, decay_power,
                  base_constant, minimum_force,
                  res_min_dist=None,

--- a/vermouth/processors/canonicalize_modifications.py
+++ b/vermouth/processors/canonicalize_modifications.py
@@ -36,7 +36,7 @@ def ptm_node_matcher(node1, node2):
     """
     Returns True iff node1 and node2 should be considered equal. This means
     they are both either marked as PTM_atom, or not. If they both are PTM
-    atoms, the elements need to match, and otherwise, the atomnames must
+    atoms, the elements need to match, and otherwise, the atom names must
     match.
     """
     if node1.get('PTM_atom', False) == node2.get('PTM_atom', False):
@@ -54,7 +54,7 @@ def find_ptm_atoms(molecule):
     """
     Finds all atoms in molecule that have the node attribute ``PTM_atom`` set
     to a value that evaluates to ``True``. ``molecule`` will be traversed
-    starting at these atoms untill all marked atoms are visited such that they
+    starting at these atoms until all marked atoms are visited such that they
     are identified per "branch", and for every branch the anchor node is known.
     The anchor node is the node(s) which are not PTM atoms and share an edge
     with the traversed branch.
@@ -71,7 +71,7 @@ def find_ptm_atoms(molecule):
         indices.
     """
 
-    # Atomnames have already been fixed, and missing atoms have been added.
+    # Atom names have already been fixed, and missing atoms have been added.
     # In addition, unrecognized atoms have been labeled with the PTM attribute.
     extra_atoms = set(n_idx for n_idx in molecule
                       if (molecule.nodes[n_idx].get('PTM_atom', False)
@@ -113,7 +113,7 @@ def find_ptm_atoms(molecule):
 
 def identify_ptms(residue, residue_ptms, known_ptms):
     """
-    Identifies all PTMs in ``known_PTMs`` nescessary to describe all PTM atoms in
+    Identifies all PTMs in ``known_PTMs`` necessary to describe all PTM atoms in
     ``residue_ptms``. Will take PTMs such that all PTM atoms in ``residue``
     will be covered by applying PTMs from ``known_PTMs`` in order.
     Nodes in ``residue`` must have correct ``atomname`` attributes, and may not
@@ -134,7 +134,7 @@ def identify_ptms(residue, residue_ptms, known_ptms):
         itself, but describe where it is attached to the molecule.
         In addition, its nodes must have the `atomname` attribute, which will
         be used to recognize where the PTM  is anchored, or to correct the
-        atomnames. Lastly, the nodes may have a `replace` attribute, which
+        atom names. Lastly, the nodes may have a `replace` attribute, which
         is a dictionary of ``{attribute_name: new_value}`` pairs. The special
         case here is if attribute_name is ``'atomname'`` and new_value is
         ``None``: in this case the node will be removed.
@@ -251,14 +251,14 @@ def allowed_ptms(residue, res_ptms, known_ptms):
 def fix_ptm(molecule):
     '''
     Canonizes all PTM atoms in molecule, and labels the relevant residues with
-    which PTMs were recognized. Modifies ``molecule`` such that atomnames of
+    which PTMs were recognized. Modifies ``molecule`` such that atom names of
     PTM atoms are corrected, and the relevant residues have been labeled with
     which PTMs were recognized.
 
     Parameters
     ----------
     molecule : networkx.Graph
-        Must not have missing atoms, and atomnames must be correct. Atoms which
+        Must not have missing atoms, and atom names must be correct. Atoms which
         could not be recognized must be labeled with the attribute
         PTM_atom=True.
     '''
@@ -370,6 +370,13 @@ def fix_ptm(molecule):
 
 
 class CanonicalizeModifications(Processor):
+    """
+    Identifies all modifications in a molecule and corrects their atom names.
+
+    See Also
+    --------
+    :func:`fix_ptm`
+    """
     def run_molecule(self, molecule):
         fix_ptm(molecule)
         return molecule

--- a/vermouth/processors/do_links.py
+++ b/vermouth/processors/do_links.py
@@ -263,7 +263,11 @@ def _build_link_interaction_from(molecule, interaction, match):
 
 
 class DoLinks(Processor):
+    """
+    Apply Links, taken from a molecule's force field, to the molecule.
+    """
     def run_molecule(self, molecule):
+        # TODO: Separate this into a function
         links = molecule.force_field.links
         _nodes_to_remove = []
         for link in links:

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -272,7 +272,8 @@ def modification_matches(molecule, mappings):
             LOGGER.warning("Can't find modification mappings for the "
                            "modifications {}. The following modification "
                            "mappings are known: {}",
-                           list(group), known_mod_mappings)
+                           list(group), known_mod_mappings,
+                           type='unmapped-atom')
             continue
         needed_mod_mappings.update(covered_by)
     matches = []
@@ -284,7 +285,7 @@ def modification_matches(molecule, mappings):
             matches.append((mol_to_mod, modification, references))
             if not set(mol_to_mod) <= modified_nodes:
                 # TODO: better message
-                LOGGER.warning('Overlapping modification mappings')
+                LOGGER.warning('Overlapping modification mappings', type='inconsistent-data')
             modified_nodes -= set(mol_to_mod)
     return matches
 

--- a/vermouth/processors/go_vs_includes.py
+++ b/vermouth/processors/go_vs_includes.py
@@ -60,8 +60,9 @@ class GoVirtIncludes(Processor):
 
     See Also
     --------
-    vermouth.processors.name_moltype.NameMolType
+    :class:`~vermouth.processors.name_moltype.NameMolType`
         Assign molecule type names to the molecules in a system.
+    :func:`add_virtual_sites`
     """
     def __init__(self, sections=('exclusions', )):
         self.sections = sections

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -316,10 +316,10 @@ class MakeBonds(Processor):
 
     If :attr:`allow_names` is True, the corresponding
     :class:`~vermouth.molecule.Block` is looked up in the system's force field.
-    Based on the edges in that block, edges will be added. In addition,
+    First edges will be added based on the edges in that block. In addition,
     *non-edges* in the reference block are also stored.
 
-    Secondly, is :attr:`allow_dist` is True, edges will be added between any
+    Secondly, if :attr:`allow_dist` is True, edges will be added between any
     atoms that are close enough together. The threshold for "close enough" is
     determined based on the elements of the atoms in question and their van der
     Waals radii, multiplied by :attr:`fudge`. This way edges will *not* be added

--- a/vermouth/processors/make_bonds.py
+++ b/vermouth/processors/make_bonds.py
@@ -301,6 +301,40 @@ def make_bonds(system, allow_name=True, allow_dist=True, fudge=1.2):
 
 
 class MakeBonds(Processor):
+    """
+    Processor to add edges to a system and separate it into separate connected
+    molecules.
+
+    Two separate criteria are used to decide where to add edges. The system's
+    molecules are separated into residues. Then intra-residue edges are added.
+
+    If :attr:`allow_names` is True, the corresponding
+    :class:`~vermouth.molecule.Block` is looked up in the system's force field.
+    Based on the edges in that block, edges will be added. In addition,
+    *non-edges* in the reference block are also stored.
+
+    Secondly, is :attr:`allow_dist` is True, edges will be added between any
+    atoms that are close enough together. The threshold for "close enough" is
+    determined based on the elements of the atoms in question and their van der
+    Waals radii, multiplied by :attr:`fudge`. This way edges will *not* be added
+    between atoms that were marked as 'non-edge' in the previous step, nor
+    between residues if one of the atoms is a hydrogen.
+
+    Attributes
+    ----------
+    allow_names: bool
+        Whether edges should be added based on atom names.
+    allow_dist: bool
+        Whether edges should be added based on distance.
+    fudge: :class:`~numbers.Number`
+        A fudge factor used to increase the reference van der Waals radii to
+        allow for conformations that are slightly out of equilibrium.
+
+    See Also
+    --------
+    :func:`make_bonds`
+
+    """
     def __init__(self, allow_name=True, allow_dist=True, fudge=1.2):
         self.allow_name = allow_name
         self.allow_dist = allow_dist

--- a/vermouth/processors/pdb_reader.py
+++ b/vermouth/processors/pdb_reader.py
@@ -27,6 +27,27 @@ from .processor import Processor
 
 
 class PDBInput(Processor):
+    """
+    Reads PDB files.
+
+    Attributes
+    ----------
+    filename: str
+        The filename to parse.
+    exclude: collections.abc.Container[str]
+        A collection of residue names that should not be parsed and excluded
+        from the final molecule(s)
+    ignh: bool
+        If True, hydrogens will be discarded from the input structure.
+    modelidx: int
+        The model number to parse/use.
+
+    See also
+    --------
+    :func:`~vermouth.pdb.pdb.read_pdb`
+    :func:`~vermouth.pdb.pdb.PDBParser`
+
+    """
     def __init__(self, filename, exclude=(), ignh=False, modelidx=0):
         super().__init__()
         self.filename = filename

--- a/vermouth/processors/repair_graph.py
+++ b/vermouth/processors/repair_graph.py
@@ -159,7 +159,7 @@ def make_reference(mol):
     Takes an molecule graph (e.g. as read from a PDB file), and finds and
     returns the graph how it should look like, including all matching nodes
     between the input graph and the references.
-    Requires residuenames to be correct.
+    Requires residue names to be correct.
 
     Notes
     -----
@@ -243,7 +243,7 @@ def make_reference(mol):
         #       good at solving isomorphism problems iff graphs look alike. We
         #       can do a similar trick here by rot+trans aligning the given
         #       residue with a reference conformation. And then sort by
-        #       distance
+        #       distance as third criterion
         new_residue_names = {old: new for new, old in enumerate(sorted(
             residue,
             key=lambda jdx: (res_names[jdx] not in ref_names.values(), res_names[jdx])  # pylint: disable=cell-var-from-loop
@@ -419,12 +419,12 @@ def repair_graph(molecule, reference_graph, include_graph=True):
     names will be canonicalized. Atoms not present in ``reference_graph`` will
     have the attribute ``PTM_atom`` set to ``True``.
 
-    `molecule` is modified in place. Missing atoms (as per `reference_graph`)
+    ``molecule`` is modified in place. Missing atoms (as per ``reference_graph``)
     are added, atom and residue names are canonicalized, and PTM atoms are
     marked.
 
-    If `include_graph` is `True`, then the subgraph corresponding to each node
-    is included in the node under the "graph" attribute.
+    If ``include_graph`` is ``True``, then the subgraph corresponding to each
+    node is included in the node under the "graph" attribute.
 
     Parameters
     ----------
@@ -437,7 +437,7 @@ def repair_graph(molecule, reference_graph, include_graph=True):
         :atomname: The atomname.
 
     reference_graph : networkx.Graph
-        The reference graph as produced by ``make_reference``. Required node
+        The reference graph as produced by :func:`make_reference`. Required node
         attributes:
 
         :resid: The residue id.
@@ -476,6 +476,25 @@ def repair_graph(molecule, reference_graph, include_graph=True):
 
 
 class RepairGraph(Processor):
+    """
+    Repairs a molecule such that it contains all atoms with appropriate atom
+    names, as per the blocks in the system's force field, while taking any
+    mutations and modification into account. These should be added as 'mutation'
+    and 'modification' attributes to the atoms of the relevant residues.
+
+    Attributes
+    ----------
+    delete_unknown: bool
+        If True, removes any molecules that contain residues that are not known
+        to the system's force field.
+    include_graph: bool
+        If True, every node in the resulting graph will have a 'graph' attribute
+        containing a subgraph constructed using the input atoms.
+
+    See Also
+    --------
+    :func:`repair_graph`
+    """
     def __init__(self, delete_unknown=False, include_graph=True):
         super().__init__()
         self.delete_unknown = delete_unknown


### PR DESCRIPTION
So I started writing documentation with the workshop in mind. Along the way I also clean up little bits of docstrings in the code.
I should have the documentation for the workflow tomorrow, with more following next week.

In the meantime, this can be reviewed in batches/per commit.

If you want to look at this the shiny way: in ./doc run `sphinx-build -b html -n source build` and open `doc/build/index.html`. Update the packages in `requirement-docs.txt` beforehand! Alternatively, see them here: https://vermouth-martinize.readthedocs.io/en/docs/

Fixes #372 

TODO:
- [x] Expand some of the processor docstrings
- [x] Intersphinx the references to Blocks etc in general_overview.rst
- [x] data.rst. 
- [x] Change some links in martinize2_worklfow to point to data.rst instead of the API docs.
- [x] graph_algorithms.rst
- [x] file_formats.rst: very briefly explain they're subject to change and undocumented. Refer to provided ff files.

I'll leave the tutorials to someone actually involved in the workshop.