### PR TITLE
Add option to generate log entries from .ff files

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -766,6 +766,9 @@ def entry():
     LOGGER.info('Writing output.', type='step')
     for molecule in system.molecules:
         LOGGER.debug("Writing molecule {}.", molecule, type='step')
+        for loglevel, entries in molecule.log_entries.items():
+            for entry in entries:
+                LOGGER.log(loglevel, entry)
 
     # Write the topology if requested
     # grompp has a limit in the number of character it can read per line

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -181,9 +181,12 @@ class FFDirector(SectionLineParser):
             self.current_modification.citations.update(self.citations)
             self.force_field.modifications[self.current_modification.name] = self.current_modification
 
-    def get_context(self, context_type):
+    def get_context(self, context_type=''):
+        if not context_type:
+            context_type = self.section[0]
         possible_contexts = {
             'block': self.current_block,
+            'moleculetype': self.current_block,
             'link': self.current_link,
             'molmeta': self.current_link,
             'modification': self.current_modification,
@@ -439,23 +442,21 @@ class FFDirector(SectionLineParser):
         cite_keys = line.split()
         self.citations.update(cite_keys)
 
-    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block', loglevel='debug')
-    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='debug')
-    @SectionLineParser.section_parser('modification', 'citation', context_type='modification', loglevel='debug')
-    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block',
-                                      loglevel='info')
-    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='info')
-    @SectionLineParser.section_parser('modification', 'citation', context_type='modification',
-                                      loglevel='info')
-    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block', loglevel='warning')
-    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='warning')
-    @SectionLineParser.section_parser('modification', 'citation', context_type='modification', loglevel='warning')
-    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block', loglevel='error')
-    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='error')
-    @SectionLineParser.section_parser('modification', 'citation', context_type='modification', loglevel='error')
-    def _parse_log_entry(self, line, lineno=0, context_type="", loglevel=""):
-        loglevel = logging.getLevelName(loglevel.upper())
-        self.get_context(context_type).log_entries[loglevel].add(line)
+    @SectionLineParser.section_parser('moleculetype', 'debug',)
+    @SectionLineParser.section_parser('link', 'debug',)
+    @SectionLineParser.section_parser('modification', 'debug')
+    @SectionLineParser.section_parser('moleculetype', 'info')
+    @SectionLineParser.section_parser('link', 'info')
+    @SectionLineParser.section_parser('modification', 'info')
+    @SectionLineParser.section_parser('moleculetype', 'warning')
+    @SectionLineParser.section_parser('link', 'warning')
+    @SectionLineParser.section_parser('modification', 'warning')
+    @SectionLineParser.section_parser('moleculetype', 'error')
+    @SectionLineParser.section_parser('link', 'error')
+    @SectionLineParser.section_parser('modification', 'error')
+    def _parse_log_entry(self, line, lineno=0):
+        loglevel = logging.getLevelName(self.section[-1].upper())
+        self.get_context().log_entries[loglevel].add(line)
 
 
 def _some_atoms_left(tokens, atoms, natoms):

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -24,6 +24,7 @@ is done in the same way an ITP file describes a molecule.
 
 import collections
 import copy
+import logging
 import numbers
 import json
 from .molecule import (
@@ -437,6 +438,25 @@ class FFDirector(SectionLineParser):
         # parses force-field wide citations
         cite_keys = line.split()
         self.citations.update(cite_keys)
+
+    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block', loglevel='debug')
+    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='debug')
+    @SectionLineParser.section_parser('modification', 'citation', context_type='modification', loglevel='debug')
+    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block',
+                                      loglevel='info')
+    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='info')
+    @SectionLineParser.section_parser('modification', 'citation', context_type='modification',
+                                      loglevel='info')
+    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block', loglevel='warning')
+    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='warning')
+    @SectionLineParser.section_parser('modification', 'citation', context_type='modification', loglevel='warning')
+    @SectionLineParser.section_parser('moleculetype', 'debug', context_type='block', loglevel='error')
+    @SectionLineParser.section_parser('link', 'citation', context_type='link', loglevel='error')
+    @SectionLineParser.section_parser('modification', 'citation', context_type='modification', loglevel='error')
+    def _parse_log_entry(self, line, lineno=0, context_type="", loglevel=""):
+        loglevel = logging.getLevelName(loglevel.upper())
+        self.get_context(context_type).log_entries[loglevel].add(line)
+
 
 def _some_atoms_left(tokens, atoms, natoms):
     """

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -439,6 +439,8 @@ class Molecule(nx.Graph):
         """
         new = self.subgraph(self.nodes)
         new.name = self.name
+        new.citations = self.citations.copy()
+        new.log_entries = copy.deepcopy(self.log_entries)
         return new
 
     def subgraph(self, nodes):
@@ -718,7 +720,6 @@ class Molecule(nx.Graph):
         for name, interactions in molecule.interactions.items():
             for interaction in interactions:
                 atoms = tuple(correspondence[atom] for atom in interaction.atoms)
-                #print(atoms, interaction.meta)
                 self.add_interaction(name, atoms, interaction.parameters, interaction.meta)
         for node1, node2 in molecule.edges:
             if correspondence[node1] != correspondence[node2]:

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -357,6 +357,7 @@ class Molecule(nx.Graph):
         super().__init__(*args, **kwargs)
         self.interactions = defaultdict(list)
         self.citations = set()
+        self.log_entries = defaultdict(set)
         self.max_node = None
 
     def __eq__(self, other):
@@ -724,6 +725,9 @@ class Molecule(nx.Graph):
                 self.add_edge(correspondence[node1], correspondence[node2])
         # merge the citation sets
         self.citations.update(molecule.citations)
+        # Merge the log entries
+        for loglevel, entries in molecule.log_entries.items():
+            self.log_entries[loglevel].update(entries)
 
         return correspondence
 
@@ -1189,6 +1193,7 @@ class Block(Molecule):
         name_to_idx = {}
         mol = Molecule(force_field=force_field)
         mol.citations = self.citations
+        mol.log_entries = copy.deepcopy(self.log_entries)
 
         for idx, node in enumerate(self.nodes, start=atom_offset):
             name_to_idx[node] = idx

--- a/vermouth/processors/do_links.py
+++ b/vermouth/processors/do_links.py
@@ -272,6 +272,9 @@ class DoLinks(Processor):
         _nodes_to_remove = []
         for link in links:
             matches = match_link(molecule, link)
+            for loglevel, entries in link.log_entries.items():
+                molecule.log_entries[loglevel].update(entries)
+
             for match in matches:
                 for node, node_attrs in link.nodes.items():
                     if 'replace' in node_attrs:

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -405,6 +405,8 @@ def apply_mod_mapping(match, molecule, graph_out, mol_to_out, out_to_mol):
     mol_to_mod, modification, references = match
     LOGGER.info('Applying modification mapping {}', modification.name, type='general')
     graph_out.citations.update(modification.citations)
+    for loglevel, entries in modification.log_entries.items():
+        graph_out.log_entries[loglevel].update(entries)
     mod_to_mol = defaultdict(dict)
     for mol_idx, mod_idxs in mol_to_mod.items():
         for mod_idx in mod_idxs:


### PR DESCRIPTION
This PR adds the option to have martinize2 generate log statements based on .ff files. Blocks, Modifications and Links get debug, info, warning, and error sections, in which each line will become a log statement with the appropriate level.
This is still WIP, since I kind of want to be able to do e.g. 
```
[ info ]
Created a disulfide bridge between residues {SC1['resid']} and {>SC1['resid']}.
```
but I'm not quite sure yet how painful that's going to be (shouldn't be too bad though, `format` will do the heavy lifting). Does require some bookkeeping .

Question, should each line in a section result in a separate log message, or should these be aggregated to a single entry?