### PR TITLE
Windows issues

### DIFF
--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -266,10 +266,14 @@ def run_dssp(system, executable='dssp', savedir=None, defer_writing=True):
         savefile = _savefile_path(system, savedir)
     else:
         savefile = None
-    # check version
-    process = subprocess.run([executable, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    match = re.search('\d+\.\d+\.\d+', process.stdout.decode('UTF8'))
-    version = match[0] if match else None
+    try:
+        # check version
+        process = subprocess.run([executable, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError as error:
+        raise DSSPError('Failed to get DSSP version information.') from error
+    else:
+        match = re.search('\d+\.\d+\.\d+', process.stdout.decode('UTF8'))
+        version = match[0] if match else None
     if not version:
         raise DSSPError('Failed to get DSSP version information.')
     if not version in SUPPORTED_DSSP_VERSIONS:

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -86,7 +86,7 @@ class ForceField:
         source_files = iter_force_field_files(directory)
         for source in source_files:
             extension = os.path.splitext(source)[-1]
-            with open(source) as infile:
+            with open(source, encoding='UTF-8') as infile:
                 FORCE_FIELD_PARSERS[extension](infile, self)
 
     @property

--- a/vermouth/gmx/gro.py
+++ b/vermouth/gmx/gro.py
@@ -50,7 +50,7 @@ def read_gro(file_name, exclude=('SOL',), ignh=False):
     field_names = ['resid', 'resname', 'atomname', 'atomid', 'x', 'y', 'z']
     field_widths = [5, 5, 5, 5]
 
-    with open(str(file_name)) as gro:
+    with open(str(file_name), encoding='UTF-8') as gro:
         next(gro)  # skip title
         num_atoms = int(next(gro))
 
@@ -149,7 +149,7 @@ def write_gro(system, file_name, precision=7, title='Martinized!', box=(0, 0, 0)
         open = deferred_open
     else:
         from builtins import open
-    with open(str(file_name), 'w') as out:
+    with open(str(file_name), 'w', encoding='UTF-8') as out:
         out.write(title + '\n')  # Title
         out.write(formatter.format('{}\n', system.num_particles))  # number of atoms
         atomid = 1

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -185,7 +185,7 @@ def write_gmx_topology(system,
             # A given moltype can appear more than once in the sequence of
             # molecules, without being uninterupted by other moltypes. Even in
             # that case, we want to write the ITP only once.
-            with deferred_open("{}.itp".format(moltype), "w") as outfile:
+            with deferred_open("{}.itp".format(moltype), "w", encoding='UTF-8') as outfile:
                 # here we format and merge all citations
                 header[-1] = header[-1] + "\n"
                 header.append("Please cite the following papers:")

--- a/vermouth/map_input.py
+++ b/vermouth/map_input.py
@@ -421,7 +421,7 @@ def read_mapping_directory(directory, force_fields):
     mappings = collections.defaultdict(lambda: collections.defaultdict(dict))
     # Old style mappings
     for path in directory.glob('**/*.map'):
-        with open(str(path)) as infile:
+        with open(str(path), encoding='UTF-8') as infile:
             try:
                 new_mappings = read_backmapping_file(infile, force_fields)
             except IOError:
@@ -430,7 +430,7 @@ def read_mapping_directory(directory, force_fields):
                 combine_mappings(mappings, new_mappings)
     # New style mappings
     for path in directory.glob('**/*.mapping'):
-        with open(str(path)) as infile:
+        with open(str(path), encoding='UTF-8') as infile:
             try:
                 new_mappings = read_mapping_file(infile, force_fields)
             except IOError:

--- a/vermouth/map_parser.py
+++ b/vermouth/map_parser.py
@@ -904,7 +904,7 @@ def parse_mapping_file(filepath, force_fields):
     list[Mapping]
         A list of all mappings described in the file.
     """
-    with open(filepath) as map_in:
+    with open(filepath, encoding='UTF-8') as map_in:
         director = MappingDirector(force_fields)
         mappings = list(director.parse(map_in))
     return mappings

--- a/vermouth/pdb/pdb.py
+++ b/vermouth/pdb/pdb.py
@@ -468,7 +468,7 @@ def read_pdb(file_name, exclude=('SOL',), ignh=False, modelidx=1):
         molecules.
     """
     parser = PDBParser(exclude, ignh, modelidx)
-    with open(str(file_name)) as file_handle:
+    with open(str(file_name), encoding='UTF-8') as file_handle:
         mols = list(parser.parse(file_handle))
     LOGGER.info('Read {} molecules from PDB file {}', len(mols), file_name)
     return mols
@@ -622,5 +622,5 @@ def write_pdb(system, path, conect=True, omit_charges=True, nan_missing_pos=Fals
         # a local variable, which means it won't be looked up from the global
         # namespace any more.
         from builtins import open
-    with open(path, 'w') as out:
+    with open(path, 'w', encoding='UTF-8') as out:
         out.write(write_pdb_string(system, conect, omit_charges, nan_missing_pos))

--- a/vermouth/processors/quote.py
+++ b/vermouth/processors/quote.py
@@ -79,6 +79,6 @@ class Quoter(Processor):
         -------
         None
         """
-        with open(self._quote_file) as handle:
+        with open(self._quote_file, encoding='UTF-8') as handle:
             all_quotes = list(read_quote_file(handle))
         LOGGER.info(random.choice(all_quotes))

--- a/vermouth/tests/gmx/test_gro.py
+++ b/vermouth/tests/gmx/test_gro.py
@@ -166,7 +166,7 @@ def gro_reference(request, tmp_path_factory):
     Generate a GRO file and the corresponding molecule.
     """
     filename = tmp_path_factory.mktemp("data") / "tmp.gro"
-    with open(filename, 'w') as outfile:
+    with open(filename, 'w', encoding='UTF-8') as outfile:
         write_ref_gro(outfile, velocities=request.param, box='10.0 11.1 12.2')
     molecule = build_ref_molecule(velocities=request.param)
     return filename, molecule
@@ -179,7 +179,7 @@ def gro_wrong_length(request, gro_reference, tmp_path_factory):  # pylint: disab
     """
     path_in, _ = gro_reference
     path_out = tmp_path_factory.mktemp("data") / "wrong.gro"
-    with open(path_in) as infile, open(path_out, 'w') as outfile:
+    with open(path_in, encoding='UTF-8') as infile, open(path_out, 'w', encoding='UTF-8') as outfile:
         outfile.write(next(infile))
         outfile.write('{}\n'.format(request.param))
         for line in infile:
@@ -566,5 +566,5 @@ def test_write_gro(gro_reference, tmp_path):
         title='Just a title',
     )
     DeferredFileWriter().write()
-    with open(filename) as ref, open(outname) as out:
+    with open(filename, encoding='UTF-8') as ref, open(outname, encoding='UTF-8') as out:
         assert out.read() == ref.read()

--- a/vermouth/tests/gmx/test_itp.py
+++ b/vermouth/tests/gmx/test_itp.py
@@ -59,10 +59,10 @@ def test_no_header(tmp_path, dummy_molecule):
     Test that no header is written if none is provided.
     """
     outpath = tmp_path / 'out.itp'
-    with open(outpath, 'w') as outfile:
+    with open(outpath, 'w', encoding='UTF-8') as outfile:
         write_molecule_itp(dummy_molecule, outfile)
 
-    with open(outpath) as infile:
+    with open(outpath, encoding='UTF-8') as infile:
         assert next(infile) == '[ moleculetype ]\n'
 
 
@@ -80,10 +80,10 @@ def test_header(tmp_path, dummy_molecule):
         '\n',
     )
     outpath = tmp_path / 'out.itp'
-    with open(outpath, 'w') as outfile:
+    with open(outpath, 'w', encoding='UTF-8') as outfile:
         write_molecule_itp(dummy_molecule, outfile, header=header)
 
-    with open(outpath) as infile:
+    with open(outpath, encoding='UTF-8') as infile:
         for line, expected_line in zip(infile, expected):
             assert line == expected_line
 

--- a/vermouth/tests/gmx/test_topology.py
+++ b/vermouth/tests/gmx/test_topology.py
@@ -86,7 +86,7 @@ def test_atomtypes(tmp_path, dummy_molecule, atomtypes, expected, C6C12):
     write_atomtypes(dummy_sys, outpath, C6C12=C6C12)
     DeferredFileWriter().write()
 
-    with open(str(outpath)) as infile:
+    with open(str(outpath), encoding='UTF-8') as infile:
         for line, ref_line in zip(infile, expected):
             assert line == ref_line
 
@@ -153,7 +153,7 @@ def test_nonbond_params(tmp_path, nbparams, expected, C6C12):
     write_nonbond_params(dummy_sys, outpath, C6C12=C6C12)
     DeferredFileWriter().write()
 
-    with open(str(outpath)) as infile:
+    with open(str(outpath), encoding='UTF-8') as infile:
         for line, ref_line in zip(infile, expected):
             assert line == ref_line
 
@@ -194,8 +194,8 @@ def test_toplevel_topology(tmp_path, dummy_molecule):
     reference =f"""#define random
 #include "martini.itp"
 
-#include "{tmp_path}/atomtypes.itp"
-#include "{tmp_path}/nonbond_params.itp"
+#include "{tmp_path/'atomtypes.itp'}"
+#include "{tmp_path/'nonbond_params.itp'}"
 #include "molecule_0.itp"
 
 [ system ]
@@ -205,6 +205,6 @@ Title of the system
 molecule_0    1
 """
     ref_lines = textwrap.dedent(reference).splitlines()
-    with open(str(outpath)) as infile:
+    with open(str(outpath), encoding='UTF-8') as infile:
         for line, ref_line in zip(infile, ref_lines):
             assert line.strip() == ref_line

--- a/vermouth/tests/helper_functions.py
+++ b/vermouth/tests/helper_functions.py
@@ -157,7 +157,7 @@ def parse_gofiles(file, atomtypes=False):
     '''
     Parser of go_nbparams.itp & go_atomtypes.itp files into an easy to assert dictionary.
     '''
-    with open(file) as my_file:
+    with open(file, encoding='UTF-8') as my_file:
         next(my_file)  # Skip header
         vals = {}
         for line in my_file:

--- a/vermouth/tests/integration_tests/test_integration.py
+++ b/vermouth/tests/integration_tests/test_integration.py
@@ -224,7 +224,7 @@ def test_integration_protein(tmp_path, monkeypatch, tier, protein):
 
     # check if strdout has citations in string
     for citation in citations:
-        assert citation in proc.stderr
+        assert proc.stderr and citation in proc.stderr
 
     files = list(tmp_path.iterdir())
 

--- a/vermouth/tests/integration_tests/test_integration.py
+++ b/vermouth/tests/integration_tests/test_integration.py
@@ -74,10 +74,10 @@ def compare_itp(filename1, filename2):
     Asserts that two itps are functionally identical
     """
     dummy_ff = ForceField(name='dummy')
-    with open(filename1) as fn1:
+    with open(filename1, encoding='UTF-8') as fn1:
         vermouth.gmx.read_itp(fn1, dummy_ff)
     dummy_ff2 = ForceField(name='dummy')
-    with open(filename2) as fn2:
+    with open(filename2, encoding='UTF-8') as fn2:
         vermouth.gmx.read_itp(fn2, dummy_ff2)
     for block in dummy_ff2.blocks.values():
         block._force_field = dummy_ff
@@ -192,7 +192,7 @@ def test_integration_protein(tmp_path, monkeypatch, tier, protein):
 
     data_path = Path(PATTERN.format(path=INTEGRATION_DATA, tier=tier, protein=protein))
 
-    with open(str(data_path / 'command')) as cmd_file:
+    with open(str(data_path / 'command'), encoding='UTF-8') as cmd_file:
         command = cmd_file.read().strip()
     assert command  # Defensive
     command = shlex.split(command)
@@ -208,7 +208,7 @@ def test_integration_protein(tmp_path, monkeypatch, tier, protein):
 
     # read the citations that are expected
     citations = []
-    with open(str(data_path/'citation')) as cite_file:
+    with open(str(data_path/'citation'), encoding='UTF-8') as cite_file:
         for line in cite_file:
             citations.append(line.strip())
     print(command)

--- a/vermouth/tests/pdb/test_read_pdb.py
+++ b/vermouth/tests/pdb/test_read_pdb.py
@@ -159,7 +159,7 @@ def test_single_model(pdbstr, ignh, nnodesnedges):
 @pytest.mark.parametrize('modelidx', range(1, 16))
 def test_integrative(ignh, modelidx):
     parser = PDBParser(ignh=ignh, modelidx=modelidx)
-    with open(str(PDB_MULTIMODEL)) as pdb_file:
+    with open(str(PDB_MULTIMODEL), encoding='UTF-8') as pdb_file:
         mols = list(parser.parse(pdb_file))
     assert len(mols) == 3  # 3 chains
     for mol in mols:

--- a/vermouth/tests/rcsu/test_read_go_map.py
+++ b/vermouth/tests/rcsu/test_read_go_map.py
@@ -57,7 +57,7 @@ from vermouth.rcsu.contact_map import read_go_map
         )))
 def test_go_map(tmp_path, lines, contacts):
     # write the go contact map file
-    with open(tmp_path / "go_file.txt", "w") as in_file:
+    with open(tmp_path / "go_file.txt", "w", encoding='UTF-8') as in_file:
         in_file.write(lines)
 
     # read go map
@@ -71,7 +71,7 @@ def test_go_error(tmp_path):
           No valid contacts in this file.
           """
     # write the go contact map file
-    with open(tmp_path / "go_file.txt", "w") as in_file:
+    with open(tmp_path / "go_file.txt", "w", encoding='UTF-8') as in_file:
         in_file.write(lines)
 
     with pytest.raises(IOError):

--- a/vermouth/tests/test_file_writer.py
+++ b/vermouth/tests/test_file_writer.py
@@ -43,21 +43,21 @@ def test_backup(tmp_path, monkeypatch, name, existing_files, expected):
     """
     monkeypatch.chdir(tmp_path)
     for idx, file in enumerate(existing_files):
-        with open(file, 'w') as handle:
+        with open(file, 'w', encoding='UTF-8') as handle:
             handle.write(str(idx))
 
     writer = DeferredFileWriter()
-    with writer.open(name, 'w') as handle:
+    with writer.open(name, 'w', encoding='UTF-8') as handle:
         handle.write("new {}".format(name))
     writer.write()
 
     assert Path(name).is_file()
-    with open(name) as file:
+    with open(name, encoding='UTF-8') as file:
         assert file.read() == "new {}".format(name)
 
     for idx, name in enumerate(expected):
         assert Path(name).is_file()
-        with open(name) as file:
+        with open(name, encoding='UTF-8') as file:
             assert file.read() == str(idx)
 
 

--- a/vermouth/tests/test_map_input.py
+++ b/vermouth/tests/test_map_input.py
@@ -437,7 +437,7 @@ def ref_mapping_directory(tmp_path_factory):
     iterate_on = itertools.product(force_fields_from, force_fields_to, range(3))
     for idx, (from_ff, to_ff, _) in enumerate(iterate_on):
         mapfile = mapdir / 'file{}.map'.format(idx)
-        with open(mapfile, 'w') as outfile:
+        with open(mapfile, 'w', encoding='UTF-8') as outfile:
             outfile.write(template.format(idx, from_ff, to_ff))
 
         mapping = {
@@ -504,14 +504,14 @@ def test_read_mapping_directory_error(tmp_path):
     mapdir = tmp_path / 'mappings'
     mapdir.mkdir()
 
-    with open(mapdir / 'valid.backmap', 'w') as outfile:
+    with open(mapdir / 'valid.backmap', 'w', encoding='UTF-8') as outfile:
         outfile.write(textwrap.dedent("""
             [ molecule ]
             valid
             [ atoms ]
             0 A B
         """))
-    with open(mapdir / 'not_valid.map', 'w') as outfile:
+    with open(mapdir / 'not_valid.map', 'w', encoding='UTF-8') as outfile:
         outfile.write('invalid content')
     with pytest.raises(IOError):
         vermouth.map_input.read_mapping_directory(mapdir, {})


### PR DESCRIPTION
Turns out Windows is borked and produces some issues where unix does not. There are also some differences in how `subprocess.run` behaves between OSes, hence the cleanup on which error gets raised when dssp doesn't exist