### PR TITLE
Attribute handling

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -912,7 +912,7 @@ def entry():
         write_repair=args.write_repair,
         write_canon=args.write_canon,
     )
-    vermouth.StashAttributes(attributes=("resid",)).run_system(system)
+    vermouth.StashAttributes(attributes=("resid",), stash_name="stash").run_system(system)
     system.meta["header"].extend(("This file was generated using the following command:",
                                   " ".join(sys.argv),
                                   VERSION,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -169,14 +169,14 @@ def pdb_to_universal(
 
 def martinize(system, mappings, to_ff, delete_unknown=False, idrs=False, disordered_regions=None):
     """
-    Convert a system from one force field to an other at lower resolution.
+    Convert a system from one force field to another at lower resolution.
     """
     LOGGER.info("Creating the graph at the target resolution.", type="step")
     vermouth.DoMapping(
         mappings=mappings,
         to_ff=to_ff,
         delete_unknown=delete_unknown,
-        attribute_keep=("cgsecstruct", "chain", "secstruct"),
+        attribute_keep=("cgsecstruct", "chain", "secstruct", "stash"),
         attribute_must=("resname",),
         attribute_stash=("resid",),
     ).run_system(system)
@@ -913,6 +913,7 @@ def entry():
         write_repair=args.write_repair,
         write_canon=args.write_canon,
     )
+    vermouth.StashAttributes(attributes=("resid",)).run_system(system)
     system.meta["header"].extend(("This file was generated using the following command:",
                                   " ".join(sys.argv),
                                   VERSION,

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -178,7 +178,6 @@ def martinize(system, mappings, to_ff, delete_unknown=False, idrs=False, disorde
         delete_unknown=delete_unknown,
         attribute_keep=("cgsecstruct", "chain", "secstruct", "stash"),
         attribute_must=("resname",),
-        attribute_stash=("resid",),
     ).run_system(system)
     LOGGER.info("Averaging the coordinates.", type="step")
     vermouth.DoAverageBead(ignore_missing_graphs=True).run_system(system)

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -1129,7 +1129,7 @@ def entry():
     # Here we need to add the resids from the PDB back if that is needed
     if args.resid_handling == "input":
         for molecule in system.molecules:
-            old_resids = nx.get_node_attributes(molecule, "_old_resid")
+            old_resids = {node: molecule.nodes[node]["stash"].get("resid") for node in molecule.nodes}
             nx.set_node_attributes(molecule, old_resids, "resid")
 
     # The Martini Go model assumes that we do not mess with the order of

--- a/vermouth/processors/__init__.py
+++ b/vermouth/processors/__init__.py
@@ -46,3 +46,4 @@ from .annotate_mut_mod import AnnotateMutMod
 from .water_bias import ComputeWaterBias
 from .annotate_idrs import AnnotateIDRs
 from .cif_reader import CIFInput
+from .stash_attributes import StashAttributes

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -39,7 +39,7 @@ def annotate_disorder(molecule, id_regions, annotation="cgidr"):
     """
 
     for key, node in molecule.nodes.items():
-        _old_resid = node['_old_resid']
+        _old_resid = node['stash']['resid']
         if _in_resid_region(_old_resid, id_regions):
             molecule.nodes[key][annotation] = True
             if "cgsecstruct" in molecule.nodes[key] and molecule.nodes[key]["cgsecstruct"] != "C":

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -391,12 +391,12 @@ def same_chain(graph, left, right):
 
 def make_same_region_criterion(regions):
     """
-    Returns ``True`` is the nodes are part of the same region.
+    Returns ``True`` if the nodes are part of the same region.
 
     Nodes are considered part of the same region if their value
     under the "resid" attribute are within the same residue range.
-    By default the resids of the input file are used (i.e. "_old_resid"
-    attribute).
+    By default the resids of the input file are used from the
+    stashed value
 
     Parameters
     ----------
@@ -420,8 +420,11 @@ def make_same_region_criterion(regions):
     def same_region(graph, left, right):
         node_left = graph.nodes[left]
         node_right = graph.nodes[right]
-        left_resid = node_left.get('_old_resid', node_left['resid'])
-        right_resid = node_right.get('_old_resid', node_right['resid'])
+        left_resid = node_left.get('stash', node_left['resid'])
+        right_resid = node_right.get('stash', node_right['resid'])
+        if isinstance(left_resid, dict) and isinstance(right_resid, dict):
+            left_resid = left_resid['resid']
+            right_resid = right_resid['resid']
         for region in regions:
             lower = min(region)
             upper = max(region)

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -420,11 +420,14 @@ def make_same_region_criterion(regions):
     def same_region(graph, left, right):
         node_left = graph.nodes[left]
         node_right = graph.nodes[right]
-        left_resid = node_left.get('stash', node_left['resid'])
-        right_resid = node_right.get('stash', node_right['resid'])
-        if isinstance(left_resid, dict) and isinstance(right_resid, dict):
-            left_resid = left_resid['resid']
-            right_resid = right_resid['resid']
+        try:
+            left_resid = node_left['stash']['resid']
+        except KeyError:
+            left_resid = node_left['resid']
+        try:
+            right_resid = node_right['stash']['resid']
+        except KeyError:
+            right_resid = node_right['resid']
         for region in regions:
             lower = min(region)
             upper = max(region)

--- a/vermouth/processors/do_mapping.py
+++ b/vermouth/processors/do_mapping.py
@@ -511,7 +511,7 @@ def attrs_from_node(node, attrs):
     return {attr: val for attr, val in node.items() if attr in attrs}
 
 
-def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), attribute_stash=()):
+def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=()):
     """
     Creates a new :class:`~vermouth.molecule.Molecule` in force field `to_ff`
     from `molecule`, based on `mappings`. It does this by doing a subgraph
@@ -539,11 +539,6 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
         The attributes that the nodes in the output graph *must* have. If
         they're not provided by the mappings/blocks they're taken from
         `molecule`.
-    attribute_stash: tuple[str]
-        The attributes that will always be transferred from the input molecule
-        to the produced graph, but prefixed with _old_.Thus they are new attributes
-        and are not conflicting with already defined attributes.
-
 
     Returns
     -------
@@ -553,7 +548,6 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
     """
     attribute_keep = tuple(attribute_keep)
     attribute_must = tuple(attribute_must)
-    attribute_stash = tuple(attribute_stash)
     # Transferring the meta maybe should be a copy, or a deep copy...
     # If it breaks we look at this line.
     graph_out = Molecule(force_field=to_ff, meta=molecule.meta)
@@ -641,20 +635,18 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
         if out_idx in all_references:
             ref_idx = all_references[out_idx]
             new_attrs = attrs_from_node(molecule.nodes[ref_idx],
-                                        attribute_keep+attribute_must+attribute_stash)
+                                        attribute_keep+attribute_must)
             for attr, val in new_attrs.items():
                 # Attrs in attribute_keep we always transfer, those in
                 # attribute_must we transfer only if they're not already in the
                 # created node
                 if attr in attribute_keep or attr not in graph_out.nodes[out_idx]:
                     graph_out.nodes[out_idx].update(new_attrs)
-                if attr in attribute_stash:
-                    graph_out.nodes[out_idx]["_old_"+attr] = val
         else:
             attrs = defaultdict(list)
             for mol_idx in mol_idxs:
                 new_attrs = attrs_from_node(molecule.nodes[mol_idx],
-                                            attribute_keep+attribute_must+attribute_stash)
+                                            attribute_keep+attribute_must)
                 for attr, val in new_attrs.items():
                     attrs[attr].append(val)
             attrs_not_sane = []
@@ -665,12 +657,6 @@ def do_mapping(molecule, mappings, to_ff, attribute_keep=(), attribute_must=(), 
                     else:
                         # No nodes hat the attribute.
                         graph_out.nodes[out_idx][attr] = None
-                if attr in attribute_stash:
-                    if vals:
-                        graph_out.nodes[out_idx]["_old_"+attr] = vals[0]
-                    else:
-                        # No nodes hat the attribute.
-                        graph_out.nodes[out_idx]["_old_"+attr] = None
 
                 if not are_all_equal(vals):
                     attrs_not_sane.append(attr)
@@ -800,23 +786,18 @@ class DoMapping(Processor):
         The attributes that the nodes in the output graph *must* have. If
         they're not provided by the mappings/blocks they're taken from
         the original molecule.
-    attribute_stash: tuple[str]
-        The attributes that will always be transferred from the input molecule
-        to the produced graph, but prefixed with _old_.Thus they are new attributes
-        and are not conflicting with already defined attributes.
 
     See Also
     --------
     :func:`do_mapping`
     """
     def __init__(self, mappings, to_ff, delete_unknown=False, attribute_keep=(),
-                 attribute_must=(), attribute_stash=()):
+                 attribute_must=()):
         self.mappings = mappings
         self.to_ff = to_ff
         self.delete_unknown = delete_unknown
         self.attribute_keep = tuple(attribute_keep)
         self.attribute_must = tuple(attribute_must)
-        self.attribute_stash = tuple(attribute_stash)
         super().__init__()
 
     def run_molecule(self, molecule):
@@ -826,7 +807,6 @@ class DoMapping(Processor):
             to_ff=self.to_ff,
             attribute_keep=self.attribute_keep,
             attribute_must=self.attribute_must,
-            attribute_stash=self.attribute_stash
         )
 
     def run_system(self, system):

--- a/vermouth/processors/stash_attributes.py
+++ b/vermouth/processors/stash_attributes.py
@@ -40,13 +40,13 @@ def stash_attributes(molecule, attributes, stash_name="stash"):
     for node in molecule.nodes:
         for attr in attributes:
             # create the stash if not already there
-            stash = molecule.nodes[node].get(stash_name)
+            stash = molecule.nodes[node].get(stash_name, {})
             molecule.nodes[node][stash_name] = stash
             # stash the attribute if it hasn't already been. Otherwise raise warning.
             if attr not in stash:
                 stash[attr] = copy.deepcopy(molecule.nodes[node].get(attr, None))
             else:
-                LOGGER.warning("Trying to stash already stashed attribute {attr} to molecule. Will not stash.", attr)
+                LOGGER.warning(f"Trying to stash already stashed attribute {attr} to molecule. Will not stash.", attr)
 
 
 class StashAttributes(Processor):

--- a/vermouth/processors/stash_attributes.py
+++ b/vermouth/processors/stash_attributes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2018 University of Groningen
+# Copyright 2025 University of Groningen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@ Provides a processor that stores attributes
 """
 
 from .processor import Processor
+from ..log_helpers import StyleAdapter, get_logger
+
+LOGGER = StyleAdapter(get_logger(__name__))
+
 
 def stash_attributes(molecule, attributes):
     """
@@ -29,7 +33,11 @@ def stash_attributes(molecule, attributes):
             # create the stash if not already there
             if not molecule.nodes[node].get("stash"):
                 molecule.nodes[node]["stash"] = {}
-            molecule.nodes[node]["stash"][attr] = molecule.nodes[node].get(attr, None)
+            # stash the attribute if it hasn't already been. Otherwise raise warning.
+            if not molecule.nodes[node]["stash"].get(attr):
+                molecule.nodes[node]["stash"][attr] = molecule.nodes[node].get(attr, None)
+            else:
+                LOGGER.warning("Trying to stash an already stashed attribute to molecule. Will not stash.")
 
 
 class StashAttributes(Processor):

--- a/vermouth/processors/stash_attributes.py
+++ b/vermouth/processors/stash_attributes.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2018 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Provides a processor that stores attributes 
+"""
+
+from .processor import Processor
+
+def stash_attributes(molecule, attributes):
+    """
+    For each node in molecule, add the attributes to a stash dictionary
+    """
+    for attr in attributes:
+        for node in molecule.nodes:
+            # create the stash if not already there
+            if not molecule.nodes[node].get("stash"):
+                molecule.nodes[node]["stash"] = {}
+            molecule.nodes[node]["stash"][attr] = molecule.nodes[node].get(attr, None)
+
+
+class StashAttributes(Processor):
+    """
+    Processor for storing current attributes of a node in a new "stash" attribute
+
+    """
+    def __init__(self, attributes = ()):
+        self.attributes = attributes
+
+    def run_molecule(self, molecule):
+        stash_attributes(
+            molecule,
+            self.attributes
+        )
+        return molecule
+
+    def run_system(self, system):
+        super().run_system(system)

--- a/vermouth/processors/stash_attributes.py
+++ b/vermouth/processors/stash_attributes.py
@@ -27,6 +27,13 @@ LOGGER = StyleAdapter(get_logger(__name__))
 def stash_attributes(molecule, attributes):
     """
     For each node in molecule, add the attributes to a stash dictionary
+
+    Parameters
+    ----------
+    molecule: :class:`~vermouth.molecule.Molecule`
+        The molecule to transform.
+    attributes: tuple[str]
+        Attributes to store in the nodes that may otherwise be modified
     """
     for attr in attributes:
         for node in molecule.nodes:
@@ -44,6 +51,8 @@ class StashAttributes(Processor):
     """
     Processor for storing current attributes of a node in a new "stash" attribute
 
+    attributes: tuple[str]
+        Attributes to be stashed for later use.
     """
     def __init__(self, attributes = ()):
         self.attributes = attributes

--- a/vermouth/processors/stash_attributes.py
+++ b/vermouth/processors/stash_attributes.py
@@ -46,7 +46,7 @@ def stash_attributes(molecule, attributes, stash_name="stash"):
             if attr not in stash:
                 stash[attr] = copy.deepcopy(molecule.nodes[node].get(attr, None))
             else:
-                LOGGER.warning(f"Trying to stash already stashed attribute {attr} to molecule. Will not stash.", attr)
+                LOGGER.warning("Trying to stash already stashed attribute {} to molecule. Will not stash.", attr)
 
 
 class StashAttributes(Processor):

--- a/vermouth/processors/water_bias.py
+++ b/vermouth/processors/water_bias.py
@@ -137,7 +137,7 @@ class ComputeWaterBias(Processor):
 
         for res_node in res_graph.nodes:
             resid = res_graph.nodes[res_node]['resid']
-            _old_resid = res_graph.nodes[res_node]['_old_resid']
+            _old_resid = res_graph.nodes[res_node]['stash']['resid']
             chain = res_graph.nodes[res_node]['chain']
 
             if _in_resid_region(_old_resid, self.idr_regions):

--- a/vermouth/processors/water_bias.py
+++ b/vermouth/processors/water_bias.py
@@ -84,7 +84,7 @@ class ComputeWaterBias(Processor):
         """
         for res_node in res_graph.nodes:
             resid = res_graph.nodes[res_node]['resid']
-            _old_resid = res_graph.nodes[res_node]['_old_resid']
+            _old_resid = res_graph.nodes[res_node]['stash']['resid']
             chain = res_graph.nodes[res_node]['chain']
             resname = res_graph.nodes[res_node]['resname']
 

--- a/vermouth/rcsu/contact_map.py
+++ b/vermouth/rcsu/contact_map.py
@@ -644,8 +644,8 @@ def _get_contacts(nresidues, overlaps, contacts, stabilisers, destabilisers, res
             all_contacts.append([i1+1, i2+1, a, b, over, cont, stab, rcsu])
             if over == 1 or (over == 0 and rcsu):
                 # this is a OV or rCSU contact we take it
-                contacts_list.append((int(G.nodes[a]['resid']), G.nodes[a]['chain'],
-                                      int(G.nodes[b]['resid']), G.nodes[b]['chain']))
+                contacts_list.append((int(G.nodes[a]['stash']['resid']), G.nodes[a]['chain'],
+                                      int(G.nodes[b]['stash']['resid']), G.nodes[b]['chain']))
 
     return contacts_list, all_contacts
 
@@ -687,9 +687,9 @@ def _write_contacts(fout, all_contacts, ca_pos, G):
         count += 1
         msg = (f"R {int(count):6d} "
                f"{int(contact[0]):5d}  {G.nodes[contact[2]]['resname']:3s} "
-               f"{G.nodes[contact[2]]['chain']:1s} {int(G.nodes[contact[2]]['resid']):4d}    "
+               f"{G.nodes[contact[2]]['chain']:1s} {int(G.nodes[contact[2]]['stash']['resid']):4d}    "
                f"{int(contact[1]):5d}  {G.nodes[contact[3]]['resname']:3s} "
-               f"{G.nodes[contact[3]]['chain']:1s} {int(G.nodes[contact[3]]['resid']):4d}    "
+               f"{G.nodes[contact[3]]['chain']:1s} {int(G.nodes[contact[3]]['stash']['resid']):4d}    "
                f"{euclidean(ca_pos[contact[2]], ca_pos[contact[3]])*10:9.4f}     "
                f"{int(contact[4]):1d} {1 if contact[5] != 0 else 0} "
                f"{1 if contact[6] != 0 else 0} {1 if contact[7] else 0}"

--- a/vermouth/rcsu/go_structure_bias.py
+++ b/vermouth/rcsu/go_structure_bias.py
@@ -136,9 +136,7 @@ class ComputeStructuralGoBias(Processor):
             for resnode in self.res_graph.nodes:
                 chain_key = self.res_graph.nodes[resnode].get('chain', None)
                 # in vermouth within a molecule all resid are unique
-                # when merging multiple chains we store the old resid
-                # the go model always references the input resid i.e.
-                # the _old_resid
+                # for a merged system the original resid of each node is preserved in the stash
                 resid_key = self.res_graph.nodes[resnode]['stash'].get('resid')
                 self.__chain_id_to_resnode[(chain_key, resid_key)] = resnode
 

--- a/vermouth/rcsu/go_structure_bias.py
+++ b/vermouth/rcsu/go_structure_bias.py
@@ -128,23 +128,24 @@ class ComputeStructuralGoBias(Processor):
                 return self.__chain_id_to_resnode[(chain, resid)]
             else:
                 LOGGER.debug(stacklevel=5, msg='chain-resid pair not found in molecule')
-
-        # for each residue collect the chain and residue in a dict
-        # we use this later for identifying the residues from the
-        # contact map
-        for resnode in self.res_graph.nodes:
-            chain_key = self.res_graph.nodes[resnode].get('chain', None)
-            # in vermouth within a molecule all resid are unique
-            # when merging multiple chains we store the old resid
-            # the go model always references the input resid i.e.
-            # the _old_resid
-            resid_key = self.res_graph.nodes[resnode].get('_old_resid')
-            self.__chain_id_to_resnode[(chain_key, resid_key)] = resnode
-
-        if self.__chain_id_to_resnode.get((chain, resid), None) is not None:
-            return self.__chain_id_to_resnode[(chain, resid)]
+        # make sure we only generate self.__chain_id_to_resnode only once
         else:
-            LOGGER.debug(stacklevel=5, msg='chain-resid pair not found in molecule')
+            # for each residue collect the chain and residue in a dict
+            # we use this later for identifying the residues from the
+            # contact map
+            for resnode in self.res_graph.nodes:
+                chain_key = self.res_graph.nodes[resnode].get('chain', None)
+                # in vermouth within a molecule all resid are unique
+                # when merging multiple chains we store the old resid
+                # the go model always references the input resid i.e.
+                # the _old_resid
+                resid_key = self.res_graph.nodes[resnode]['stash'].get('resid')
+                self.__chain_id_to_resnode[(chain_key, resid_key)] = resnode
+
+            if self.__chain_id_to_resnode.get((chain, resid), None) is not None:
+                return self.__chain_id_to_resnode[(chain, resid)]
+            else:
+                LOGGER.debug(stacklevel=5, msg='chain-resid pair not found in molecule')
 
 
     def contact_selector(self, molecule):
@@ -206,11 +207,11 @@ class ComputeStructuralGoBias(Processor):
                     # cut-off criteria
                     if self.cutoff_long > dist > self.cutoff_short:
                         atype_a = next(get_go_type_from_attributes(self.res_graph.nodes[resA]['graph'],
-                                                                   _old_resid=resIDA,
+                                                                   stash=self.res_graph.nodes[resA]['stash'],
                                                                    chain=chainA,
                                                                    prefix=self.moltype))
                         atype_b = next(get_go_type_from_attributes(self.res_graph.nodes[resB]['graph'],
-                                                                   _old_resid=resIDB,
+                                                                   stash=self.res_graph.nodes[resB]['stash'],
                                                                    chain=chainB,
                                                                    prefix=self.moltype))
                         # Check if symmetric contact has already been processed before

--- a/vermouth/rcsu/go_structure_bias.py
+++ b/vermouth/rcsu/go_structure_bias.py
@@ -140,7 +140,7 @@ class ComputeStructuralGoBias(Processor):
                 resid_key = self.res_graph.nodes[resnode]['stash'].get('resid')
                 self.__chain_id_to_resnode[(chain_key, resid_key)] = resnode
 
-            if self.__chain_id_to_resnode.get((chain, resid), None) is not None:
+            if (chain, resid) in self.__chain_id_to_resnode:
                 return self.__chain_id_to_resnode[(chain, resid)]
             else:
                 LOGGER.debug(stacklevel=5, msg='chain-resid pair not found in molecule')

--- a/vermouth/rcsu/go_vs_includes.py
+++ b/vermouth/rcsu/go_vs_includes.py
@@ -113,7 +113,6 @@ class VirtualSiteCreator(Processor):
 
                 virtual_site_nodes.append((new_node_id, {
                     'resid': atom['resid'],
-                    '_old_resid': atom['_old_resid'],
                     'resname': atom['resname'],
                     'atype': '{}_{}'.format(prefix, atom['resid']),
                     'charge_group': new_charge_group,

--- a/vermouth/rcsu/go_vs_includes.py
+++ b/vermouth/rcsu/go_vs_includes.py
@@ -123,6 +123,7 @@ class VirtualSiteCreator(Processor):
                     'charge': charge,
                     'mass': 0.0,
                     'cgsecstruct': atom.get('cgsecstruct', None),
+                    'stash': atom.get('stash', None)
                 }))
                 virtual_sites.append(Interaction(
                     atoms=[new_node_id, node_id],

--- a/vermouth/tests/helper_functions.py
+++ b/vermouth/tests/helper_functions.py
@@ -193,34 +193,34 @@ def test_molecule(scope='function'):
     # due to the keys being accidentally sorted.
     molecule.add_node(2, atomname='SC2', resname='res0', chain='A',
                       position=np.array([0., 1.0, 0.0]), resid=1,
-                      _res_serial=0)
+                      _res_serial=0, stash={'resid': 1})
     molecule.add_node(0, atomname='BB', resname='res0', chain='A',
                       position=np.array([0., 0., 0.]), resid=1,
-                      _res_serial=0)
+                      _res_serial=0, stash={'resid': 1})
     molecule.add_node(1, atomname='SC1', resname='res0', chain='A',
                       position=np.array([0., 0.5, 0.0]), resid=1,
-                      _res_serial=0)
+                      _res_serial=0, stash={'resid': 1})
 
     molecule.add_node(3, atomname='BB', resname='res1', chain='A',
                       position=np.array([0.5, 0.0, 0.0]), resid=2,
-                      _res_serial=1)
+                      _res_serial=1, stash={'resid': 2})
     molecule.add_node(4, atomname='SC1', resname='res1', chain='A',
                       position=np.array([0.5, 0.5, 0.0]), resid=2,
-                      _res_serial=1)
+                      _res_serial=1, stash={'resid': 2})
 
     molecule.add_node(5, atomname='BB', resname='res2', chain='A',
                       position=np.array([1.0, 0.0, 0.0]), resid=3,
-                      _res_serial=2)
+                      _res_serial=2, stash={'resid': 3})
 
     molecule.add_node(6, atomname='BB', resname='res0', chain='A',
                       position=np.array([1.5, 0.0, 0.0]), resid=4,
-                      _res_serial=3)
+                      _res_serial=3, stash={'resid': 4})
     molecule.add_node(7, atomname='SC1', resname='res0', chain='A',
                       position=np.array([1.5, 0.5, 0.0]), resid=4,
-                      _res_serial=3)
+                      _res_serial=3, stash={'resid': 4})
     molecule.add_node(8, atomname='SC2', resname='res0', chain='A',
                       position=np.array([1.5, 1.0, 0.0]), resid=4,
-                      _res_serial=3)
+                      _res_serial=3, stash={'resid': 4})
 
     molecule.add_edge(0, 1)
     molecule.add_edge(0, 2)

--- a/vermouth/tests/test_do_mapping.py
+++ b/vermouth/tests/test_do_mapping.py
@@ -245,8 +245,7 @@ def test_peptide():
             peptide.nodes[node]['resid'] = 5
 
     # make sure the old resids with the gap are stashed
-    cg = do_mapping(peptide, mappings, FF_MARTINI, attribute_keep=('chain',),
-                    attribute_stash=('resid',))
+    cg = do_mapping(peptide, mappings, FF_MARTINI, attribute_keep=('chain',))
 
     expected = Molecule(force_field=FF_MARTINI)
     expected.add_nodes_from({1: {'atomname': 'BB',
@@ -255,7 +254,6 @@ def test_peptide():
                                  'charge': 0.0,
                                  'charge_group': 1,
                                  'resid': 1,
-                                 '_old_resid': 1,
                                  'resname': 'GLY'},
                              2: {'atomname': 'BB',
                                  'atype': 'P5',
@@ -263,7 +261,6 @@ def test_peptide():
                                  'charge': 0.0,
                                  'charge_group': 2,
                                  'resid': 2,
-                                 '_old_resid': 5,
                                  'resname': 'ILE'},
                              3: {'atomname': 'SC1',
                                  'atype': 'AC1',
@@ -271,7 +268,6 @@ def test_peptide():
                                  'charge': 0.0,
                                  'charge_group': 3,
                                  'resid': 2,
-                                 '_old_resid': 5,
                                  'resname': 'ILE'},
                              4: {'atomname': 'BB',
                                  'atype': 'P5',
@@ -279,7 +275,6 @@ def test_peptide():
                                  'charge': 0.0,
                                  'charge_group': 4,
                                  'resid': 3,
-                                 '_old_resid': 3,
                                  'resname': 'LEU'},
                              5: {'atomname': 'SC1',
                                  'atype': 'AC1',
@@ -287,7 +282,6 @@ def test_peptide():
                                  'charge': 0.0,
                                  'charge_group': 5,
                                  'resid': 3,
-                                 '_old_resid': 3,
                                  'resname': 'LEU'}}.items()
                             )
     expected.add_edges_from([(1, 2), (2, 3), (2, 4), (4, 5)])

--- a/vermouth/tests/test_stash_attributes.py
+++ b/vermouth/tests/test_stash_attributes.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 University of Groningen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the StashAttributes processor
+"""
+from pickle import FALSE
+
+import pytest
+from vermouth.tests.datafiles import (
+    FF_UNIVERSAL_TEST,
+)
+from .helper_functions import create_sys_all_attrs
+from vermouth.system import System
+from vermouth.molecule import Molecule
+from vermouth.forcefield import ForceField
+from vermouth.processors.stash_attributes import stash_attributes, StashAttributes
+
+
+@pytest.fixture
+def example_mol():
+    mol = Molecule(force_field=ForceField(FF_UNIVERSAL_TEST))
+    nodes = [
+        {'chain': 'A', 'resname': 'GLY', 'resid': 1},  # 0,
+        {'chain': 'A', 'resname': 'GLY', 'resid': 2},  # 1,
+        {'chain': 'A', 'resname': 'GLY', 'resid': 3},  # 2,
+        {'chain': 'A', 'resname': 'PHE', 'resid': 4},  # 3,
+        {'chain': 'B', 'resname': 'GLY', 'resid': 1},  # 4,
+        {'chain': 'B', 'resname': 'GLY', 'resid': 2},  # 5,
+        {'chain': 'B', 'resname': 'GLY', 'resid': 3},  # 6,
+        {'chain': 'B', 'resname': 'PHE', 'resid': 4},  # 7,
+        {'chain': 'A', 'resname': 'CYS', 'resid': 5},  # 8,
+        {'chain': 'C', 'resname': 'not_protein', 'resid': 1}, # 9
+    ]
+    mol.add_nodes_from(enumerate(nodes))
+    mol.add_edges_from([(0, 1), (1, 2), (2, 3), (4, 5), (5, 6), (6, 7), (3, 8)])
+    return mol
+
+@pytest.mark.parametrize('attributes',
+                         (('resid',),
+                          ('resid', 'chain')))
+def test_stash_attributes(example_mol, attributes):
+    stash_attributes(example_mol, attributes)
+
+    for node in example_mol.nodes:
+        assert len(example_mol.nodes[node]['stash']) == len(attributes)
+        for attr in attributes:
+            assert example_mol.nodes[node]['stash'].get(attr) == example_mol.nodes[node].get(attr)
+
+
+@pytest.mark.parametrize('do_twice, expected',
+                         ((False, False),
+                          (True, True)
+                          ))
+def test_already_stored(example_mol, caplog, do_twice, expected):
+    stash_attributes(example_mol, ('resid',))
+
+    if do_twice:
+        stash_attributes(example_mol, ('resid',))
+
+    assert any([rec.levelname == 'WARNING' for rec in caplog.records]) == expected
+
+def test_StashAttributes(example_mol):
+
+    system = System()
+    system.molecules.append(example_mol)
+
+    processor = StashAttributes(attributes=('resid',))
+    processor.run_system(system)
+
+    for molecule in system.molecules:
+        for node in molecule.nodes:
+            assert molecule.nodes[node]['stash']['resid'] == molecule.nodes[node]['resid']
+


### PR DESCRIPTION
mainly to fix issues with the Go pipeline, add an attribute stash processor that stores things that shouldn't change.

Currently the Go pipeline fails for reading in contact maps for multichain proteins, because of the `MergeMolecules` that gets done to the system prior to `martinize()`, which means the resids of the input nodes are lost (#694). This PR changes the resids used to identify go contacts proper to the stashed ones, regardless of whether the contacts were found from the internal processor or an external file.

While this is just being used to sort out the Go processor, stashed attributes could also be used in other parts of the martinize pipeline