### PR TITLE
change elastic network default

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -472,7 +472,7 @@ def entry():
         "-ef",
         dest="rb_force_constant",
         type=float,
-        default=500,
+        default=700,
         help="Elastic bond force constant Fc in kJ/mol/nm^2",
     )
     rb_group.add_argument(


### PR DESCRIPTION
increase from 500 kJ/mol/nm^2 to 700 kJ/mol/nm^2 to match martini 3 default.

This breaks a whole bunch of tests at the moment, so we need to decide how to best correct them