### PR TITLE
quick fix doc

### DIFF
--- a/vermouth/graph_utils.py
+++ b/vermouth/graph_utils.py
@@ -183,7 +183,7 @@ def get_attrs(node, attrs):
 def partition_graph(graph, partitions):
     """
     Create a new graph based on `graph`, where nodes are aggregated based on
-    `partitions`, similar to :func:`~networkx.algorithms.minors.quotient_graph`,
+    `partitions`, similar to the networkx `quotient_graph`,
     except that it only accepts pre-made partitions, and edges are not given
     a 'weight' attribute. Much fast than the quotient_graph, since it creates
     edges based on existing edges rather than trying all possible combinations.


### PR DESCRIPTION
quick fix on the doc-string. Apparently it has nothing to do with versions of netwrokx or sphinx. I tested exectly the same state of packages as when the tests worked and now the fail. Might have to do with some ubuntu setup, I don't know. Bumping to nx version 3 doesn't help either and also would require to change all downstream packages. It works but I think it is too early for that. Hence here a hopefully working quick fix. 