### PR TITLE
-el fix

### DIFF
--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -339,7 +339,7 @@ def apply_rubber_band(molecule, selector,
         to_key = idx_to_node[selection[to_idx]]
         force_constant = constants[from_idx, to_idx]
         length = distance_matrix[from_idx, to_idx]
-        if force_constant > minimum_force:
+        if (force_constant > minimum_force) and (force_constant < base_constant):
             molecule.add_interaction(
                 type_='bonds',
                 atoms=(from_key, to_key),

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -94,9 +94,8 @@ def compute_force_constants(distance_matrix, lower_bound, upper_bound,
     np.fill_diagonal(constants, 0)
     constants *= base_constant
     constants[constants < minimum_force] = 0
-    constants[constants > base_constant] = 0
+    constants[constants > base_constant] = base_constant
     constants[distance_matrix > upper_bound] = 0
-    constants[distance_matrix < lower_bound] = 0    
     return constants
 
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -89,6 +89,14 @@ def compute_force_constants(distance_matrix, lower_bound, upper_bound,
 
     The force constant can be modified with a decay function, and it can be
     bounded with a minimum threshold, or a distance upper and lower bonds.
+    
+    If decay_factor = decay_power = 0 all forces applied are = base_constant
+    
+    Forces applied to distances above upper_bound are removed.
+    Forces below minimum_force are removed.
+    
+    If decay_factor or decay_power != 0, forces below lower_bound are greater 
+    than base_constant, in which case they are set back to = base_constant    
     """
     constants = compute_decay(distance_matrix, lower_bound, decay_factor, decay_power)
     np.fill_diagonal(constants, 0)

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -341,7 +341,7 @@ def apply_rubber_band(molecule, selector,
         to_key = idx_to_node[selection[to_idx]]
         force_constant = constants[from_idx, to_idx]
         length = distance_matrix[from_idx, to_idx]
-        if (force_constant > minimum_force):
+        if force_constant > minimum_force:
             molecule.add_interaction(
                 type_='bonds',
                 atoms=(from_key, to_key),

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -93,10 +93,10 @@ def compute_force_constants(distance_matrix, lower_bound, upper_bound,
     constants = compute_decay(distance_matrix, lower_bound, decay_factor, decay_power)
     np.fill_diagonal(constants, 0)
     constants *= base_constant
-
     constants[constants < minimum_force] = 0
     constants[constants > base_constant] = 0
     constants[distance_matrix > upper_bound] = 0
+    constants[distance_matrix < lower_bound] = 0    
     return constants
 
 

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -93,7 +93,9 @@ def compute_force_constants(distance_matrix, lower_bound, upper_bound,
     constants = compute_decay(distance_matrix, lower_bound, decay_factor, decay_power)
     np.fill_diagonal(constants, 0)
     constants *= base_constant
+
     constants[constants < minimum_force] = 0
+    constants[constants > base_constant] = 0
     constants[distance_matrix > upper_bound] = 0
     return constants
 
@@ -339,7 +341,7 @@ def apply_rubber_band(molecule, selector,
         to_key = idx_to_node[selection[to_idx]]
         force_constant = constants[from_idx, to_idx]
         length = distance_matrix[from_idx, to_idx]
-        if (force_constant > minimum_force) and (force_constant < base_constant):
+        if (force_constant > minimum_force):
             molecule.add_interaction(
                 type_='bonds',
                 atoms=(from_key, to_key),

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -543,19 +543,31 @@ def test_bail_out_on_nan(caplog, test_molecule):
                           ([1, 2, 0, 0, 500, 400, np.array([[  0,500,500,  0],
                                                             [500,  0,500,500],
                                                             [500,500,  0,500],
-                                                            [  0,500,500,500]])], # no decays, return the base constant within the bounds
+                                                            [  0,500,500,  0]])], # no decays, return the base constant within the bounds
                            [1, 2, 0, 0, 500, 600, np.array([[  0,  0,  0,  0],
                                                             [  0,  0,  0,  0],
                                                             [  0,  0,  0,  0],
                                                             [  0,  0,  0,  0]])], # all forces less than the minumum force
                            [1, 0.5, 0, 0, 500, 600, np.array([[  0,  0,  0,  0],
-                                                            [  0,  0,  0,  0],
-                                                            [  0,  0,  0,  0],
-                                                            [  0,  0,  0,  0]])], # all distances larger than the upper bound
+                                                              [  0,  0,  0,  0],
+                                                              [  0,  0,  0,  0],
+                                                              [  0,  0,  0,  0]])], # all distances larger than the upper bound
                            [4, 2, 0, 0, 500, 600, np.array([[  0,  0,  0,  0],
                                                             [  0,  0,  0,  0],
                                                             [  0,  0,  0,  0],
                                                             [  0,  0,  0,  0]])], # all distances less than the lower bound
+                           [1, 3, 0.1, 0, 500, 400, np.array([[  0.        , 452.41870902, 452.41870902, 452.41870902],
+                                                              [452.41870902,   0.        , 452.41870902, 452.41870902],
+                                                              [452.41870902, 452.41870902,   0.        , 452.41870902],
+                                                              [452.41870902, 452.41870902, 452.41870902,   0.        ]])], # with a decay factor
+                           [1, 3, 0, 2, 500, 400, np.array([[  0,500,500,500],
+                                                            [500,  0,500,500],
+                                                            [500,500,  0,500],
+                                                            [500,500,500,  0]])], # with a decay factor
+                           [1, 3, 0.1, 2, 500, 400, np.array([[  0.        , 500.        , 452.41870902,   0.        ],
+                                                              [500.        ,   0.        , 500.        , 452.41870902],
+                                                              [452.41870902, 500.        ,   0.        , 500.        ],
+                                                              [  0.        , 452.41870902, 500.        ,   0.        ]])], # with a complex decay
                           )
                         )
 def test_compute_force_constants(lower_bound, upper_bound, decay_factor, decay_power, base_constant, minimum_force, expected_output):
@@ -571,4 +583,4 @@ def test_compute_force_constants(lower_bound, upper_bound, decay_factor, decay_p
                                                                            minimum_force)
 
     # Assert the result against the expected output
-    assert result.all() == expected_output.all()
+    assert result == pytest.approx(expected_output)

--- a/vermouth/tests/test_apply_rubber_band.py
+++ b/vermouth/tests/test_apply_rubber_band.py
@@ -537,3 +537,38 @@ def test_bail_out_on_nan(caplog, test_molecule):
     assert record.getMessage() == required_warning
     assert len(caplog.records) == 1
     assert test_molecule.interactions['bonds'] == []
+
+
+@pytest.mark.parametrize('lower_bound, upper_bound, decay_factor, decay_power, base_constant, minimum_force, expected_output', 
+                          ([1, 2, 0, 0, 500, 400, np.array([[  0,500,500,  0],
+                                                            [500,  0,500,500],
+                                                            [500,500,  0,500],
+                                                            [  0,500,500,500]])], # no decays, return the base constant within the bounds
+                           [1, 2, 0, 0, 500, 600, np.array([[  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0]])], # all forces less than the minumum force
+                           [1, 0.5, 0, 0, 500, 600, np.array([[  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0]])], # all distances larger than the upper bound
+                           [4, 2, 0, 0, 500, 600, np.array([[  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0],
+                                                            [  0,  0,  0,  0]])], # all distances less than the lower bound
+                          )
+                        )
+def test_compute_force_constants(lower_bound, upper_bound, decay_factor, decay_power, base_constant, minimum_force, expected_output):
+    # Define the constant distance_matrix for the test cases
+    distance_matrix = np.array([[0, 1, 2, 3],
+                                [1, 0, 1, 2],
+                                [2, 1, 0, 1],
+                                [3, 2, 1, 0]])
+
+    # Call the compute_force_constants function with the constant distance_matrix and varied parameters
+    result = vermouth.processors.apply_rubber_band.compute_force_constants(distance_matrix, lower_bound, upper_bound, 
+                                                                           decay_factor, decay_power, base_constant, 
+                                                                           minimum_force)
+
+    # Assert the result against the expected output
+    assert result.all() == expected_output.all()


### PR DESCRIPTION
Currently, if elastic network rubber bands are applied and are 1) below the cutoff for -el and 2) not otherwise eliminated by the -ermd threshold for the force field, they are kept in. Ie. the -el cutoff is not actually currently applied. This PR applies the cutoff.