### PR TITLE
Secstruc gmx header fix

### DIFF
--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -548,7 +548,7 @@ def gmx_system_header(system):
     ss_sequence = list(
         itertools.chain(
             *(
-                sequence_from_residues(molecule, "secstruct")
+                sequence_from_residues(molecule, "aasecstruct")
                 for molecule in system.molecules
                 if is_protein(molecule)
             )
@@ -560,26 +560,6 @@ def gmx_system_header(system):
                                       "was used for the full system:",
                                       "".join(ss_sequence),
                                      ))
-
-    if any([molecule.meta.get('modified_cgsecstruct', False) for molecule in system.molecules]):
-        supplementary_ss_seq = list(
-            itertools.chain(
-                *(
-                    sequence_from_residues(molecule, "cgsecstruct")
-                    for molecule in system.molecules
-                    if is_protein(molecule)
-                )
-            )
-        )
-
-        LOGGER.info(("Secondary structure assignment changed between dssp and martinize. "
-                     "Check files for details."), type="general")
-        system.meta["header"].extend((
-            "The assigned secondary structure conflicted with ",
-            "annotated IDRs. The following sequence of Martini secondary ",
-            "structure was actually applied to the system:",
-            "".join([SS_CG[i] for i in supplementary_ss_seq])
-        ))
 
 class AnnotateDSSP(Processor):
     name = 'AnnotateDSSP'

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -746,34 +746,3 @@ def test_gmx_system_header(test_molecule, resnames, ss_string, secstruc):
     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
 
     assert ss_string in system.meta.get('header', [''])
-#
-# @pytest.mark.parametrize('modify, expected',
-#                          ((True, True),
-#                          (False, False)
-# ))
-# def test_gmx_system_header_supplementary(test_molecule, modify, expected):
-#
-#     atypes = {0: "P1", 1: "SN4a", 2: "SN4a",
-#               3: "SP1", 4: "C1",
-#               5: "TP1",
-#               6: "P1", 7: "SN3a", 8: "SP4"}
-#     resnames = {0: "ALA", 1: "ALA", 2: "ALA",
-#                 3: "GLY", 4: "GLY",
-#                 5: "MET",
-#                 6: "ARG", 7: "ARG", 8: "ARG"}
-#     secstruc ={1: "H", 2: "H", 3: "H", 4: "H"}
-#
-#     system = create_sys_all_attrs(test_molecule,
-#                                   moltype="molecule_0",
-#                                   secstruc=secstruc,
-#                                   defaults={"chain": "A"},
-#                                   attrs={"resname": resnames,
-#                                          "atype": atypes})
-#     if modify:
-#         system.molecules[0].meta['modified_cgsecstruct'] = True
-#
-#     dssp.AnnotateResidues(attribute="aasecstruct",
-#                           sequence="HHHH").run_system(system)
-#     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
-#
-#     assert expected == any(["IDR" in i for i in system.meta.get('header', [''])])

--- a/vermouth/tests/test_dssp.py
+++ b/vermouth/tests/test_dssp.py
@@ -740,40 +740,40 @@ def test_gmx_system_header(test_molecule, resnames, ss_string, secstruc):
                                          "atype": atypes})
 
     # annotate the actual 'secstruct' attribute because create_sys_all_attrs actually annotates cgsecstruct
-    dssp.AnnotateResidues(attribute="secstruct",
+    dssp.AnnotateResidues(attribute="aasecstruct",
                           sequence="HHHH").run_system(system)
 
     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
 
     assert ss_string in system.meta.get('header', [''])
-
-@pytest.mark.parametrize('modify, expected',
-                         ((True, True),
-                         (False, False)
-))
-def test_gmx_system_header_supplementary(test_molecule, modify, expected):
-
-    atypes = {0: "P1", 1: "SN4a", 2: "SN4a",
-              3: "SP1", 4: "C1",
-              5: "TP1",
-              6: "P1", 7: "SN3a", 8: "SP4"}
-    resnames = {0: "ALA", 1: "ALA", 2: "ALA",
-                3: "GLY", 4: "GLY",
-                5: "MET",
-                6: "ARG", 7: "ARG", 8: "ARG"}
-    secstruc ={1: "H", 2: "H", 3: "H", 4: "H"}
-
-    system = create_sys_all_attrs(test_molecule,
-                                  moltype="molecule_0",
-                                  secstruc=secstruc,
-                                  defaults={"chain": "A"},
-                                  attrs={"resname": resnames,
-                                         "atype": atypes})
-    if modify:
-        system.molecules[0].meta['modified_cgsecstruct'] = True
-
-    dssp.AnnotateResidues(attribute="secstruct",
-                          sequence="HHHH").run_system(system)
-    dssp.AnnotateMartiniSecondaryStructures().run_system(system)
-
-    assert expected == any(["IDR" in i for i in system.meta.get('header', [''])])
+#
+# @pytest.mark.parametrize('modify, expected',
+#                          ((True, True),
+#                          (False, False)
+# ))
+# def test_gmx_system_header_supplementary(test_molecule, modify, expected):
+#
+#     atypes = {0: "P1", 1: "SN4a", 2: "SN4a",
+#               3: "SP1", 4: "C1",
+#               5: "TP1",
+#               6: "P1", 7: "SN3a", 8: "SP4"}
+#     resnames = {0: "ALA", 1: "ALA", 2: "ALA",
+#                 3: "GLY", 4: "GLY",
+#                 5: "MET",
+#                 6: "ARG", 7: "ARG", 8: "ARG"}
+#     secstruc ={1: "H", 2: "H", 3: "H", 4: "H"}
+#
+#     system = create_sys_all_attrs(test_molecule,
+#                                   moltype="molecule_0",
+#                                   secstruc=secstruc,
+#                                   defaults={"chain": "A"},
+#                                   attrs={"resname": resnames,
+#                                          "atype": atypes})
+#     if modify:
+#         system.molecules[0].meta['modified_cgsecstruct'] = True
+#
+#     dssp.AnnotateResidues(attribute="aasecstruct",
+#                           sequence="HHHH").run_system(system)
+#     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
+#
+#     assert expected == any(["IDR" in i for i in system.meta.get('header', [''])])


### PR DESCRIPTION
Per #689 I thought I had something weird going on with an mdtraj installation not being picked up and used, but it turned out that was a local environment problem. While tracking it down to make sure it was all ok, I did notice that with the recent changes 

1) the dssp string wasn't actually being written to the header because we were still looking for a `secstruct` attribute not `aasecstruct`
2) the business with changing the effective string wrt IDRs wasn't actually being used because of where the dssp gmx header annotation comes in the pipeline.

So, this PR fixes 1) easily and 2) by moving some code around