### PR TITLE
Add HIS(charmm)->HSE(martini22) mapping

### DIFF
--- a/vermouth/data/mappings/his.charmm.mapping
+++ b/vermouth/data/mappings/his.charmm.mapping
@@ -1,0 +1,30 @@
+[ block ]
+[ from ]
+charmm
+[ to ]
+martini22
+
+[ from blocks ]
+HIS
+
+[ to blocks ]
+HSE
+
+[ mapping ]
+  N    BB
+ HN    BB
+ CA    BB
+ HA    BB
+ CB   SC1
+HB1   SC1
+HB2   SC1
+CD2   SC2
+HD2   SC2
+ CG   SC1
+NE2   SC2
+HE2   SC2
+ND1   SC3
+CE1   SC3
+HE1   SC3
+  C    BB
+  O    BB

--- a/vermouth/data/mappings/his.gromos.mapping
+++ b/vermouth/data/mappings/his.gromos.mapping
@@ -1,0 +1,27 @@
+[ block ]
+[ from ]
+gromos
+[ to ]
+martini22
+
+[ from blocks ]
+HIS
+
+[ to blocks ]
+HSE
+
+[ mapping ]
+  N    BB
+  H    BB
+ CA    BB
+ CB   SC1
+ CG   SC1
+ND1   SC3
+HD1   SC3
+CD2   SC2
+HD2   SC2
+CE1   SC3
+HE1   SC3
+NE2   SC2
+  C    BB
+  O    BB


### PR DESCRIPTION
So somewhere between v0.7.3 and v0.8.1 the martini22 forcefield lost its HIS block (it got renamed to HSE). Because of this there no longer was a mapping charmm(HIS)->martini22(HIS). The fix here is to add the mapping HIS->martini22(HSE) from the atomistic force fields.

Fixes #567 