### PR TITLE
do not sort when Go

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -762,8 +762,12 @@ def entry():
             old_resids = nx.get_node_attributes(molecule, "_old_resid")
             nx.set_node_attributes(molecule, old_resids, "resid")
 
-    LOGGER.info("Sorting atomids", type='step')
-    vermouth.SortMoleculeAtoms().run_system(system)
+   # The Martini Go model assumes that we do not mess with the order of
+   # particles in any way especially the virtual sites needed for the Go
+   # model, thus we skip the sorting here altogether. 
+    if not args.govs_includes:
+        LOGGER.info("Sorting atomids", type='step')
+        vermouth.SortMoleculeAtoms().run_system(system)
 
     LOGGER.info('Writing output.', type='step')
     for molecule in system.molecules:

--- a/vermouth/processors/go_vs_includes.py
+++ b/vermouth/processors/go_vs_includes.py
@@ -128,6 +128,7 @@ def add_virtual_sites(molecule, prefix, backbone='BB', atomname='CA', charge=0):
             new_charge_group += 1
             virtual_site_nodes.append((new_node_id, {
                 'resid': atom['resid'],
+                '_old_resid': atom['_old_resid'],
                 'resname': atom['resname'],
                 'atype': '{}_{}'.format(prefix, atom['resid']),
                 'charge_group': new_charge_group,

--- a/vermouth/tests/test_go_vs_includes.py
+++ b/vermouth/tests/test_go_vs_includes.py
@@ -41,6 +41,7 @@ def molecule_for_go(request):
             molecule.add_node(
                 base_atom_idx + relative_atom_idx,
                 resid=residue_idx,
+                _old_resid=residue_idx,
                 resname='XX',
                 atomname=atomname,
                 charge_group=base_atom_idx,


### PR DESCRIPTION
Do not sort atoms when a Go model is requested. This is for sure a quick patch but seeing that the Go model makes pretty strict assumptions about what order beads and Go sites can be in, I think it will be not too much of a problem.