### PR TITLE
Add molecule sorting function to pdb_to_universal

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -164,6 +164,7 @@ def pdb_to_universal(
             defer_writing=False,
         )
     vermouth.AttachMass(attribute="mass").run_system(canonicalized)
+    vermouth.SortMoleculeAtoms().run_system(canonicalized)
     return canonicalized
 
 


### PR DESCRIPTION
From a user bug error, some missing links were found by gromacs (atoms unconnected to anything else). Investigation found that this was the result of a scrambling of node order somehow applied by the CanonicalizeModifications processor. I didn't investigate any further cause. Adding the extra processor in the pipeline appears to resolve the issue.