### PR TITLE
add boxes to parsers

### DIFF
--- a/vermouth/gmx/gro.py
+++ b/vermouth/gmx/gro.py
@@ -107,6 +107,11 @@ def read_gro(file_name, exclude=('SOL',), ignh=False):
 
             molecule.add_node(idx, **properties)
             idx += 1
+        box = np.array(line.strip().split(), dtype=float)
+        # not pretty but the parser is out of touch with the rest of the parsing
+        # infrastructure already
+        molecule.box = box
+
     return molecule
 
 

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -279,13 +279,12 @@ class PDBParser(LineParser):
             ('beta', float, 7),
             ('gamma', float, 7),
             ('space_group', str, 11),
+            ('', str, 1),
             ('z_value', int, 4),
             ]
         start = 0
         field_slices = []
         for name, type_, width in fields:
-            if name == "space_group":
-                start+=1
             if name:
                 field_slices.append((name, type_, slice(start, start + width)))
             start += width

--- a/vermouth/tests/gmx/test_gro.py
+++ b/vermouth/tests/gmx/test_gro.py
@@ -540,7 +540,7 @@ def test_read_gro(gro_reference, exclude, ignh):  # pylint: disable=redefined-ou
     molecule = gro.read_gro(filename, exclude=exclude, ignh=ignh)
     pprint(list(molecule.nodes.items()))
     assert_molecule_equal(molecule, reference)
-
+    assert all(molecule.box == np.array([10.0, 11.1, 12.2]))
 
 def test_read_gro_wrong_atom_number(gro_wrong_length):  # pylint: disable=redefined-outer-name
     """


### PR DESCRIPTION
For multiple reasons it would be very useful, when the coordinate parsers would also store the box. I've added this parsing feature to the gro / pdb parser in the least invasive way. The gro solution is not so neat but then again the parser is also entirely out of line with the rest. 

For the PDB parser I stored the box in the parser object itself. In my opinion this would be safer and then we can decide when and if to use it with molecules. Unfortunately this doesn't work for the gro file reader so it then becomes a molecule class variable. I'm open to other suggestions, but would rather have it fast than redoing any major part of the parsers