### PR TITLE
Undo premature optimization in ff loglevel parser

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -453,8 +453,7 @@ class FFDirector(SectionLineParser):
     @SectionLineParser.section_parser('modification', 'error', context_type='modification')
     def _parse_log_entry(self, line, lineno=0, context_type=''):
         loglevel = logging.getLevelName(self.section[-1].upper())
-        if LOGGER.isEnabledFor(loglevel):
-            self.get_context(context_type).log_entries[loglevel][line] = []
+        self.get_context(context_type).log_entries[loglevel][line] = []
 
 
 def _some_atoms_left(tokens, atoms, natoms):


### PR DESCRIPTION
Undo the premature optimization introduced in a837b69e109ba0f2ce4901e758be30e94bd205ab to fix the issue encounterd in https://github.com/marrink-lab/polyply_1.0/pull/292