### PR TITLE
Flank the wildcard SecStruct sequence with dots

### DIFF
--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -422,7 +422,8 @@ def convert_dssp_to_martini(sequence):
     # This should not cause further issues, since '..' doesn't map to anything
     wildcard_sequence = '.' + wildcard_sequence + '.'
     for pattern, replacement in patterns.items():
-        wildcard_sequence = wildcard_sequence.replace(pattern, replacement)
+        while pattern in wildcard_sequence:  # EXPENSIVE! :'(
+            wildcard_sequence = wildcard_sequence.replace(pattern, replacement)
     # And remove the flanking dots again
     wildcard_sequence = wildcard_sequence[1:-1]
     result = ''.join(

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -417,8 +417,14 @@ def convert_dssp_to_martini(sequence):
     cg_sequence = ''.join(ss_cg[secstruct] for secstruct in sequence)
     wildcard_sequence = ''.join('H' if secstruct == 'H' else '.'
                                 for secstruct in cg_sequence)
+    # Flank the sequence with dots. Otherwise in a sequence consisting of only
+    # H will not have a start or end. See also issue 566.
+    # This should not cause further issues, since '..' doesn't map to anything
+    wildcard_sequence = '.' + wildcard_sequence + '.'
     for pattern, replacement in patterns.items():
         wildcard_sequence = wildcard_sequence.replace(pattern, replacement)
+    # And remove the flanking dots again
+    wildcard_sequence = wildcard_sequence[1:-1]
     result = ''.join(
         wildcard if wildcard != '.' else cg
         for wildcard, cg in zip(wildcard_sequence, cg_sequence)

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -690,6 +690,7 @@ def test_cterm_atomnames():
     ('EHHHHHHC', 'E113322C'),
     ('HHHHHHHHH', '1111H2222'),
     ('CHHHHHHHHHC', 'C1111H2222C'),
+    ('CHHHHEHHHHC', 'C3333E3333C'),
 ])
 def test_convert_dssp_to_martini(sequence, expected):
     found = dssp.convert_dssp_to_martini(sequence)

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -686,8 +686,10 @@ def test_cterm_atomnames():
     ('H', '3'),
     ('HH', '33'),
     ('CHH', 'C33'),
+    ('HHHHHH', '113322'),
+    ('EHHHHHHC', 'E113322C'),
     ('HHHHHHHHH', '1111H2222'),
-    ()
+    ('CHHHHHHHHHC', 'C1111H2222C'),
 ])
 def test_convert_dssp_to_martini(sequence, expected):
     found = dssp.convert_dssp_to_martini(sequence)

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -680,3 +680,15 @@ def test_cterm_atomnames():
     vermouth.processors.CanonicalizeModifications().run_system(system)
     dssp_out = dssp.run_dssp(system, executable=DSSP_EXECUTABLE)
     assert dssp_out == list("CC")
+
+
+@pytest.mark.parametrize('sequence, expected', [
+    ('H', '3'),
+    ('HH', '33'),
+    ('CHH', 'C33'),
+    ('HHHHHHHHH', '1111H2222'),
+    ()
+])
+def test_convert_dssp_to_martini(sequence, expected):
+    found = dssp.convert_dssp_to_martini(sequence)
+    assert expected == found


### PR DESCRIPTION
This way terminal helices will have a proper end and finish, as indicated with secstructs 1 and 2.
I'll still add some tests before this can be merged

Fixes #566