### PR TITLE
Fix #558 by inverting the link logic generating charged backbone charge dummy exclusions for polarizable forcefields

### DIFF
--- a/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
+++ b/vermouth/data/force_fields/elnedyn22p/aminoacids.ff
@@ -687,3 +687,8 @@ SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 ;[ features ]
 ;disulfide
 
+; Exclusions between the charged terminii and the charge dummies
+[ link ]
+resname $protein_resnames
+[ exclusions ]
+BB {"atype": "Qd|Qa"} XX {"atomname": "SCP|SCN"}

--- a/vermouth/data/force_fields/martini22p/aminoacids.ff
+++ b/vermouth/data/force_fields/martini22p/aminoacids.ff
@@ -894,4 +894,4 @@ SC1 >SC1 1 0.24 {"comment": "Disulfide bridge"}
 [ link ]
 resname $protein_resnames
 [ exclusions ]
-BB {"atype": "Qd|Qa"} *XX {"atomname": "SCP|SCN"}
+BB {"atype": "Qd|Qa"} XX {"atomname": "SCP|SCN"}


### PR DESCRIPTION
Turns out those exclusions were missing from elnedyn22p completely as well...