### PR TITLE
Add non-forcefield-specific citations to the root of the data directory

### DIFF
--- a/vermouth/citation_parser.py
+++ b/vermouth/citation_parser.py
@@ -34,8 +34,8 @@ class BibTexDirector():
     check for missing fields or invalid fields. All
     fields are accepted and no fields are required.
     """
-    def __init__(self, force_field):
-        self.force_field = force_field
+    def __init__(self):
+        self.citations = {}
         self.known_entries = ["article",
                               "book",
                               "booklet",
@@ -153,14 +153,14 @@ class BibTexDirector():
         cite_key, entry_string = self.pop_key(entry_string)
         field_dict = dict(self.extract_fields(entry_string))
         field_dict["type"] = entry_type
-        self.force_field.citations[cite_key] = field_dict
+        self.citations[cite_key] = field_dict
 
     def parse(self, lines):
         """
         Given lines from a bibtex file parse them and update
         the force-field citation instance variable.
         """
-        # convert file to string deleting end of line charcters
+        # convert file to string deleting end of line characters
         citations_string = self.prepare_file(lines)
         # extract the entries from the string
         entries = list(self.find_entries(citations_string))
@@ -168,11 +168,14 @@ class BibTexDirector():
         # parse each entry to generate a citation
         for idx, jdx in zip(entries[:-1], entries[1:]):
             self.parse_entry(citations_string[idx:jdx])
-        return self.force_field.citations
+        return self.citations
 
-def read_bib(lines, force_field):
-    director = BibTexDirector(force_field=force_field)
-    return director.parse(iter(lines))
+def read_bib(lines, force_field=None):
+    director = BibTexDirector()
+    director.parse(iter(lines))
+    if force_field:
+        force_field.citations = director.citations
+    return director.citations
 
 def citation_formatter(citation, title=False):
     """

--- a/vermouth/data/__init__.py
+++ b/vermouth/data/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .data import *

--- a/vermouth/data/citations.bib
+++ b/vermouth/data/citations.bib
@@ -1,0 +1,22 @@
+@article{MDTraj,
+    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
+    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
+    journal={Biophysical Journal},
+    volume={109},
+    number={8},
+    pages={1528 -- 1532},
+    year={2015},
+    doi={10.1016/j.bpj.2015.08.015}
+}
+@article{vermouth,
+    title={Martinize2 and Vermouth: Unified Framework for Topology Generation},
+    url={http://dx.doi.org/10.7554/eLife.90627.2},
+    doi={10.7554/elife.90627.2},
+    journal={elife},
+    volume={12},
+    pages={RP90627}
+    publisher={eLife Sciences Publications, Ltd},
+    author={Kroon, PC and Grunewald, F and Barnoud, J and van Tilburg, M and Souza, PCT and Wassenaar, TA and Marrink, SJ},
+    year={2024},
+    month=jun
+}

--- a/vermouth/data/citations.bib
+++ b/vermouth/data/citations.bib
@@ -16,7 +16,7 @@
     volume={12},
     pages={RP90627}
     publisher={eLife Sciences Publications, Ltd},
-    author={Kroon, PC and Grunewald, F and Barnoud, J and van Tilburg, M and Souza, PCT and Wassenaar, TA and Marrink, SJ},
+    author={Kroon, Peter C and Grunewald, F and Barnoud, J and van Tilburg, M and Souza, Paulo CT and Wassenaar, Tsjerk A and Marrink, Siewert J},
     year={2024},
     month=jun
 }

--- a/vermouth/data/data.py
+++ b/vermouth/data/data.py
@@ -15,5 +15,29 @@
 from .. import DATA_PATH
 from ..citation_parser import read_bib
 
+
+def _read_quote_file(filehandle):
+    """
+    Iterates over `filehandle`, and yields all strings that are not empty.
+
+    Parameters
+    ----------
+    filehandle: collections.abc.Iterable[str]
+        A file opened for reading.
+
+    Yields
+    ------
+    str
+        All stripped elements of `filehandle` that are not empty.
+    """
+    for line in filehandle:
+        line = line.strip()
+        if line:
+            yield line
+
+
 with open(DATA_PATH/'citations.bib') as citation_file:
     COMMON_CITATIONS = read_bib(citation_file)
+
+with open(DATA_PATH/'quotes.txt') as quotes_file:
+    QUOTES = list(_read_quote_file(quotes_file))

--- a/vermouth/data/data.py
+++ b/vermouth/data/data.py
@@ -1,0 +1,19 @@
+# Copyright 2025 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import DATA_PATH
+from ..citation_parser import read_bib
+
+with open(DATA_PATH/'citations.bib') as citation_file:
+    COMMON_CITATIONS = read_bib(citation_file)

--- a/vermouth/data/force_fields/elnedyn21/citations.bib
+++ b/vermouth/data/force_fields/elnedyn21/citations.bib
@@ -52,13 +52,3 @@
   year={2010},
   publisher={Public Library of Science}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/data/force_fields/elnedyn22/citations.bib
+++ b/vermouth/data/force_fields/elnedyn22/citations.bib
@@ -52,13 +52,3 @@
   year={2010},
   publisher={Public Library of Science}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/data/force_fields/elnedyn22p/citations.bib
+++ b/vermouth/data/force_fields/elnedyn22p/citations.bib
@@ -52,13 +52,3 @@
   year={2010},
   publisher={Public Library of Science}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/data/force_fields/martini22/citations.bib
+++ b/vermouth/data/force_fields/martini22/citations.bib
@@ -52,13 +52,3 @@
   year={2010},
   publisher={Public Library of Science}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/data/force_fields/martini22p/citations.bib
+++ b/vermouth/data/force_fields/martini22p/citations.bib
@@ -52,13 +52,3 @@
   year={2010},
   publisher={Public Library of Science}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/data/force_fields/martini3001/citations.bib
+++ b/vermouth/data/force_fields/martini3001/citations.bib
@@ -18,16 +18,6 @@ year={2021}
   year={2022},
   publisher={Wiley Online Library}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}
 @article{M3_GO,
 title={GōMartini 3: From large conformational changes in proteins to environmental bias corrections},
 author={Souza, Paulo C. T. and Araujo, Luis P. Borges and Brasnett, Chris and Moreira, Rodrigo A. and Grunewald, Fabian and Park, Peter and Wang, Liguo and Razmazma, Hafez and Borges-Araujo, Ana C. and Cofas-Vargas, Luis F. and Monticelli, Luca and Mera-Adasme, Raul and Melo, Manuel N. and Wu, Sangwook and Marrink, Siewert J. and Poma, Adolfo B. and Thallmair, Sebastian},

--- a/vermouth/data/force_fields/martini30b32/citations.bib
+++ b/vermouth/data/force_fields/martini30b32/citations.bib
@@ -3,13 +3,3 @@
   author={Souza, Paulo C T and Marrink, Siewert Jan},
   year={2020}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/data/force_fields/martini30dev/citations.bib
+++ b/vermouth/data/force_fields/martini30dev/citations.bib
@@ -3,13 +3,3 @@
   author={Souza, Paulo C T and Marrink, Siewert Jan},
   year={2020}
 }
-@article{MDTraj,
-    title={MDTraj: A Modern Open Library for the Analysis of Molecular Dynamics Trajectories},
-    author={McGibbon, Robert T. and Beauchamp, Kyle A. and Harrigan, Matthew P. and Klein, Christoph and Swails, Jason M. and Hernández, Carlos X.  and Schwantes, Christian R. and Wang, Lee-Ping and Lane, Thomas J. and Pande, Vijay S.},
-    journal={Biophysical Journal},
-    volume={109},
-    number={8},
-    pages={1528 -- 1532},
-    year={2015},
-    doi={10.1016/j.bpj.2015.08.015}
-}

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -26,7 +26,6 @@ from . import DATA_PATH
 
 FORCE_FIELD_PARSERS = {'.rtp': read_rtp, '.ff': read_ff, '.bib': read_bib}
 # All data files that are in the root DATA_PATH, and apply to all force fields.
-COMMON_DATA_FILES = {'citations.bib'}
 
 # Cache the force fields.
 # It should only be used by the get_native_force_field function, else it would
@@ -70,11 +69,6 @@ class ForceField:
         self.variables = {}
         self.name = None
         self.citations = {}
-        for filename in COMMON_DATA_FILES:
-            # This is kind of inefficient. Better to parse the common files
-            # once, and pass around the data.
-            path = DATA_PATH / filename
-            self._read_from_file(path)
         if directory is not None:
             self.read_from(directory)
             self.name = os.path.basename(str(directory))
@@ -90,7 +84,7 @@ class ForceField:
     def __eq__(self, other):
         # Note, we cannot compare blocks/links/modifications, since those
         # compare their forcefields for equality.
-        return self.name == other.name
+        return isinstance(other, self.__class__) and self.name == other.name
 
     def read_from(self, directory):
         """
@@ -236,6 +230,3 @@ def get_native_force_field(name):
     except KeyError:
         _FORCE_FIELDS = find_force_fields(os.path.join(DATA_PATH, 'force_fields'))
         return _FORCE_FIELDS[name]
-
-
-DUMMY_FF = ForceField(name='dummy')

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -84,6 +84,14 @@ class ForceField:
             msg = 'At least one of `directory` or `name` must be provided.'
             raise TypeError(msg)
 
+    def __str__(self):
+        return f'ForceField({self.name})'
+
+    def __eq__(self, other):
+        # Note, we cannot compare blocks/links/modifications, since those
+        # compare their forcefields for equality.
+        return self.name == other.name
+
     def read_from(self, directory):
         """
         Populate or update the force field from a directory.

--- a/vermouth/forcefield.py
+++ b/vermouth/forcefield.py
@@ -236,3 +236,6 @@ def get_native_force_field(name):
     except KeyError:
         _FORCE_FIELDS = find_force_fields(os.path.join(DATA_PATH, 'force_fields'))
         return _FORCE_FIELDS[name]
+
+
+DUMMY_FF = ForceField(name='dummy')

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -356,7 +356,7 @@ class Molecule(nx.Graph):
         self.nrexcl = kwargs.pop('nrexcl', None)
         super().__init__(*args, **kwargs)
         self.interactions = defaultdict(list)
-        self.citations = set()
+        self.citations = {'vermouth'}  # This is part of martinize2/vermouth, so you should cite it!
         # {loglevel: {entry: [fmt_args]}}
         self.log_entries = defaultdict(lambda: defaultdict(list))
         self.max_node = None

--- a/vermouth/processors/quote.py
+++ b/vermouth/processors/quote.py
@@ -18,57 +18,33 @@
 Reads quotes, and produces a random one.
 """
 
-import os.path
 import random
 
 from .processor import Processor
-from .. import DATA_PATH
+from ..data import QUOTES
 from ..log_helpers import StyleAdapter, get_logger
 
 LOGGER = StyleAdapter(get_logger(__name__))
 
-QUOTE_FILE = os.path.join(DATA_PATH, 'quotes.txt')
-
-
-def read_quote_file(filehandle):
-    """
-    Iterates over `filehandle`, and yields all strings that are not empty.
-
-    Parameters
-    ----------
-    filehandle: collections.abc.Iterable[str]
-        A file opened for reading.
-
-    Yields
-    ------
-    str
-        All stripped elements of `filehandle` that are not empty.
-    """
-    for line in filehandle:
-        line = line.strip()
-        if line:
-            yield line
-
 
 class Quoter(Processor):
     """
-    Processor that can produce random string taken from a file. Useful for e.g.
+    Processor that can produce random string taken from a list. Useful for e.g.
     quotes.
 
     Parameters
     ----------
-    quote_file: pathlib.Path or str
-        The path of the file containing the strings. Must contain at least one
-        line.
+    quotes: list[str]
+        List of strings describing the quotes.
     """
-    def __init__(self, quote_file=None):
-        if quote_file is None:
-            quote_file = QUOTE_FILE
-        self._quote_file = quote_file
+    def __init__(self, quotes=None):
+        if not quotes:
+            quotes = QUOTES
+        self.quotes = quotes
 
     def run_system(self, system):
         """
-        Logs a random line from the file passed at initialization.
+        Logs a random line from the list passed at initialization.
 
         Parameters
         ----------
@@ -79,6 +55,4 @@ class Quoter(Processor):
         -------
         None
         """
-        with open(self._quote_file) as handle:
-            all_quotes = list(read_quote_file(handle))
-        LOGGER.info(random.choice(all_quotes))
+        LOGGER.info(random.choice(self.quotes))

--- a/vermouth/system.py
+++ b/vermouth/system.py
@@ -17,6 +17,7 @@
 Provides a class to describe a system.
 """
 from collections import defaultdict
+from .forcefield import DUMMY_FF
 
 class System:
     """
@@ -30,6 +31,9 @@ class System:
     def __init__(self, force_field=None):
         self.molecules = []
         self._force_field = None
+        if force_field is None:
+            # Create a dummy FF
+            force_field = DUMMY_FF
         self.force_field = force_field
         self.gmx_topology_params = defaultdict(list)
         self.go_params = defaultdict(list)
@@ -62,6 +66,17 @@ class System:
         ----------
         molecule: :class:`~vermouth.molecule.Molecule`
         """
+        if molecule.force_field is None:
+            molecule._force_field = self.force_field
+        if molecule.force_field != self.force_field:
+            if self.force_field is DUMMY_FF:
+                # We didn't have a force field, so take the one from the
+                # incoming molecule
+                self.force_field = molecule.force_field
+            else:
+                raise KeyError(f'Cannot add Molecule with force field '
+                               f'{molecule.force_field} to system with force field '
+                               f'{self.force_field}')
         self.molecules.append(molecule)
 
     @property

--- a/vermouth/system.py
+++ b/vermouth/system.py
@@ -17,7 +17,6 @@
 Provides a class to describe a system.
 """
 from collections import defaultdict
-from .forcefield import DUMMY_FF
 
 class System:
     """
@@ -31,9 +30,6 @@ class System:
     def __init__(self, force_field=None):
         self.molecules = []
         self._force_field = None
-        if force_field is None:
-            # Create a dummy FF
-            force_field = DUMMY_FF
         self.force_field = force_field
         self.gmx_topology_params = defaultdict(list)
         self.go_params = defaultdict(list)
@@ -68,15 +64,13 @@ class System:
         """
         if molecule.force_field is None:
             molecule._force_field = self.force_field
+        if self.force_field is None:
+            # We didn't have a FF, but we have one now!
+            self.force_field = molecule.force_field
         if molecule.force_field != self.force_field:
-            if self.force_field is DUMMY_FF:
-                # We didn't have a force field, so take the one from the
-                # incoming molecule
-                self.force_field = molecule.force_field
-            else:
-                raise KeyError(f'Cannot add Molecule with force field '
-                               f'{molecule.force_field} to system with force field '
-                               f'{self.force_field}')
+            raise KeyError(f'Cannot add Molecule with force field '
+                           f'{molecule.force_field} to system with force field '
+                           f'{self.force_field}')
         self.molecules.append(molecule)
 
     @property

--- a/vermouth/tests/gmx/test_topology.py
+++ b/vermouth/tests/gmx/test_topology.py
@@ -166,7 +166,7 @@ def test_toplevel_topology(tmp_path, dummy_molecule):
     """
     os.chdir(tmp_path)
     system = vermouth.System()
-    system.molecules.append(dummy_molecule)
+    system.add_molecule(dummy_molecule)
     dummy_molecule.meta['moltype'] = "molecule_0"
     # "node": 0, "sigma": 0.43, "epsilon": 2.3, "meta": {}}
     system.gmx_topology_params['atomtypes'].append(Atomtype(node=0,

--- a/vermouth/tests/rcsu/test_read_go_map.py
+++ b/vermouth/tests/rcsu/test_read_go_map.py
@@ -57,7 +57,7 @@ from vermouth.tests.helper_functions import test_molecule
          """,
          [(1, "A", 2, "B"), (1, "A", 40, "B"), (2, "C", 37, "D"), (2, "C", 39, "D")]
         )))
-def test_go_map(tmp_path, lines, contacts):
+def test_go_map(test_molecule, tmp_path, lines, contacts):
     # write the go contact map file
     with open(tmp_path / "go_file.txt", "w") as in_file:
         in_file.write(lines)
@@ -69,7 +69,7 @@ def test_go_map(tmp_path, lines, contacts):
     read_go_map(system, tmp_path / "go_file.txt")
     assert system.go_params["go_map"][0] == contacts
 
-def test_go_error(tmp_path):
+def test_go_error(test_molecule, tmp_path):
     lines="""
           ID    I1  AA  C I(PDB)     I2  AA  C I(PDB)        DCA       CMs    rCSU   Count Model
           ============================================================================================

--- a/vermouth/tests/test_system.py
+++ b/vermouth/tests/test_system.py
@@ -1,0 +1,58 @@
+# Copyright 2025 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test some of the behaviour of :class:`vermouth.system.System`
+"""
+
+import pytest
+
+from vermouth import System, Molecule
+from vermouth.forcefield import ForceField
+
+
+def test_add_molecule_mismatch_ff():
+    """
+    Assert that adding a molecule to a system with a mismatching force field
+    errors.
+    """
+    ff_a = ForceField(name='a')
+    ff_b = ForceField(name='b')
+    assert ff_a != ff_b
+
+    system = System(force_field=ff_a)
+    mol_a = Molecule(force_field=ff_a)
+    system.add_molecule(mol_a)
+    assert len(system.molecules) == 1
+    mol_b = Molecule(force_field=ff_b)
+    with pytest.raises(KeyError):
+        system.add_molecule(mol_b)
+
+
+def test_system_automatic_ff():
+    """
+    Assert that a system automatically gets a force field when given a molecule.
+    """
+    ff_a = ForceField(name='a')
+    ff_b = ForceField(name='b')
+    assert ff_a != ff_b
+
+    system = System(force_field=None)
+    mol_a = Molecule(force_field=ff_a)
+    system.add_molecule(mol_a)
+    assert len(system.molecules) == 1
+    assert system.force_field == ff_a
+    mol_b = Molecule(force_field=ff_b)
+    with pytest.raises(KeyError):
+        system.add_molecule(mol_b)


### PR DESCRIPTION
This is particularly useful for *code* that needs citing, such as MDTraj, and vermouth.

The vermouth citation gets formatted as
```
    INFO - general - Please cite: Kroon, P C; Grunewald, F; Barnoud, J; van Tilburg, M; Souza, P C; Wassenaar, T A; Marrink, S J;  elife 2024; 10.7554/elife.90627.2
```

Things got a bit more messy because of Molecules and Systems without forcefield (or, `force_field=None`), so I also did something sane with the defaults there.