### PR TITLE
bump image for tests from ubuntu-20.04 to ubuntu-latest 

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     
     strategy:
       matrix:


### PR DESCRIPTION
bump image from ubuntu-20.04 to ubuntu-latest per https://github.com/actions/runner-images/issues/11101