### PR TITLE
Fix write_pdb to always define open

### DIFF
--- a/vermouth/gmx/gro.py
+++ b/vermouth/gmx/gro.py
@@ -142,6 +142,8 @@ def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0)
 
     if defer_writing:
         open = deferred_open
+    else:
+        from builtins import open
     with open(str(file_name), 'w') as out:
         out.write(title + '\n')  # Title
         out.write(formatter.format('{}\n', system.num_particles))  # number of atoms

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -582,5 +582,10 @@ def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=Fals
     """
     if defer_writing:
         open = deferred_open
+    else:
+        # This is needed since the variable assignment above declares `open` as
+        # a local variable, which means it won't be looked up from the global
+        # namespace any more.
+        from builtins import open
     with open(path, 'w') as out:
         out.write(write_pdb_string(system, conect, omit_charges, nan_missing_pos))


### PR DESCRIPTION
Since open is defined as a local variable (if defer_writing) it won't be looked up in the global namespace (if not defer_writing).

Fixes #433