### PR TITLE
fix modifications

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -384,7 +384,7 @@ class FFDirector(SectionLineParser):
     @SectionLineParser.section_parser('moleculetype', 'patterns')
     @SectionLineParser.section_parser('moleculetype', 'features')
     @SectionLineParser.section_parser('moleculetype', 'non-edge')
-    @SectionLineParser.section_parser('modifications', 'non-edge')
+    @SectionLineParser.section_parser('modification', 'non-edge')
     def _invalid_out_of_link(self, line, lineno=0):
         raise IOError('The "{}" section is only valid in links.'
                       .format(self.section[-1]))
@@ -409,7 +409,7 @@ class FFDirector(SectionLineParser):
         tokens = collections.deque(_tokenize(line))
         _parse_link_atom(tokens, self.current_modification,
                          defaults={'PTM_atom': False},
-                         treat_prefix=False)
+                         treat_prefix=True)
 
     @SectionLineParser.section_parser('link', 'patterns', context_type='link')
     @SectionLineParser.section_parser('modification', 'patterns', context_type='modification')
@@ -806,9 +806,8 @@ def _base_parser(tokens, context, context_type, section, natoms=None, delete=Fal
     # * interactions create nodes
     if context_type == 'block':
         treated_atoms = _treat_block_interaction_atoms(atoms, context, section)
-    elif context_type in ('link', 'modifications'):
+    elif context_type in ('link', 'modification'):
         treated_atoms = _treat_link_interaction_atoms(atoms, context, section)
-
 
     # Getting the atoms consumed the "--" delimiter if any. So what is left
     # are the interaction parameters or the meta attributes.

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -114,6 +114,8 @@ def _old_atomname_match(node1, node2):
     node2 = node2.copy()
     node1['_name'] = name1
     node2['_name'] = name2
+    if 'order' in node2 and 'order' not in node1:
+        node1['order'] = node2['order']
     del node1['atomname']
     del node2['atomname']
     return node_matcher(node1, node2)

--- a/vermouth/tests/test_ff_files.py
+++ b/vermouth/tests/test_ff_files.py
@@ -1061,7 +1061,7 @@ class TestModification:
         """
         lines = """
         [ modification ]
-        [modification]
+        [ modification ]
         """
         lines = textwrap.dedent(lines).splitlines()
         ff = vermouth.forcefield.ForceField(name='test_ff')
@@ -1079,12 +1079,15 @@ class TestModification:
         CA{"element": "C"}  ; the space between the name and the attributes is optionnal
         C {"element": "C"}
         O {"element": "O"}
+        H {"element": "H", "PTM_atom": true}
         OXT {"element": "O", "PTM_atom": true, "replace": {"atomname": null}}
-
+        [ bonds ]
+        O  H  1  0.12  1000
         [ edges ]
         CA C
         C O
         C OXT
+        O H
         """
         lines = textwrap.dedent(lines).splitlines()
         ff = vermouth.forcefield.ForceField(name='test_ff')
@@ -1093,19 +1096,26 @@ class TestModification:
 
         assert modification.name == 'C-ter'
         assert tuple(modification.nodes(data=True)) == (
-            ('CA', {'element': 'C', 'PTM_atom': False, 'atomname': 'CA'}),
-            ('C', {'element': 'C', 'PTM_atom': False, 'atomname': 'C'}),
-            ('O', {'element': 'O', 'PTM_atom': False, 'atomname': 'O'}),
+            ('CA', {'element': 'C', 'PTM_atom': False, 'atomname': 'CA', 'order': 0}),
+            ('C', {'element': 'C', 'PTM_atom': False, 'atomname': 'C', 'order': 0}),
+            ('O', {'element': 'O', 'PTM_atom': False, 'atomname': 'O', 'order': 0}),
+            ('H', {'element': 'H', 'PTM_atom': True, 'atomname': 'H', 'order': 0}),
             ('OXT', {
                 'element': 'O',
                 'PTM_atom': True,
                 'atomname': 'OXT',
+                'order': 0,
                 'replace': {'atomname': None}
             }),
         )
+        assert modification.interactions['bonds'] == [vermouth.molecule.Interaction(atoms=['O', 'H'],
+                                                                                    parameters=['1', '0.12', '1000'],
+                                                                                    meta={},)]
+
         assert set(frozenset(edge) for edge in modification.edges) == {
             frozenset(('CA', 'C')),
             frozenset(('C', 'O')),
+            frozenset(('H', 'O')),
             frozenset(('C', 'OXT')),
         }
 


### PR DESCRIPTION
This fixes issue #384. However, there is one caveat: Now the modification can have an order attribute. This originates from the way we treat the atoms when making interactions. Even though we maybe don't want this, having order attributes is most consistent in my opinion with the fact that modifications is a subclass of `Link`. I would propose to later down the line disentangle the Modifications object from the Link, because they are really very separate things. As far as I can asses it makes no difference between having order attributes as to not having them in the current code. 