### PR TITLE
correct logic for writing out contact map to an external file

### DIFF
--- a/vermouth/rcsu/contact_map.py
+++ b/vermouth/rcsu/contact_map.py
@@ -21,6 +21,7 @@ from itertools import product
 from vermouth.file_writer import deferred_open
 from collections import defaultdict
 from vermouth import __version__ as VERSION
+from pathlib import Path
 
 # BOND TYPE
 # Types of contacts:
@@ -769,7 +770,7 @@ def do_contacts(molecule, write_file):
                             res_idx,
                             mol_graph)
 
-    if isinstance(write_file, str):
+    if isinstance(write_file, Path):
         _write_contacts(write_file, all_contacts, ca_pos, mol_graph)
 
     return contacts

--- a/vermouth/rcsu/contact_map.py
+++ b/vermouth/rcsu/contact_map.py
@@ -770,7 +770,7 @@ def do_contacts(molecule, write_file):
                             res_idx,
                             mol_graph)
 
-    if isinstance(write_file, Path):
+    if isinstance(write_file, (str, Path)):
         _write_contacts(write_file, all_contacts, ca_pos, mol_graph)
 
     return contacts

--- a/vermouth/tests/rcsu/test_contact_map.py
+++ b/vermouth/tests/rcsu/test_contact_map.py
@@ -27,6 +27,7 @@ from vermouth.rcsu.contact_map import GenerateContactMap
 from vermouth.tests.helper_functions import test_molecule, equal_graphs, create_sys_all_attrs
 from vermouth.tests.datafiles import TEST_MOLECULE_CONTACT_MAP
 from vermouth.file_writer import DeferredFileWriter
+from pathlib import Path
 
 @pytest.mark.parametrize('resname, atomname, expected',
                          (
@@ -398,7 +399,7 @@ def test_write_contacts(test_molecule, tmp_path):
 def test_do_contacts(test_molecule, tmp_path, write_out):
 
     if write_out:
-        outpath = str(tmp_path / 'contacts.out')
+        outpath = Path(tmp_path / 'contacts.out')
     else:
         outpath = False
 


### PR DESCRIPTION
per #666 the logic wasn't correct for writing out the contact map calculated using `-go`. This PR fixes it