### PR TITLE
Log a helpful message when an element is not present in the ATOM_MASS dict

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-branch = True
-omit = 
-    vermouth/tests/*
-    vermouth/redistributed/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
         
     - name: Run pytest with codecoverage
       run: |
-        coverage run --source=vermouth $(which pytest) -vv vermouth --hypothesis-show-statistics
+        coverage run $(which pytest) -vv --hypothesis-show-statistics
         coverage report --omit='*/bin/pytest'
         
     - if: ${{ matrix.WITH_CODECOV }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -53,7 +53,11 @@ jobs:
         pip install -r requirements-tests.txt
         
     - name: Run pytest with codecoverage
-      run:  pytest vermouth --cov=vermouth --cov-report=xml --hypothesis-show-statistics
+      run: |
+        coverage run $(which pytest) -vv --hypothesis-show-statistics
+        coverage report
+        coverage xml 
+
     - if: ${{ matrix.WITH_CODECOV }}
       name: Upload coverage codecov   
       uses: codecov/codecov-action@v3 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ python_files = "test_*.py"
 
 [tool.coverage.run]
 branch = true
-omit = ["vermouth/tests/*", "vermouth/redistributed/*"]
-
+omit = ["vermouth/tests/*", "vermouth/redistributed/*", '*/bin/pytest']
+source_pkgs = ["vermouth"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ requires = [
         "setuptools >= 30.3.0",
         "pbr",
     ]
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+testpaths = ["vermouth/tests"]
+python_files = "test_*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ requires = [
 addopts = "--import-mode=importlib"
 testpaths = ["vermouth/tests"]
 python_files = "test_*.py"
+
+[tool.coverage.run]
+branch = true
+omit = ["vermouth/tests/*", "vermouth/redistributed/*"]
+

--- a/vermouth/processors/attach_mass.py
+++ b/vermouth/processors/attach_mass.py
@@ -18,10 +18,13 @@ molecule based on it's element.
 
 
 from .processor import Processor
+from ..log_helpers import StyleAdapter, get_logger
+
+LOGGER = StyleAdapter(get_logger(__name__))
 
 # TODO: make the masses part of the forcefield
-ATOM_MASSES = {'H': 1, 'C': 12, 'N': 14, 'O': 16, 'S': 32, 'P': 31, 'M': 0}
-
+ATOM_MASSES = {'H': 1, 'C': 12, 'N': 14, 'O': 16, 'S': 32, 'P': 31}
+DEFAULT_MASS = 30
 
 def attach_mass(molecule, attribute='mass'):
     """
@@ -36,7 +39,11 @@ def attach_mass(molecule, attribute='mass'):
         The attribute the mass is assigned to.
     """
     for node in molecule.nodes.values():
-        node[attribute] = ATOM_MASSES[node['element']]
+        element = node['element']
+        if element not in ATOM_MASSES:
+            LOGGER.info("Cannot find a mass for element {}. We assume it's some"
+                        " metal, and will set its mass to {} amu.", element, DEFAULT_MASS)
+        node[attribute] = ATOM_MASSES.get(node['element'], DEFAULT_MASS)
 
 
 class AttachMass(Processor):


### PR DESCRIPTION
… and then use a relatively high mass since it's probably a metal.

Side-effect of #570. I currently set the loglevel to INFO, since I don't think it usually results in a faulty structure or topology.