### PR TITLE
move header writing in gmx files to a system level meta attribute

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -912,19 +912,6 @@ def entry():
         write_canon=args.write_canon,
     )
 
-    # grompp has a limit in the number of character it can read per line
-    # (due to the size limit of a buffer somewhere in its implementation).
-    # The command line can be longer than this limit and therefore
-    # prevent grompp from reading the topology.
-    gromacs_char_limit = 4000  # the limit is actually 4095, but I play safe
-    command = " ".join(sys.argv)
-    if len(command) > gromacs_char_limit:
-        command = command[:gromacs_char_limit] + " ..."
-    system.meta["header"].extend(("This file was generated using the following command:",
-                                  command,
-                                  VERSION,
-                                 ))
-
     LOGGER.info("Read input.", type="step")
     for molecule in system.molecules:
         LOGGER.debug("Read molecule {}.", molecule, type="step")
@@ -1156,7 +1143,9 @@ def entry():
                            args.top_path,
                            itp_paths=itp_paths,
                            C6C12=False,
-                           defines=defines)
+                           defines=defines,
+                           command=sys.argv,
+                           version=VERSION)
 
     # Write a PDB file.
     vermouth.pdb.write_pdb(system, str(args.outpath), omit_charges=True)

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -911,7 +911,10 @@ def entry():
         write_repair=args.write_repair,
         write_canon=args.write_canon,
     )
-
+    system.meta["header"].extend(("This file was generated using the following command:",
+                                  " ".join(sys.argv),
+                                  VERSION,
+                                  ))
     LOGGER.info("Read input.", type="step")
     for molecule in system.molecules:
         LOGGER.debug("Read molecule {}.", molecule, type="step")
@@ -1143,9 +1146,7 @@ def entry():
                            args.top_path,
                            itp_paths=itp_paths,
                            C6C12=False,
-                           defines=defines,
-                           command=sys.argv,
-                           version=VERSION)
+                           defines=defines)
 
     # Write a PDB file.
     vermouth.pdb.write_pdb(system, str(args.outpath), omit_charges=True)

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -912,6 +912,19 @@ def entry():
         write_canon=args.write_canon,
     )
 
+    # grompp has a limit in the number of character it can read per line
+    # (due to the size limit of a buffer somewhere in its implementation).
+    # The command line can be longer than this limit and therefore
+    # prevent grompp from reading the topology.
+    gromacs_char_limit = 4000  # the limit is actually 4095, but I play safe
+    command = " ".join(sys.argv)
+    if len(command) > gromacs_char_limit:
+        command = command[:gromacs_char_limit] + " ..."
+    system.meta["header"].extend(("This file was generated using the following command:",
+                                  command,
+                                  VERSION,
+                                 ))
+
     LOGGER.info("Read input.", type="step")
     for molecule in system.molecules:
         LOGGER.debug("Read molecule {}.", molecule, type="step")
@@ -1137,19 +1150,6 @@ def entry():
                     LOGGER.log(loglevel, entry, **fmt_arg, type="model")
 
     # Write the topology if requested
-    # grompp has a limit in the number of character it can read per line
-    # (due to the size limit of a buffer somewhere in its implementation).
-    # The command line can be longer than this limit and therefore
-    # prevent grompp from reading the topology.
-    gromacs_char_limit = 4000  # the limit is actually 4095, but I play safe
-    command = " ".join(sys.argv)
-    if len(command) > gromacs_char_limit:
-        command = command[:gromacs_char_limit] + " ..."
-
-    system.meta["header"].append(["This file was generated using the following command:",
-                                  command,
-                                  VERSION,
-                                  ])
 
     if args.top_path is not None:
         write_gmx_topology(system,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -1155,25 +1155,23 @@ def entry():
     command = " ".join(sys.argv)
     if len(command) > gromacs_char_limit:
         command = command[:gromacs_char_limit] + " ..."
-    header = [
-        "This file was generated using the following command:",
-        command,
-        VERSION,
-    ]
+
+    system.meta["header"].append(["This file was generated using the following command:",
+                                  command,
+                                  VERSION,
+                                  ])
     if None not in ss_sequence:
-        header += [
-            "The following sequence of secondary structure ",
-            "was used for the full system:",
-            "".join(ss_sequence),
-        ]
+        system.meta["header"].append(["The following sequence of secondary structure ",
+                                      "was used for the full system:",
+                                      "".join(ss_sequence),
+                                      ])
 
     if args.top_path is not None:
         write_gmx_topology(system,
                            args.top_path,
                            itp_paths=itp_paths,
                            C6C12=False,
-                           defines=defines,
-                           header=header)
+                           defines=defines)
 
     # Write a PDB file.
     vermouth.pdb.write_pdb(system, str(args.outpath), omit_charges=True)

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -975,16 +975,6 @@ def entry():
                            'for this force field',
                            type="missing-feature")
 
-    # ss_sequence = list(
-    #     itertools.chain(
-    #         *(
-    #             dssp.sequence_from_residues(molecule, "secstruct")
-    #             for molecule in system.molecules
-    #             if selectors.is_protein(molecule)
-    #         )
-    #     )
-    # )
-
     if args.cystein_bridge == "none":
         vermouth.RemoveCysteinBridgeEdges().run_system(system)
     elif args.cystein_bridge != "auto":

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -174,7 +174,7 @@ def martinize(system, mappings, to_ff, delete_unknown=False, idrs=False, disorde
         mappings=mappings,
         to_ff=to_ff,
         delete_unknown=delete_unknown,
-        attribute_keep=("cgsecstruct", "chain"),
+        attribute_keep=("cgsecstruct", "chain", "secstruct"),
         attribute_must=("resname",),
         attribute_stash=("resid",),
     ).run_system(system)
@@ -975,15 +975,15 @@ def entry():
                            'for this force field',
                            type="missing-feature")
 
-    ss_sequence = list(
-        itertools.chain(
-            *(
-                dssp.sequence_from_residues(molecule, "secstruct")
-                for molecule in system.molecules
-                if selectors.is_protein(molecule)
-            )
-        )
-    )
+    # ss_sequence = list(
+    #     itertools.chain(
+    #         *(
+    #             dssp.sequence_from_residues(molecule, "secstruct")
+    #             for molecule in system.molecules
+    #             if selectors.is_protein(molecule)
+    #         )
+    #     )
+    # )
 
     if args.cystein_bridge == "none":
         vermouth.RemoveCysteinBridgeEdges().run_system(system)
@@ -1160,11 +1160,6 @@ def entry():
                                   command,
                                   VERSION,
                                   ])
-    if None not in ss_sequence:
-        system.meta["header"].append(["The following sequence of secondary structure ",
-                                      "was used for the full system:",
-                                      "".join(ss_sequence),
-                                      ])
 
     if args.top_path is not None:
         write_gmx_topology(system,

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -554,7 +554,7 @@ def gmx_system_header(system):
         )
     )
 
-    if (None not in ss_sequence) and (len(ss_sequence) > 0):
+    if None not in ss_sequence and ss_sequence:
         system.meta["header"].extend(("The following sequence of secondary structure ",
                                       "was used for the full system:",
                                       "".join(ss_sequence),

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -554,7 +554,7 @@ def gmx_system_header(system):
         )
     )
 
-    if None not in ss_sequence:
+    if (None not in ss_sequence) and (len(ss_sequence) > 0):
         system.meta["header"].extend(("The following sequence of secondary structure ",
                                       "was used for the full system:",
                                       "".join(ss_sequence),

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -591,6 +591,7 @@ class AnnotateMartiniSecondaryStructures(Processor):
 
     def run_system(self, system):
         gmx_system_header(system)
+        super().run_system(system)
 
 
 class AnnotateResidues(Processor):

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 import tempfile
 import re
+import itertools
 
 from ..file_writer import deferred_open
 from ..pdb import pdb
@@ -541,6 +542,24 @@ def convert_dssp_annotation_to_martini(
         raise ValueError('Not all residues have a DSSP assignation.')
 
 
+def gmx_system_header(system):
+
+    ss_sequence = list(
+        itertools.chain(
+            *(
+                sequence_from_residues(molecule, "secstruct")
+                for molecule in system.molecules
+                if is_protein(molecule)
+            )
+        )
+    )
+
+    if None not in ss_sequence:
+        system.meta["header"].extend(("The following sequence of secondary structure ",
+                                      "was used for the full system:",
+                                      "".join(ss_sequence),
+                                     ))
+
 class AnnotateDSSP(Processor):
     name = 'AnnotateDSSP'
 
@@ -569,6 +588,9 @@ class AnnotateMartiniSecondaryStructures(Processor):
     def run_molecule(molecule):
         convert_dssp_annotation_to_martini(molecule)
         return molecule
+
+    def run_system(self, system):
+        gmx_system_header(system)
 
 
 class AnnotateResidues(Processor):

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -178,7 +178,7 @@ def write_gmx_topology(system,
         system.molecules, key=lambda x: x.meta["moltype"]
     )
 
-    header = system.meta["header"]
+    header = system.meta.get("header", [])
 
     for moltype, molecules in molecule_groups:
         molecule = next(molecules)

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -183,10 +183,13 @@ def write_gmx_topology(system,
     # The command line can be longer than this limit and therefore
     # prevent grompp from reading the topology.
     gromacs_char_limit = 4000  # the limit is actually 4095, but I play safe
-    header = system.meta.get('header', [])
-    for line in header:
+    _header = system.meta.get('header', [])
+    header = []
+    for line in _header:
         if len(line) > gromacs_char_limit:
             header.append(line[:gromacs_char_limit] + " ...")
+    if not header:
+        header = _header
 
     for moltype, molecules in molecule_groups:
         molecule = next(molecules)

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -188,8 +188,8 @@ def write_gmx_topology(system,
     for line in _header:
         if len(line) > gromacs_char_limit:
             header.append(line[:gromacs_char_limit] + " ...")
-    if not header:
-        header = _header
+        else:
+            header.append(line)
 
     for moltype, molecules in molecule_groups:
         molecule = next(molecules)

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -118,9 +118,7 @@ def write_gmx_topology(system,
                        itp_paths={"nonbond_params": "extra_nbparams.itp",
                                   "atomtypes": "extra_atomtypes.itp"},
                        C6C12=False,
-                       defines=(),
-                       command=[],
-                       version=''):
+                       defines=()):
     """
     Writes a Gromacs .top file for the specified system. Gromacs topology
     files are defined by directives for example `[ atomtypes ]`. However,
@@ -145,10 +143,6 @@ def write_gmx_topology(system,
         C6C12 form
     defines: tuple(str)
         define statments to include in the topology
-    command: list
-        command used to generate the system
-    version: str
-        version of vermouth used to generate system
     """
     if not system.molecules:
         raise ValueError("No molecule in the system. Nothing to write.")
@@ -189,15 +183,10 @@ def write_gmx_topology(system,
     # The command line can be longer than this limit and therefore
     # prevent grompp from reading the topology.
     gromacs_char_limit = 4000  # the limit is actually 4095, but I play safe
-    command_used = " ".join(command)
-    if len(command_used) > gromacs_char_limit:
-        command_used = command_used[:gromacs_char_limit] + " ..."
-    system.meta["header"].extend(("This file was generated using the following command:",
-                                  command_used,
-                                  version,
-                                  ))
-
-    header = system.meta.get("header", [])
+    header = system.meta.get('header', [])
+    for line in header:
+        if len(line) > gromacs_char_limit:
+            header.append(line[:gromacs_char_limit] + " ...")
 
     for moltype, molecules in molecule_groups:
         molecule = next(molecules)

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -17,27 +17,6 @@ LOGGER = StyleAdapter(get_logger(__name__))
 Atomtype = namedtuple('Atomtype', 'molecule node sigma epsilon meta')
 NonbondParam = namedtuple('NonbondParam', 'atoms sigma epsilon meta')
 
-def system_header(system):
-
-    ss_sequence = list(
-        itertools.chain(
-            *(
-                sequence_from_residues(molecule, "secstruct")
-                for molecule in system.molecules
-                if is_protein(molecule)
-            )
-        )
-    )
-
-    if None not in ss_sequence:
-        system.meta["header"].append(["The following sequence of secondary structure ",
-                                      "was used for the full system:",
-                                      "".join(ss_sequence),
-                                      ])
-
-    header = [i for j in system.meta["header"] for i in j]
-
-    return header
 
 def _group_by_conditionals(interactions):
     interactions_group_sorted = sorted(interactions,
@@ -164,8 +143,6 @@ def write_gmx_topology(system,
         C6C12 form
     defines: tuple(str)
         define statments to include in the topology
-    header: tuple(str)
-        any comment lines to include at the beginning
     """
     if not system.molecules:
         raise ValueError("No molecule in the system. Nothing to write.")
@@ -201,7 +178,7 @@ def write_gmx_topology(system,
         system.molecules, key=lambda x: x.meta["moltype"]
     )
 
-    header = system_header(system)
+    header = system.meta["header"]
 
     for moltype, molecules in molecule_groups:
         molecule = next(molecules)

--- a/vermouth/gmx/topology.py
+++ b/vermouth/gmx/topology.py
@@ -116,8 +116,7 @@ def write_gmx_topology(system,
                        itp_paths={"nonbond_params": "extra_nbparams.itp",
                                   "atomtypes": "extra_atomtypes.itp"},
                        C6C12=False,
-                       defines=(),
-                       header=()):
+                       defines=()):
     """
     Writes a Gromacs .top file for the specified system. Gromacs topology
     files are defined by directives for example `[ atomtypes ]`. However,
@@ -178,6 +177,8 @@ def write_gmx_topology(system,
     molecule_groups = itertools.groupby(
         system.molecules, key=lambda x: x.meta["moltype"]
     )
+
+    header = [i for j in system.meta["header"] for i in j]
     for moltype, molecules in molecule_groups:
         molecule = next(molecules)
         if molecule.force_field is not None:

--- a/vermouth/system.py
+++ b/vermouth/system.py
@@ -33,6 +33,7 @@ class System:
         self.force_field = force_field
         self.gmx_topology_params = defaultdict(list)
         self.go_params = defaultdict(list)
+        self.meta = defaultdict(list)
 
     @property
     def force_field(self):

--- a/vermouth/tests/gmx/test_topology.py
+++ b/vermouth/tests/gmx/test_topology.py
@@ -178,12 +178,12 @@ def test_toplevel_topology(tmp_path, dummy_molecule):
                                                                      sigma=0.43,
                                                                      epsilon=2.3,
                                                                      meta={}))
+    system.meta["header"] = ['first header comment', 'second header comment']
     outpath = tmp_path / 'out.itp'
     atompath = tmp_path / 'atomtypes.itp'
     nbpath = tmp_path / 'nonbond_params.itp'
     write_gmx_topology(system,
                        outpath,
-                       header=['first header comment', 'second header comment'],
                        defines=('random', ),
                        itp_paths={"atomtypes": atompath, "nonbond_params": nbpath},
                        # at this level C6C12 doesn't matter; it gets

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -37,6 +37,7 @@ from vermouth.tests.datafiles import (
     PDB_ALA5_CG,
     PDB_ALA5,
 )
+from vermouth.tests.helper_functions import test_molecule, create_sys_all_attrs
 
 DSSP_EXECUTABLE = os.environ.get("VERMOUTH_TEST_DSSP", "dssp")
 SECSTRUCT_1BTA = list(
@@ -705,3 +706,28 @@ def test_cterm_atomnames():
 def test_convert_dssp_to_martini(sequence, expected):
     found = dssp.convert_dssp_to_martini(sequence)
     assert expected == found
+
+
+def test_dssp_system_header(test_molecule):
+
+    atypes = {0: "P1", 1: "SN4a", 2: "SN4a",
+              3: "SP1", 4: "C1",
+              5: "TP1",
+              6: "P1", 7: "SN3a", 8: "SP4"}
+    # the molecule resnames
+    resnames = {0: "A", 1: "A", 2: "A",
+                3: "B", 4: "B",
+                5: "C",
+                6: "D", 7: "D", 8: "D"}
+    secstruc = {1: "H", 2: "H", 3: "H", 4: "H"}
+
+    system = create_sys_all_attrs(test_molecule,
+                                  moltype="molecule_0",
+                                  secstruc=secstruc,
+                                  defaults={"chain": "A"},
+                                  attrs={"resname": resnames,
+                                         "atype": atypes})
+
+    dssp.AnnotateMartiniSecondaryStructures().run_system(system)
+
+    assert system.meta.get('head')

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -730,4 +730,4 @@ def test_dssp_system_header(test_molecule):
 
     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
 
-    assert system.meta.get('head')
+    assert system.meta.get('header')

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -708,17 +708,17 @@ def test_convert_dssp_to_martini(sequence, expected):
     assert expected == found
 
 
-def test_dssp_system_header(test_molecule):
+def test_gmx_system_header(test_molecule):
 
     atypes = {0: "P1", 1: "SN4a", 2: "SN4a",
               3: "SP1", 4: "C1",
               5: "TP1",
               6: "P1", 7: "SN3a", 8: "SP4"}
-    # the molecule resnames
-    resnames = {0: "A", 1: "A", 2: "A",
-                3: "B", 4: "B",
-                5: "C",
-                6: "D", 7: "D", 8: "D"}
+    # the molecule resnames. needs to be actual protein resnames because gmx_system_header checks is_protein(molecule)
+    resnames = {0: "ALA", 1: "ALA", 2: "ALA",
+                3: "GLY", 4: "GLY",
+                5: "MET",
+                6: "ARG", 7: "ARG", 8: "ARG"}
     secstruc = {1: "H", 2: "H", 3: "H", 4: "H"}
 
     system = create_sys_all_attrs(test_molecule,
@@ -728,6 +728,12 @@ def test_dssp_system_header(test_molecule):
                                   attrs={"resname": resnames,
                                          "atype": atypes})
 
+    # need to annotate the actual 'secstruct' attribute because create_sys_all_attrs actually annotates cgsecstruct
+    dssp.AnnotateResidues(attribute="secstruct",
+                          sequence="HHHH").run_system(system)
+
     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
 
-    assert system.meta.get('header')
+    assert len(system.meta.get('header')) == 3
+    assert system.meta.get('header')[-1] == "HHHH"
+


### PR DESCRIPTION
instead of collecting the header for gmx files as a list, move it to a system.meta["header"] list that can be more dynamically added to