### PR TITLE
Deferring

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -118,8 +118,8 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
                        fudge=bonds_fudge).run_system(canonicalized)
     vermouth.MergeNucleicStrands().run_system(canonicalized)
     if write_graph is not None:
-        vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True)
-        DeferredFileWriter().write()
+        vermouth.pdb.write_pdb(canonicalized, str(write_graph), omit_charges=True,
+                               defer_writing=False)
 
     LOGGER.debug('Annotating required mutations and modifications.', type='step')
     vermouth.AnnotateMutMod(modifications, mutations).run_system(canonicalized)
@@ -127,14 +127,14 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
     vermouth.RepairGraph(delete_unknown=delete_unknown, include_graph=False).run_system(canonicalized)
     if write_repair is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_repair),
-                               omit_charges=True, nan_missing_pos=True)
-        DeferredFileWriter().write()
+                               omit_charges=True, nan_missing_pos=True, 
+                               defer_writing=False)
     LOGGER.info('Dealing with modifications.', type='step')
     vermouth.CanonicalizeModifications().run_system(canonicalized)
     if write_canon is not None:
         vermouth.pdb.write_pdb(canonicalized, str(write_canon),
-                               omit_charges=True, nan_missing_pos=True)
-        DeferredFileWriter().write()
+                               omit_charges=True, nan_missing_pos=True,
+                               defer_writing=False)
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
     vermouth.SortMoleculeAtoms().run_system(canonicalized) # was system
     return canonicalized

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -28,7 +28,7 @@ import sys
 
 import vermouth
 import vermouth.forcefield
-from vermouth.file_writer import open, DeferredFileWriter
+from vermouth.file_writer import deferred_open, DeferredFileWriter
 from vermouth import DATA_PATH
 from vermouth.dssp import dssp
 from vermouth.dssp.dssp import (
@@ -191,7 +191,7 @@ def write_gmx_topology(system, top_path, defines=(), header=()):
             # A given moltype can appear more than once in the sequence of
             # molecules, without being uninterupted by other moltypes. Even in
             # that case, we want to write the ITP only once.
-            with open('{}.itp'.format(moltype), 'w') as outfile:
+            with deferred_open('{}.itp'.format(moltype), 'w') as outfile:
                 # here we format and merge all citations
                 header[-1] = header[-1]+"\n"
                 header.append("Pleas cite the following papers:")
@@ -232,7 +232,7 @@ def write_gmx_topology(system, top_path, defines=(), header=()):
     define_string = '\n'.join(
         '#define {}'.format(define) for define in defines
     )
-    with open(str(top_path), 'w') as outfile:
+    with deferred_open(str(top_path), 'w') as outfile:
         outfile.write(
             textwrap.dedent(
                 template.format(

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -22,7 +22,7 @@ import os
 import subprocess
 import tempfile
 
-from ..file_writer import open
+from ..file_writer import deferred_open
 from ..pdb import pdb
 from ..system import System
 from ..processors.processor import Processor
@@ -143,7 +143,7 @@ def read_dssp2(lines):
     return secstructs
 
 
-def run_dssp(system, executable='dssp', savefile=None):
+def run_dssp(system, executable='dssp', savefile=None, defer_writing=True):
     """
     Run DSSP on a system and return the assigned secondary structures.
 
@@ -170,6 +170,8 @@ def run_dssp(system, executable='dssp', savefile=None):
         Where to find the DSSP executable.
     savefile: None or str or pathlib.Path
         If set to a path, the output of DSSP is written in that file.
+    defer_writing: bool
+        Whether to use :meth:`~vermouth.file_writer.DeferredFileWriter.write` for writing data
 
     Returns
     list of str
@@ -216,6 +218,8 @@ def run_dssp(system, executable='dssp', savefile=None):
         LOGGER.debug('DSSP input file written to {}', tmpfile_name)
 
     if savefile is not None:
+        if defer_writing:
+            open = deferred_open
         with open(str(savefile), 'w') as outfile:
             outfile.write(process.stdout)
     return read_dssp2(process.stdout.split('\n'))

--- a/vermouth/file_writer.py
+++ b/vermouth/file_writer.py
@@ -202,4 +202,4 @@ class DeferredFileWriter(metaclass=Singleton):
         # super().__del__()  # object has no __del__
 
 
-open = DeferredFileWriter().open
+deferred_open = DeferredFileWriter().open

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -19,7 +19,6 @@ Provides a class used to describe a forcefield and all associated data.
 import itertools
 from glob import glob
 import os
-from .file_writer import open
 from .gmx.rtp import read_rtp
 from .ffinput import read_ff
 from .citation_parser import read_bib

--- a/vermouth/gmx/gro.py
+++ b/vermouth/gmx/gro.py
@@ -20,7 +20,7 @@ from itertools import chain
 
 import numpy as np
 
-from ..file_writer import open
+from ..file_writer import deferred_open
 from ..molecule import Molecule
 from ..truncating_formatter import TruncFormatter
 from ..utils import first_alpha
@@ -110,7 +110,7 @@ def read_gro(file_name, exclude=('SOL',), ignh=False):
     return molecule
 
 
-def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0)):
+def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0), defer_writing=True):
     """
     Write `system` to `file_name`, which will be a GRO96 file.
 
@@ -126,6 +126,8 @@ def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0)
         Title for the gro file.
     box: tuple[float]
         Box length and optionally angles.
+    defer_writing: bool
+        Whether to use :meth:`~vermouth.file_writer.DeferredFileWriter.write` for writing data
     """
     formatter = TruncFormatter()
     pos_format_string = '{{:{ntx}.3ft}}'.format(ntx=precision + 1)
@@ -138,6 +140,8 @@ def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0)
         vel_format_string = '{{:{ntx}.4ft}}'*3
         vel_format_string = vel_format_string.format(ntx=precision+1)
 
+    if defer_writing:
+        open = deferred_open
     with open(str(file_name), 'w') as out:
         out.write(title + '\n')  # Title
         out.write(formatter.format('{}\n', system.num_particles))  # number of atoms

--- a/vermouth/map_input.py
+++ b/vermouth/map_input.py
@@ -22,7 +22,6 @@ import collections
 import itertools
 from pathlib import Path
 
-from .file_writer import open
 from .log_helpers import StyleAdapter, get_logger
 from .map_parser import MappingDirector, Mapping
 

--- a/vermouth/map_parser.py
+++ b/vermouth/map_parser.py
@@ -18,7 +18,6 @@ Contains the Mapping object and the associated parser.
 from collections import defaultdict
 from functools import partial
 
-from .file_writer import open
 from .ffinput import _tokenize, _parse_atom_attributes
 from .graph_utils import MappingGraphMatcher
 from .log_helpers import StyleAdapter, get_logger

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -19,7 +19,7 @@ Provides functions for reading and writing PDB files.
 import numpy as np
 import networkx as nx
 
-from ..file_writer import open
+from ..file_writer import deferred_open
 from ..molecule import Molecule
 from ..utils import first_alpha, distance, format_atom_string
 from ..parser_utils import LineParser
@@ -552,7 +552,7 @@ def write_pdb_string(system, conect=True, omit_charges=True, nan_missing_pos=Fal
     return '\n'.join(out)
 
 
-def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=False):
+def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=False, defer_writing=True):
     """
     Writes `system` to `path` as a PDB formatted string.
 
@@ -573,10 +573,14 @@ def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=Fals
         with 'nan' as coordinates; this will cause the output file to be
         *invalid* for most uses.
         for most use.
+    defer_writing: bool
+        Whether to use :class:`~vermouth.file_writer.DeferredFileWriter` for writing data
 
     See Also
     --------
     :func:write_pdb_string
     """
+    if defer_writing:
+        open = deferred_open
     with open(path, 'w') as out:
         out.write(write_pdb_string(system, conect, omit_charges, nan_missing_pos))

--- a/vermouth/processors/quote.py
+++ b/vermouth/processors/quote.py
@@ -21,7 +21,6 @@ Reads quotes, and produces a random one.
 import os.path
 import random
 
-from ..file_writer import open
 from .processor import Processor
 from .. import DATA_PATH
 from ..log_helpers import StyleAdapter, get_logger


### PR DESCRIPTION
This PR changes file_writer.open to file_writer.deferred_open and adds defer_writing=TRUE as boolean keyword argument to writing functions, so as to allow both direct as well as deferred writing (e.g. in write_pdb). Overwriting the function 'open' with file_writer.DeferredWriter().open was never a good idea.