### PR TITLE
Rtp patch

### DIFF
--- a/vermouth/gmx/itp_read.py
+++ b/vermouth/gmx/itp_read.py
@@ -250,6 +250,10 @@ class ITPDirector(SectionLineParser):
         tokens = collections.deque(_tokenize(line))
         self._parse_block_atom(tokens, self.current_block)
 
+
+    @SectionLineParser.section_parser('moleculetype', 'cmap')
+    def _skip(self, line, lineno=0):
+        pass
     @SectionLineParser.section_parser('moleculetype', 'bonds')
     @SectionLineParser.section_parser('moleculetype', 'angles')
     @SectionLineParser.section_parser('moleculetype', 'dihedrals')

--- a/vermouth/molecule.py
+++ b/vermouth/molecule.py
@@ -739,7 +739,12 @@ class Molecule(nx.Graph):
             # We assume that the last id is always the largest.
             last_node_idx = self.max_node
             offset = last_node_idx
-            residue_offset = self.nodes[last_node_idx].get('resid', 1)
+            # guard against nodes that don't have a resid
+            nodes = sorted(list(self.nodes), reverse=True)
+            for last_node_idx in nodes:
+                residue_offset = self.nodes[last_node_idx].get('resid', None)
+                if residue_offset:
+                    break
             offset_charge_group = self.nodes[last_node_idx].get('charge_group', 1)
         else:
             offset = 0

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -408,7 +408,6 @@ def apply_mod_mapping(match, molecule, graph_out, mol_to_out, out_to_mol):
     mol_to_mod, modification, references = match
     LOGGER.info('Applying modification mapping {}', modification.name, type='general')
     graph_out.citations.update(modification.citations)
-
     mod_to_mol = defaultdict(dict)
     for mol_idx, mod_idxs in mol_to_mod.items():
         for mod_idx in mod_idxs:
@@ -464,6 +463,21 @@ def apply_mod_mapping(match, molecule, graph_out, mol_to_out, out_to_mol):
         out_idx = mod_to_out[mod_idx]
         if 'charge_group' not in graph_out.nodes[out_idx]:
             graph_out.nodes[out_idx]['charge_group'] = charge_group
+
+    # FIXME we need to assing updated resids to the modification atoms
+    # the block mapping does this for the unmodified atoms
+    for mod_idx, out_idx in mod_to_out.items():
+        if mod_idx in anchors:
+            continue
+        neighbors = modification.neighbors(mod_idx)
+        for mod_idx_neigh in neighbors:
+            anchor = mod_to_out[mod_idx_neigh]
+            resid_new = graph_out.nodes[anchor].get('resid', None)
+            resid_old = graph_out.nodes[anchor].get('_old_resid', None)
+            if resid_new:
+                graph_out.nodes[out_idx]['_old_resid'] = resid_old
+                graph_out.nodes[out_idx]['resid'] = resid_new
+                break
 
     for mol_idx in mol_to_mod:
         for mod_idx, weight in mol_to_mod[mol_idx].items():
@@ -609,7 +623,6 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
     # One to many - e.g. CG to AA. This mostly works, but we don't know how to
     #               make sure the "many" should be connected together. Gives a
     #               warning if it's disconnected.
-
     mol_to_out = defaultdict(dict)
     out_to_mol = defaultdict(dict)
     overlapping_mappings = set()
@@ -641,6 +654,7 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
     # At this point, we should have created graph_out at the desired
     # resolution, *and* have the associated correspondence in mol_to_out and
     # out_to_mol.
+
 
     # Set node attributes based on what the original atoms are.
     to_remove = set()
@@ -712,6 +726,7 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
             for out_idx, out_jdx in product(out_idxs, out_jdxs):
                 if out_idx != out_jdx:
                     graph_out.add_edge(out_idx, out_jdx)
+
 
     ############################
     # Sanity check the results #


### PR DESCRIPTION
Patch to make the rtp parser play nice with modifications. Essentially, we need to add updated resids to modification atoms. I also added a fail-safe in molecule resid assignment upon merging. 