### PR TITLE
Install dssp=3.0 during CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     strategy:
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           **/pyproject.toml
     - name: Install dependencies part I
       run: |
-        sudo apt-get install dssp=3.0.0-3build1
+        sudo apt-get install dssp
         pip install --upgrade setuptools pip
     - name: Install package and requirements
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           **/pyproject.toml
     - name: Install dependencies part I
       run: |
-        sudo apt-get install dssp
+        sudo apt-get install dssp=3.0.0-3build1
         pip install --upgrade setuptools pip
     - name: Install package and requirements
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,7 +47,7 @@ jobs:
           **/pyproject.toml
     - name: Install dependencies part I
       run: |
-        sudo apt-get install dssp
+        sudo apt-get install dssp=3.0.0-3build1
         pip install --upgrade setuptools pip
     - name: Install package and requirements
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     strategy:
       matrix:
@@ -47,8 +47,7 @@ jobs:
           **/pyproject.toml
     - name: Install dependencies part I
       run: |
-        wget http://de.archive.ubuntu.com/ubuntu/pool/universe/d/dssp/dssp_3.0.0-3build1_amd64.deb
-        sudo apt-get install ./dssp_3.0.0-3build1_amd64.deb
+        sudo apt-get install dssp
         pip install --upgrade setuptools pip
     - name: Install package and requirements
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,6 +47,7 @@ jobs:
           **/pyproject.toml
     - name: Install dependencies part I
       run: |
+        apt-cache madison dssp
         sudo apt-get install dssp=3.0.0-3build1
         pip install --upgrade setuptools pip
     - name: Install package and requirements

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,8 +47,8 @@ jobs:
           **/pyproject.toml
     - name: Install dependencies part I
       run: |
-        apt-cache madison dssp
-        sudo apt-get install dssp=3.0.0-3build1
+        wget http://de.archive.ubuntu.com/ubuntu/pool/universe/d/dssp/dssp_3.0.0-3build1_amd64.deb
+        sudo apt-get install ./dssp_3.0.0-3build1_amd64.deb
         pip install --upgrade setuptools pip
     - name: Install package and requirements
       run: |


### PR DESCRIPTION
The github CI runner changed to 22.04 (from 20.04), which has DSSP version 4.0 (https://packages.ubuntu.com/jammy/dssp), which doesn't work with vermouth. So try to specify a different version. If this works we can add a version check to the DSSP processor.