### PR TITLE
Update gh actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: pip
         cache-dependency-path: |
           **/setup.cfg
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-           python-version: 3.10
+           python-version: '3.10'
            cache: pip
            cache-dependency-path: |
              **/setup.cfg
@@ -120,7 +120,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: pip
         cache-dependency-path: |
           **/setup.cfg

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,15 +19,15 @@ jobs:
     
     strategy:
       matrix:
-       py_version: ["3.6", "3.7", "3.8", "3.9"] 
+       py_version: ["3.7", "3.8", "3.9", "3.10"]
        include:
-         - py_version: "3.6"
-           WITH_CODECOV: true
          - py_version: "3.7"
            WITH_CODECOV: true
          - py_version: "3.8"
            WITH_CODECOV: true
          - py_version: "3.9"
+           WITH_CODECOV: true
+         - py_version: "3.10"
            WITH_CODECOV: true
 
     steps:
@@ -61,10 +61,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
         cache: pip
     - name: Install dependencies
       run: |
@@ -82,10 +82,10 @@ jobs:
       
       steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-           python-version: 3.9
+           python-version: 3.10
            cache: pip
       - name: Install dependencies
         run: |
@@ -105,10 +105,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
         cache: pip
         
     - name: Install pypa/build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,10 @@ jobs:
       with:
         python-version: ${{ matrix.py_version }}
         cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/requirements-*.txt
+          **/pyproject.toml
     - name: Install dependencies part I
       run: |
         sudo apt-get install dssp
@@ -66,6 +70,10 @@ jobs:
       with:
         python-version: 3.10
         cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/requirements-*.txt
+          **/pyproject.toml
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip
@@ -87,6 +95,10 @@ jobs:
         with:
            python-version: 3.10
            cache: pip
+           cache-dependency-path: |
+             **/setup.cfg
+             **/requirements-*.txt
+             **/pyproject.toml
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools pip
@@ -110,6 +122,10 @@ jobs:
       with:
         python-version: 3.10
         cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/requirements-*.txt
+          **/pyproject.toml
         
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,11 +31,12 @@ jobs:
            WITH_CODECOV: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.py_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.py_version }}
+        cache: pip
     - name: Install dependencies part I
       run: |
         sudo apt-get install dssp
@@ -59,11 +60,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
+        cache: pip
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip
@@ -79,11 +81,12 @@ jobs:
       runs-on: ubuntu-latest
       
       steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
            python-version: 3.9
+           cache: pip
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools pip
@@ -101,11 +104,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.9
+        cache: pip
         
     - name: Install pypa/build
       run: >-
@@ -124,7 +128,7 @@ jobs:
         --outdir dist/
         
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master      
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-       user: __token__
-       password: ${{ secrets.PYPI_API_TOKEN }}
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     
     strategy:
       matrix:
-       py_version: ["3.7", "3.8", "3.9", "3.10"]
+       py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
        include:
          - py_version: "3.7"
            WITH_CODECOV: true
@@ -28,6 +28,8 @@ jobs:
          - py_version: "3.9"
            WITH_CODECOV: true
          - py_version: "3.10"
+           WITH_CODECOV: true
+         - py_version: "3.11"
            WITH_CODECOV: true
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     
     strategy:
       matrix:
-       py_version: ["3.7", "3.8", "3.9", "3.10", "3.7-dev", "3.8-dev", "3.9-dev", "3.10-dev"]
+       py_version: ["3.7", "3.8", "3.9", "3.10"]
        include:
          - py_version: "3.7"
            WITH_CODECOV: true
@@ -30,12 +30,6 @@ jobs:
          - py_version: "3.9"
            WITH_CODECOV: true
          - py_version: "3.10"
-           WITH_CODECOV: true
-         - py_version: "3.8-dev"
-           WITH_CODECOV: true
-         - py_version: "3.9-dev"
-           WITH_CODECOV: true
-         - py_version: "3.10-dev"
            WITH_CODECOV: true
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,19 +21,21 @@ jobs:
     
     strategy:
       matrix:
-       py_version: ["3.6", "3.7", "3.8", "3.9", "3.6-dev", "3.7-dev", "3.8-dev", "3.9-dev"] 
+       py_version: ["3.7", "3.8", "3.9", "3.10", "3.7-dev", "3.8-dev", "3.9-dev", "3.10-dev"]
        include:
-         - py_version: "3.6"
-           WITH_CODECOV: true
          - py_version: "3.7"
            WITH_CODECOV: true
          - py_version: "3.8"
            WITH_CODECOV: true
          - py_version: "3.9"
            WITH_CODECOV: true
+         - py_version: "3.10"
+           WITH_CODECOV: true
          - py_version: "3.8-dev"
            WITH_CODECOV: true
          - py_version: "3.9-dev"
+           WITH_CODECOV: true
+         - py_version: "3.10-dev"
            WITH_CODECOV: true
 
     steps:
@@ -67,10 +69,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
         cache: pip
     - name: Install dependencies
       run: |
@@ -88,10 +90,10 @@ jobs:
       
       steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-           python-version: 3.9
+           python-version: 3.10
            cache: pip
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
         cache: pip
         cache-dependency-path: |
           **/setup.cfg
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-           python-version: 3.10
+           python-version: '3.10'
            cache: pip
            cache-dependency-path: |
              **/setup.cfg

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     
     strategy:
       matrix:
-       py_version: ["3.7", "3.8", "3.9", "3.10"]
+       py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
        include:
          - py_version: "3.7"
            WITH_CODECOV: true
@@ -30,6 +30,8 @@ jobs:
          - py_version: "3.9"
            WITH_CODECOV: true
          - py_version: "3.10"
+           WITH_CODECOV: true
+         - py_version: "3.11"
            WITH_CODECOV: true
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,11 +37,12 @@ jobs:
            WITH_CODECOV: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.py_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.py_version }}
+        cache: pip
     - name: Install dependencies part I
       run: |
         sudo apt-get install dssp
@@ -65,11 +66,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
+        cache: pip
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip
@@ -85,11 +87,12 @@ jobs:
       runs-on: ubuntu-latest
       
       steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
            python-version: 3.9
+           cache: pip
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,6 +45,10 @@ jobs:
       with:
         python-version: ${{ matrix.py_version }}
         cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/requirements-*.txt
+          **/pyproject.toml
     - name: Install dependencies part I
       run: |
         sudo apt-get install dssp
@@ -74,6 +78,10 @@ jobs:
       with:
         python-version: 3.10
         cache: pip
+        cache-dependency-path: |
+          **/setup.cfg
+          **/requirements-*.txt
+          **/pyproject.toml
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip
@@ -95,6 +103,10 @@ jobs:
         with:
            python-version: 3.10
            cache: pip
+           cache-dependency-path: |
+             **/setup.cfg
+             **/requirements-*.txt
+             **/pyproject.toml
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools pip


### PR DESCRIPTION
The GH workflow started complaining about soon-to-be deprecated node.js versions, so I figured I'd update the actions we use. In addition, I took the liberty to update the python versions we test against. In particular, I dropped py3.6 and added py3.10