### PR TITLE
[VIPR] Parser for [ meta ] information

### DIFF
--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -226,14 +226,21 @@ class FFDirector(SectionLineParser):
     @SectionLineParser.section_parser('moleculetype', 'meta')
     def _parse_block_meta(self, line, lineno=0):
         # parse each line
-        # update the object current_block
+        # update the object current_block with meta information
+        # exemple :
+        # [meta]
+        # key value
+        # key2 value1 value2 
+        # will give
+        # {'key': value, 'key2': ['value1' , 'value2']}
+        
         line_splited = line.split()
         key = line_splited[0]
+        
+        # depend of the number of value 
         if len(line_splited[1:]) == 1 : 
-            #one value
             value = line_splited[1] 
         else: 
-            #case list of values
             value = line_splited[1:]
         self.current_block.meta[key] = value
 

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -222,6 +222,20 @@ class FFDirector(SectionLineParser):
     def _block_atoms(self, line, lineno=0):
         tokens = collections.deque(_tokenize(line))
         _parse_block_atom(tokens, self.current_block)
+        
+    @SectionLineParser.section_parser('moleculetype', 'meta')
+    def _parse_block_meta(self, line, lineno=0):
+        # parse each line
+        # update the object current_block
+        line_splited = line.split()
+        key = line_splited[0]
+        if len(line_splited[1:]) == 1 : 
+            #one value
+            value = line_splited[1] 
+        else: 
+            #case list of values
+            value = line_splited[1:]
+        self.current_block.meta[key] = value
 
     @SectionLineParser.section_parser('moleculetype', 'edges',
                                       negate=False, context_type='block')

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -225,23 +225,38 @@ class FFDirector(SectionLineParser):
         
     @SectionLineParser.section_parser('moleculetype', 'meta')
     def _parse_block_meta(self, line, lineno=0):
-        # parse each line
-        # update the object current_block with meta information
-        # exemple :
-        # [meta]
-        # key value
-        # key2 value1 value2 
-        # will give
-        # {'key': value, 'key2': ['value1' , 'value2']}
+        """
+        Parse the meta section and update the object current_block with meta information
         
-        line_splited = line.split()
-        key = line_splited[0]
+        Example :
+            [meta]
+            flag1
+            key value
+            key2 value1 value2 
+        
+            will give :
+                {'flag1' : None, 'key': value, 'key2': ['value1' , 'value2']}
+        
+        Parameters
+        ----------
+        line: str
+        lineno: str
+        """
+        
+        split_line = line.split()
+        key = split_line[0]
         
         # depend of the number of value 
-        if len(line_splited[1:]) == 1 : 
-            value = line_splited[1] 
+        if len(split_line[1:]) == 0 : 
+            value = None
+        elif len(split_line[1:]) == 1 : 
+            value = split_line[1]
+            #check the value, numeric, float or string
+            if value.replace(".", "").isnumeric(): 
+                value = float( value)
         else: 
-            value = line_splited[1:]
+            value = [ float(e) if e.replace(".", "").isnumeric() else e for e in split_line[1:]]
+        
         self.current_block.meta[key] = value
 
     @SectionLineParser.section_parser('moleculetype', 'edges',

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -236,7 +236,11 @@ class FFDirector(SectionLineParser):
             key2 value1 0.37 
         
             will give :
-                {'flag1' : None, 'key': value, 'key2': ['value1' , 0.37]}
+                {   
+                    'flag1' : None, 
+                    'key': 'value', 
+                    'key2': ['value1' , '0.37']
+                }
         
         Parameters
         ----------

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -226,16 +226,17 @@ class FFDirector(SectionLineParser):
     @SectionLineParser.section_parser('moleculetype', 'meta')
     def _parse_block_meta(self, line, lineno=0):
         """
-        Parse the meta section and update the object current_block with meta information
+        Parse the meta section and update the object current_block with meta information. 
+        Allow the dictionnary value to be None (in case of flag), string, int or float. 
         
         Example :
             [meta]
             flag1
             key value
-            key2 value1 value2 
+            key2 value1 0.37 
         
             will give :
-                {'flag1' : None, 'key': value, 'key2': ['value1' , 'value2']}
+                {'flag1' : None, 'key': value, 'key2': ['value1' , 0.37]}
         
         Parameters
         ----------

--- a/vermouth/ffinput.py
+++ b/vermouth/ffinput.py
@@ -247,16 +247,13 @@ class FFDirector(SectionLineParser):
         split_line = line.split()
         key = split_line[0]
         
-        # depend of the number of value 
+        # depend of the number of value(s) 
         if len(split_line[1:]) == 0 : 
             value = None
         elif len(split_line[1:]) == 1 : 
             value = split_line[1]
-            #check the value, numeric, float or string
-            if value.replace(".", "").isnumeric(): 
-                value = float( value)
         else: 
-            value = [ float(e) if e.replace(".", "").isnumeric() else e for e in split_line[1:]]
+            value = split_line[1:]
         
         self.current_block.meta[key] = value
 

--- a/vermouth/tests/test_ff_files.py
+++ b/vermouth/tests/test_ff_files.py
@@ -94,7 +94,7 @@ class TestBlock:
         ff = vermouth.forcefield.ForceField(name='test_ff')
         vermouth.ffinput.read_ff(lines, ff)
         block = ff.blocks['XXX']
-        assert len(block.meta) == 4
+        assert len(block.meta) == 3
         assert block.meta['flag'] == None 
         assert block.meta['key1'] == '0.15' 
         assert block.meta['key2'] ==  ['value1', 'value2']

--- a/vermouth/tests/test_ff_files.py
+++ b/vermouth/tests/test_ff_files.py
@@ -81,6 +81,26 @@ class TestBlock:
                                       'other': 'plop'}
 
     @staticmethod
+    def test_meta():
+        lines = """
+        [ moleculetype ]
+        XXX 1
+        [ meta ]
+        flag
+        key1 0.15 ;test
+        key2 value1 value2
+        """
+        lines = textwrap.dedent(lines).splitlines()
+        ff = vermouth.forcefield.ForceField(name='test_ff')
+        vermouth.ffinput.read_ff(lines, ff)
+        block = ff.blocks['XXX']
+        assert len(block.meta) == 4
+        assert block.meta['flag'] == None 
+        assert block.meta['key1'] == '0.15' 
+        assert block.meta['key2'] ==  ['value1', 'value2']
+        
+        
+    @staticmethod
     def test_fixed_number_interaction():
         """
         Define an interaction for which the number of atoms required is known.


### PR DESCRIPTION
This PR contains my proposition for parsing block meta. 
I suggest keeping the format separated by tab or space, the first element will be the key and the rest will be the value(s). Then it allowed the user to add extra information to .itp file, and retrieve it through a dictionary. 

Example : 

        [ moleculetype ]
          GLY  3
        [ atoms ]
         1 P4 1 ALA BB 1
     
        [ meta ]
        group protein polymer organic; test
        realname Glycine


Output : 
( ff.blocks['GLY'].meta )
     {'group': ['protein', 'polymer', 'organic'], 'realname': 'Glycine'} 