### PR TITLE
Fix/432 by making sure modifications are connected components

### DIFF
--- a/vermouth/data/force_fields/universal/modifications.ff
+++ b/vermouth/data/force_fields/universal/modifications.ff
@@ -61,28 +61,37 @@ OE1 HE1
 [ modification ]
 HSD
 [ atoms ]
+NE2 {"resname": "HIS", "element": "N"}
+HE2 {"resname": "HIS", "element": "H", "replace": {"atomname": null}}
+CE1 {"resname": "HIS", "element": "C"}
 ND1 {"resname": "HIS", "element": "N"}
 HD1 {"resname": "HIS", "element": "H", "PTM_atom": true}
 [ edges ]
+NE2 HE2
+CE1 NE2
+ND1 CE1
 ND1 HD1
 
 [ modification ]
 HSE
 [ atoms ]
-NE1 {"resname": "HIS", "element": "N"}
-HE1 {"resname": "HIS", "element": "H", "PTM_atom": true}
+NE2 {"resname": "HIS", "element": "N"}
+HE2 {"resname": "HIS", "element": "H", "PTM_atom": false}
 [ edges ]
-NE1 HE1
+NE2 HE2
 
 [ modification ]
 HSP
 [ atoms ]
-NE1 {"resname": "HIS", "element": "N"}
-HE1 {"resname": "HIS", "element": "H", "PTM_atom": true}
+NE2 {"resname": "HIS", "element": "N"}
+HE2 {"resname": "HIS", "element": "H", "PTM_atom": false}
+CE1 {"resname": "HIS", "element": "C"}
 ND1 {"resname": "HIS", "element": "N"}
 HD1 {"resname": "HIS", "element": "H", "PTM_atom": true}
 [ edges ]
-NE1 HE1
+NE2 HE2
+CE1 NE2
+ND1 CE1
 ND1 HD1
 
 [ modification ]

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -36,6 +36,9 @@ from .parser_utils import (
     SectionLineParser, _tokenize, _substitute_macros, _parse_macro
 )
 
+from .log_helpers import StyleAdapter, get_logger
+import networkx as nx
+
 # Python 3.4 does not raise JSONDecodeError but ValueError.
 
 try:
@@ -43,6 +46,7 @@ try:
 except ImportError:
     JSONDecodeError = ValueError
 
+LOGGER = StyleAdapter(get_logger(__name__))
 VALUE_PREDICATES = {
     'not': NotDefinedOrNot,
 }
@@ -170,6 +174,9 @@ class FFDirector(SectionLineParser):
 
         if self.current_modification is not None:
             # add FF wide citations
+            if not nx.is_connected(self.current_modification):
+                LOGGER.error('Modification {} in force field {} is not a single connected component',
+                             self.current_modification.name, self.force_field.name)
             self.current_modification.citations.update(self.citations)
             self.force_field.modifications[self.current_modification.name] = self.current_modification
 

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -174,7 +174,7 @@ class FFDirector(SectionLineParser):
 
         if self.current_modification is not None:
             # add FF wide citations
-            if not nx.is_connected(self.current_modification):
+            if self.current_modification and not nx.is_connected(self.current_modification):
                 LOGGER.error('Modification {} in force field {} is not a single connected component',
                              self.current_modification.name, self.force_field.name)
             self.current_modification.citations.update(self.citations)

--- a/vermouth/log_helpers.py
+++ b/vermouth/log_helpers.py
@@ -219,7 +219,7 @@ class CountingHandler(logging.NullHandler):
         """
         out = 0
         for lvl, type_counts in self.counts.items():
-            if level is not None and level != lvl:
+            if level is not None and lvl < level:
                 continue
             for type_, count in type_counts.items():
                 if type is not None and type != type_:

--- a/vermouth/tests/test_logging.py
+++ b/vermouth/tests/test_logging.py
@@ -301,7 +301,7 @@ def test_bipolar_formatter_logger():
 
 @pytest.mark.parametrize('level, type_, expected', (
     [None, None, 7],
-    [logging.DEBUG, None, 2],
+    [logging.DEBUG, None, 7],
     [None, 'a', 2],
     [logging.INFO, 'general', 2],
     [None, 'd', 0]


### PR DESCRIPTION
`canonicalize_modificaitons.identify_ptms` assumes modifications are connected components. If this assumption is violated, in combination with the `-modify` flag, this causes hard to debug user facing errors (see #432 for more background).

This PR resolves that by
1) Log an error for any modification that is not a connected component.
2) Modify the maxwarn mechanism to count all messages >= warning, meaning an error will cause no files to be written. Note that the `-maxwarn` flag cannot override errors, only warnings.