### PR TITLE
Idr annotation fix

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -633,7 +633,7 @@ def entry():
         nargs='+',
         help=("Intrinsically disordered regions specified by resid."
               "These parts are biased differently when applying a water bias."
-              "format: <chain>-<start_resid_1>:<end_resid_1> <chain>-<start_resid_2>:<end_resid_2> ..."
+              "format: [<chain>-]<start_resid_1>:<end_resid_1> [<chain>-]<start_resid_2>:<end_resid_2> ..."
              ),
     )
     idr_tuning = water_group.add_argument(

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -184,7 +184,7 @@ def martinize(system, mappings, to_ff, delete_unknown=False, idrs=False, disorde
     vermouth.DoAverageBead(ignore_missing_graphs=True).run_system(system)
     if idrs:
         LOGGER.info("Annotating IDRs.", type="step")
-        vermouth.AnnotateIDRs(id_regions=[(int(start), int(stop)) for start, stop in disordered_regions]).run_system(system)
+        vermouth.AnnotateIDRs(id_regions=disordered_regions).run_system(system)
     LOGGER.info("Applying the links.", type="step")
     vermouth.DoLinks().run_system(system)
     LOGGER.info("Placing the charge dummies.", type="step")
@@ -629,12 +629,11 @@ def entry():
     water_group.add_argument(
         "-id-regions",
         dest="water_idrs",
-        type=lambda s: s.split(":"),
         default=[],
         nargs='+',
         help=("Intrinsically disordered regions specified by resid."
               "These parts are biased differently when applying a water bias."
-              "format: <start_resid_1>:<end_resid_1> <start_resid_2>:<end_resid_2>..."
+              "format: <chain>-<start_resid_1>:<end_resid_1> <chain>-<start_resid_2>:<end_resid_2> ..."
              ),
     )
     idr_tuning = water_group.add_argument(
@@ -1036,7 +1035,7 @@ def entry():
             # this ensures that disordered-folded go bonds get removed regardless of force field.
             vermouth.processors.ComputeWaterBias(args.water_bias,
                                                  {s: float(eps) for s, eps in args.water_bias_eps},
-                                                 [(int(start), int(stop)) for start, stop in args.water_idrs],
+                                                 args.water_idrs,
                                                 ).run_system(system)
     else:
         # don't write non-bonded interactions
@@ -1122,7 +1121,7 @@ def entry():
         # now we add a bias by defining specific virtual-site water interactions
         vermouth.processors.ComputeWaterBias(args.water_bias,
                                              { s:float(eps) for s, eps in args.water_bias_eps},
-                                             [(int(start), int(stop)) for start, stop in args.water_idrs],
+                                             args.water_idrs,
                                             ).run_system(system)
 
     # Here we need to add the resids from the PDB back if that is needed

--- a/doc/source/tutorials/water_biasing.rst
+++ b/doc/source/tutorials/water_biasing.rst
@@ -3,7 +3,7 @@ Water biasing
 =============
 
 One feature associated with the latest version of the
-`Go model <https://www.biorxiv.org/content/10.1101/2024.04.15.589479v1>`_ is the ability to
+`Go model <https://www.nature.com/articles/s41467-025-58719-0>`_ is the ability to
 bias the non-bonded interactions with water, specified by secondary structure. As the reference
 demonstrates, this may be important in fixing several problems with the current model of proteins,
 including over-compactness of intrinsically disordered regions.
@@ -17,7 +17,7 @@ The documentation describes these features::
                           the idr option (e.g. idr:2.1) intrinsically disordered regions are biased seperately. (default: [])
     -id-regions WATER_IDRS [WATER_IDRS ...]
                           Intrinsically disordered regions specified by resid.These parts are biased differently when applying a water bias.format:
-                          <start_resid_1>:<end_resid_1> <start_resid_2>:<end_resid_2>... (default: [])
+                          <chain>-<start_resid_1>:<end_resid_1> <chain>-<start_resid_2>:<end_resid_2>... (default: [])
     -idr-tune             Tune the idr regions with specific bonded potentials. (default: False)
 
 These flags can be specified in conjunction with the Go model.
@@ -50,21 +50,28 @@ Water biasing for intrinsically disordered regions/proteins
 -----------------------------------------------------------
 
 If you have disordered regions in your protein, then they can have additional bonded and nonbonded
-parameters added (described more in the `Go model paper <https://www.biorxiv.org/content/10.1101/2024.04.15.589479v1>`_).
+parameters added (described more in the `Go model paper <https://www.nature.com/articles/s41467-025-58719-0>`_).
 
 These regions need to firstly be annotated by the user, using the ``-id-regions`` flag to indicate resid segments
 known to be disordered:
 
-``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions 1:10 65:92``
+``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions A-1:10 B-65:92``
 
 Ideally, as the paper describes, these should have their water bias and bonded parameters fixed too.
 This can be done by combining the above command with the ones previously described about water biasing:
 
-``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions 1:10 65:92 -idr-tune -water-bias -water-bias-eps idr:0.5``
+``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions A-1:10 B-65:92 -idr-tune -water-bias -water-bias-eps idr:0.5``
 
 Here, ``-idr-tune`` makes sure that the additional bonded parameters are applied to the region specified by ``-id-regions``,
 while ``-water-bias`` and ``-water-bias-eps idr:0.5`` ensures that for the idr region defined, an additional nonbonded parameter
 with water is written to the nonbond_params.itp file.
+
+For a single chain, or a homomultimer containing identical disordered regions, the chain specifier on the ``-id-regions`` flag is
+not necessary. The command:
+
+``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions 50:75 -idr-tune -water-bias -water-bias-eps idr:0.5``
+
+will apply disordered parameters and biasing to residues 50:75 of all chains in the system.
 
 If you're working extensively with proteins which are fully disordered in Martini, it may be more convenient to
 use `Polyply <https://github.com/marrink-lab/polyply_1.0>`_ to generate the input parameters for your system

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -52,6 +52,8 @@ def parse_residues(resspec):
         out['resids'] = [(int(res_start), int(res_end))]
     if chain:
         out['chain'] = chain[0]
+    else:
+        out['chain'] = None
     return out
 
 def annotate_disorder(molecule, id_regions, annotation="cgidr"):

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -69,8 +69,8 @@ def annotate_disorder(molecule, id_regions, annotation="cgidr"):
         for key, node in molecule.nodes.items():
             _old_resid = node['_old_resid']
             chain = node['chain']
-            # make sure we have the correct chain and are in the right region. If no chain in resspec assume True.
-            if (chain == region.get('chain', True)) and _in_resid_region(_old_resid, region.get('resids')):
+            # make sure we have the correct chain and are in the right region. If no chain in region assume single chain system.
+            if (region.get('chain') is None or region.get('chain') == chain) and _in_resid_region(_old_resid, region.get('resids')):
                 molecule.nodes[key][annotation] = True
                 if "cgsecstruct" in molecule.nodes[key] and molecule.nodes[key]["cgsecstruct"] != "C":
                         molecule.nodes[key]["cgsecstruct"] = "C"

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -21,7 +21,7 @@ from itertools import chain
 from ..dssp.dssp import SS_CG, sequence_from_residues
 from ..selectors import is_protein
 from .processor import Processor
-from ..rcsu.go_utils import _in_resid_region
+from ..rcsu.go_utils import _in_chain_and_resid_region
 from ..log_helpers import StyleAdapter, get_logger
 
 LOGGER = StyleAdapter(get_logger(__name__))
@@ -29,7 +29,7 @@ LOGGER = StyleAdapter(get_logger(__name__))
 
 def parse_residues(resspec):
     """
-    Parse a residue specification: [<chain>-][[#]<resid>]:[[#]<resid>] where
+    Parse a residue specification: [<chain>-][<resid_start>]:[<resid_end>] where
     resid is /[0-9]+/.
     Returns a dictionary with keys 'chain', 'resid_start', and 'resid_end' for the
     fields that are specified. Resids will be ints.
@@ -61,7 +61,7 @@ def annotate_disorder(molecule, id_regions, annotation="cgidr"):
     molecule: :class:`vermouth.molecule.Molecule`
             the molecule
     idr_regions: list
-        list of tuples defining the resids of the idrs in the molecule
+        dictionaries defining the disordered regions to annotate
     annotation: str
         name of the annotation in the node
     """
@@ -70,7 +70,7 @@ def annotate_disorder(molecule, id_regions, annotation="cgidr"):
             _old_resid = node['_old_resid']
             chain = node['chain']
             # make sure we have the correct chain and are in the right region. If no chain in region assume single chain system.
-            if (region.get('chain') is None or region.get('chain') == chain) and _in_resid_region(_old_resid, region.get('resids')):
+            if _in_chain_and_resid_region(region, _old_resid, chain):
                 molecule.nodes[key][annotation] = True
                 if "cgsecstruct" in molecule.nodes[key] and molecule.nodes[key]["cgsecstruct"] != "C":
                         molecule.nodes[key]["cgsecstruct"] = "C"

--- a/vermouth/rcsu/go_utils.py
+++ b/vermouth/rcsu/go_utils.py
@@ -79,3 +79,29 @@ def _get_bead_size(atype):
     else:
         bead_size = "regular"
     return bead_size
+
+def _in_chain_and_resid_region(region, resid, chain):
+    """
+    Check if a chain and resid match
+
+    Parameters
+    ----------
+    region: dict
+        dictionary containing chain and resids of annotated region
+    resid: int
+        resid of residue
+    chain: str
+        chain of residue
+
+    Returns
+    -------
+    bool
+    """
+    condition0 = (region.get('chain') is None or region.get('chain') == chain)
+    condition1 = _in_resid_region(resid, region.get('resids'))
+
+    if condition0 and condition1:
+        return True
+    else:
+        return False
+

--- a/vermouth/rcsu/go_utils.py
+++ b/vermouth/rcsu/go_utils.py
@@ -100,8 +100,5 @@ def _in_chain_and_resid_region(region, resid, chain):
     condition0 = (region.get('chain') is None or region.get('chain') == chain)
     condition1 = _in_resid_region(resid, region.get('resids'))
 
-    if condition0 and condition1:
-        return True
-    else:
-        return False
+    return condition0 and condition1
 

--- a/vermouth/tests/rcsu/test_go_utils.py
+++ b/vermouth/tests/rcsu/test_go_utils.py
@@ -19,7 +19,7 @@ Unit tests for the Go contact map reader.
 import pytest
 import hypothesis
 import hypothesis.strategies as st
-from vermouth.rcsu.go_utils import _get_bead_size, _in_resid_region, get_go_type_from_attributes
+from vermouth.rcsu.go_utils import _get_bead_size, _in_resid_region, get_go_type_from_attributes, _in_chain_and_resid_region
 from vermouth.tests.molecule_strategies import random_molecule
 
 @pytest.mark.parametrize('atype, size', (
@@ -56,3 +56,20 @@ def test_get_go_type_from_attributes(mol):
     mol.add_node(vs_node, atype="prefix_0", chain="A", resid=5)
     found_atype = next(get_go_type_from_attributes(mol, prefix="prefix", chain="A", resid=5))
     assert found_atype == "prefix_0"
+
+@pytest.mark.parametrize('regions, resid, chain, result', (
+        # single region true
+        ({'chain': "A", 'resids': [(101, 120)]}, 115, 'A', True),
+        # single region false resid
+        ({'chain': "A", 'resids': [(101, 120)]}, 125, 'A', False),
+        # single region false chain
+        ({'chain': "A", 'resids': [(101, 120)]}, 115, 'B', False),
+        # two regions true
+        ({'chain': "A", 'resids': [(101, 120), (130, 150)]}, 115, 'A', True),
+        # two regions false chain
+        ({'chain': "A", 'resids': [(101, 120), (130, 150)]}, 115, 'B', False),
+        # two regions false resid
+        ({'chain': "A", 'resids': [(101, 120), (130, 150)]}, 125, 'A', False)
+))
+def test_in_chain_and_resid_region(regions, resid, chain, result):
+    assert result == _in_chain_and_resid_region(regions, resid, chain)

--- a/vermouth/tests/test_annotate_idrs.py
+++ b/vermouth/tests/test_annotate_idrs.py
@@ -22,7 +22,7 @@ from vermouth.tests.helper_functions import create_sys_all_attrs, test_molecule
 
 @pytest.mark.parametrize('idr_regions, expected', [
     (
-    [(1,2)],
+    ["1:2"],
     [True, True, True, True, True, False, False, False, False]
     ),
     (
@@ -61,28 +61,28 @@ def test_make_disorder_string(test_molecule,
     assert result == expected
 
 @pytest.mark.parametrize('idr_regions, secstruc, write_sec, expected',(
-        ([(1, 4)],
+        (["1:4"],
          {1: "H", 2: "H", 3: "H", 4: "H"},
          True,
          [{0: "C", 1: "C", 2: "C",
           3: "C", 4: "C",
           5: "C",
           6: "C", 7: "C", 8: "C"}, True]),
-        ([(1, 2)],
+        (["1:2"],
          {1: "H", 2: "H", 3: "H", 4: "H"},
          True,
          [{0: "C", 1: "C", 2: "C",
           3: "C", 4: "C",
           5: "H",
           6: "H", 7: "H", 8: "H"}, True]),
-        ([(1, 2)],
+        (["1:2"],
          {1: "H", 2: "H", 3: "H", 4: "H"},
          False,
          [{0: None, 1: None, 2: None,
           3: None, 4: None,
           5: None,
           6: None, 7: None, 8: None}, False]),
-        ([(1, 2)],
+        (["1:2"],
          {1: "C", 2: "C", 3: "C", 4: "C"},
          True,
          [{0: "C", 1: "C", 2: "C",
@@ -139,7 +139,7 @@ def test_gmx_system_header_supplementary(test_molecule, modify, expected):
                                   attrs={"resname": resnames,
                                          "atype": atypes})
     if modify:
-        AnnotateIDRs(id_regions=[(0,1)]).run_system(system)
+        AnnotateIDRs(id_regions=["1:2"]).run_system(system)
 
     dssp.AnnotateResidues(attribute="aasecstruct",
                           sequence="HHHH").run_system(system)

--- a/vermouth/tests/test_annotate_idrs.py
+++ b/vermouth/tests/test_annotate_idrs.py
@@ -17,7 +17,7 @@ Test for the tune idp bonds processor.
 """
 import pytest
 from vermouth.dssp import dssp
-from vermouth.processors.annotate_idrs import AnnotateIDRs
+from vermouth.processors.annotate_idrs import AnnotateIDRs, parse_residues
 from vermouth.tests.helper_functions import create_sys_all_attrs, test_molecule
 
 @pytest.mark.parametrize('idr_regions, expected', [
@@ -146,3 +146,23 @@ def test_gmx_system_header_supplementary(test_molecule, modify, expected):
     dssp.AnnotateMartiniSecondaryStructures().run_system(system)
 
     assert expected == any(["IDR" in i for i in system.meta.get('header', [''])])
+
+@pytest.mark.parametrize('resspec, expected',
+                         ((['A-10:20'],
+                           [{'chain': 'A', 'resids': [(10, 20)]}]),
+                          (['10:20'],
+                           [{'chain': None, 'resids': [(10, 20)]}]),
+                         (['10:20', 'A-50:65'],
+                          [{'chain': None, 'resids': [(10, 20)]}, {'chain': 'A', 'resids': [(50, 65)]}])
+
+                          ))
+def test_parse_disorder_resspec(resspec, expected):
+    parsed = []
+    for spec in resspec:
+        parsed.append(parse_residues(spec))
+    assert len(parsed) == len(expected)
+
+    for i,j in zip(parsed, expected):
+        for key in i.keys():
+            assert i[key] == j[key]
+

--- a/vermouth/tests/test_water_bias.py
+++ b/vermouth/tests/test_water_bias.py
@@ -45,17 +45,17 @@ from vermouth.gmx.topology import NonbondParam
         # only idp bias
         ({1: "H", 2: "H", 3: "C", 4: "C"},
         {"idr": 2.1},
-        [(2, 3)],
+        ["2:3"],
         {3: "idr", 5: "idr"}
         ),
         # idp and sec struc bias
         ({1: "H", 2: "H", 3: "C", 4: "C"},
         {"idr": 1.1, "C": 3.1, "H": 2.1},
-        [(2, 3)],
+        ["2:3"],
         {0: "H", 3: "idr", 5: "idr", 6: "C"}
         )
         ))
-def test_assign_residue_water_bias(test_molecule, 
+def test_assign_residue_water_bias(test_molecule,
                                    secstruc,
                                    water_bias,
                                    idr_regions,
@@ -65,12 +65,12 @@ def test_assign_residue_water_bias(test_molecule,
     # the molecule atomtypes
     atypes = {0: "P1", 1: "SN4a", 2: "SN4a",
               3: "SP1", 4: "C1",
-              5: "TP1", 
+              5: "TP1",
               6: "P1", 7: "SN3a", 8: "SP4"}
     # the molecule resnames
     resnames = {0: "A", 1: "A", 2: "A",
                 3: "B", 4: "B",
-                5: "C", 
+                5: "C",
                 6: "D", 7: "D", 8: "D"}
 
     system = create_sys_all_attrs(test_molecule,
@@ -109,12 +109,12 @@ def test_assign_residue_water_bias(test_molecule,
              [[1, 3], [2, 4]]
             ),
             (#central idr to remove bonds from
-             [(2, 3)],
+             ["2:3"],
              [[1, 3], [2, 4], [1, 4]],
              [[1, 4]]
             ),
             (#remove all bonds within a region
-            [(1, 4)],
+            ["1:4"],
             [[1, 2], [2, 3], [3, 4], [1, 4]],
             []
             )
@@ -183,7 +183,7 @@ def test_no_moltype_error(test_molecule):
     # set up processor
     processor = ComputeWaterBias(water_bias={"C": 3.1},
                                  auto_bias=True,
-                                 idr_regions=None)
+                                 idr_regions=[])
     # no moltype set
     system = vermouth.System()
     system.add_molecule(test_molecule)
@@ -198,7 +198,7 @@ def test_no_system_error(test_molecule):
     # set up processor
     processor = ComputeWaterBias(water_bias={"C": 3.1},
                                  auto_bias=True,
-                                 idr_regions=None)
+                                 idr_regions=[])
     test_molecule.meta['moltype'] = "random"
     # no system
     with pytest.raises(IOError):
@@ -208,7 +208,7 @@ def test_clean_return(test_molecule):
     # set up processor
     processor = ComputeWaterBias(water_bias={"C": 3.1},
                                  auto_bias=None,
-                                 idr_regions=None)
+                                 idr_regions=[])
     test_molecule.meta['moltype'] = "random"
     system = vermouth.System()
     system.add_molecule(test_molecule)


### PR DESCRIPTION
Currently the `-id-regions` flag only accepts resid regions, with no chain specifier. This PR fixes that by slightly changing the input to be more like the modifications style, `<chain>-<resid_start>:<resid_end>`.