### PR TITLE
Fix #652

### DIFF
--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -266,8 +266,13 @@ def run_dssp(system, executable='dssp', savedir=None, defer_writing=True):
         savefile = _savefile_path(system, savedir)
     else:
         savefile = None
-    # check version
-    process = subprocess.run([executable, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    try:
+        # check version
+        process = subprocess.run([executable, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        raise DSSPError("DSSP executable not found. Perhaps MDTraj was not installed in the environment?")
+
     match = re.search('\d+\.\d+\.\d+', process.stdout.decode('UTF8'))
     version = match[0] if match else None
     if not version:

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -459,7 +459,7 @@ def test_run_dssp_executable():
         system.add_molecule(molecule)
 
     with pytest.raises(DSSPError):
-        dssp.run_dssp(system, executable=' ')
+        dssp.run_dssp(system, executable='doesnt_exist')
 
 @pytest.mark.parametrize('ss_struct, expected', (
     (list('ABCDE'), list('ABCDE')),

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -459,7 +459,7 @@ def test_run_dssp_executable():
         system.add_molecule(molecule)
 
     with pytest.raises(DSSPError):
-        dssp.run_dssp(system, executable='dssp')
+        dssp.run_dssp(system, executable=' ')
 
 @pytest.mark.parametrize('ss_struct, expected', (
     (list('ABCDE'), list('ABCDE')),

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -450,6 +450,16 @@ def test_run_dssp_input_file(tmp_path, caplog, pdb, loglevel, expected):
         # Make sure it's a valid PDB file. Mostly anyway.
         list(read_pdb(matches[0]))
 
+def test_run_dssp_executable():
+    """
+    Test that the executable for dssp is actually found
+    """
+    system = vermouth.System()
+    for molecule in read_pdb(str(PDB_PROTEIN)):
+        system.add_molecule(molecule)
+
+    with pytest.raises(DSSPError):
+        dssp.run_dssp(system, executable='dssp')
 
 @pytest.mark.parametrize('ss_struct, expected', (
     (list('ABCDE'), list('ABCDE')),


### PR DESCRIPTION
raise helpful error if dssp executable is not found. Can easily happen if `-dssp` is given with no path (i.e. user expects to use MDTraj dssp functionality) but MDTraj is not installed in the python environment. Will fix #652 