### PR TITLE
Fix a typo in pdb.py that causes DSSP to fail

### DIFF
--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -539,7 +539,7 @@ def write_pdb_string(system, conect=True, omit_charges=True, nan_missing_pos=Fal
             resname = get_not_none(node, 'resname', '')
             chain = get_not_none(node, 'chain', '')
             resid = get_not_none(node, 'resid', 1)
-            insertion_code = get_not_none(node, 'insertioncode', '')
+            insertion_code = get_not_none(node, 'insertion_code', '')
             try:
                 # converting from nm to A
                 x, y, z = node['position'] * 10  # pylint: disable=invalid-name

--- a/vermouth/tests/pdb/test_write_pdb.py
+++ b/vermouth/tests/pdb/test_write_pdb.py
@@ -56,7 +56,7 @@ def dummy_system():
         {'atomname': 'E', 'resname': 'A', 'resid': 4, },
         {'atomname': 'F', 'resname': 'B', 'resid': 4, },
         {'atomname': 'G', 'resname': 'B', 'resid': 4, },
-        {'atomname': 'H', 'resname': 'B', 'resid': 4, },
+        {'atomname': 'H', 'resname': 'B', 'resid': 4, 'insertion_code': 'A'},
     )
     edges = [(0, 1), (2, 3), (4, 5), (5, 6), (5, 7)]
     graph = nx.Graph()
@@ -100,8 +100,8 @@ TER       6      A       3
 ATOM      7 E    A       4      10.000  20.000 -30.000  1.00  0.00          E   
 ATOM      8 F    B       4      10.000  20.000 -30.000  1.00  0.00          F   
 ATOM      9 G    B       4      10.000  20.000 -30.000  1.00  0.00          G   
-ATOM     10 H    B       4      10.000  20.000 -30.000  1.00  0.00          H   
-TER      11      B       4 
+ATOM     10 H    B       4A     10.000  20.000 -30.000  1.00  0.00          H   
+TER      11      B       4A
 CONECT    1    2
 CONECT    4    5
 CONECT    7    8
@@ -141,8 +141,8 @@ TER       6      A       3
 ATOM      7 E    A       4      10.000  20.000 -30.000  1.00  0.00          E   
 ATOM      8 F    B       4      10.000  20.000 -30.000  1.00  0.00          F   
 ATOM      9 G    B       4      10.000  20.000 -30.000  1.00  0.00          G   
-ATOM     10 H    B       4      10.000  20.000 -30.000  1.00  0.00          H   
-TER      11      B       4 
+ATOM     10 H    B       4A     10.000  20.000 -30.000  1.00  0.00          H   
+TER      11      B       4A
 END
 '''
     assert pdb_found.strip() == expected.strip()


### PR DESCRIPTION
There is a typo in pdb.py which causes DSSP to fail. #348 