### PR TITLE
remove -idr-tune flag.

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -974,7 +974,7 @@ def entry():
         )
     vermouth.SetMoleculeMeta(scfix=scfix).run_system(system)
 
-    idr_tune = True if any(args.water_idrs) else False
+    idr_tune = any(args.water_idrs)
     vermouth.SetMoleculeMeta(idr=idr_tune).run_system(system)
     if idr_tune:
         if not target_ff.has_feature("idr"):

--- a/bin/martinize2
+++ b/bin/martinize2
@@ -168,7 +168,7 @@ def pdb_to_universal(
     return canonicalized
 
 
-def martinize(system, mappings, to_ff, delete_unknown=False, idrs=False, disordered_regions=None):
+def martinize(system, mappings, to_ff, delete_unknown=False, disordered_regions=None):
     """
     Convert a system from one force field to another at lower resolution.
     """
@@ -182,7 +182,7 @@ def martinize(system, mappings, to_ff, delete_unknown=False, idrs=False, disorde
     ).run_system(system)
     LOGGER.info("Averaging the coordinates.", type="step")
     vermouth.DoAverageBead(ignore_missing_graphs=True).run_system(system)
-    if idrs:
+    if any(disordered_regions):
         LOGGER.info("Annotating IDRs.", type="step")
         vermouth.AnnotateIDRs(id_regions=disordered_regions).run_system(system)
     LOGGER.info("Applying the links.", type="step")
@@ -636,14 +636,6 @@ def entry():
               "format: [<chain>-]<start_resid_1>:<end_resid_1> [<chain>-]<start_resid_2>:<end_resid_2> ..."
              ),
     )
-    idr_tuning = water_group.add_argument(
-        "-idr-tune",
-        dest="idr_tune",
-        action="store_true",
-        default=False,
-        help=("Tune the idr regions with specific bonded potentials."),
-    )
-
 
     prot_group = parser.add_argument_group("Protein description")
     prot_group.add_argument(
@@ -973,8 +965,9 @@ def entry():
         )
     vermouth.SetMoleculeMeta(scfix=scfix).run_system(system)
 
-    vermouth.SetMoleculeMeta(idr=args.idr_tune).run_system(system)
-    if args.idr_tune:
+    idr_tune = True if any(args.water_idrs) else False
+    vermouth.SetMoleculeMeta(idr=idr_tune).run_system(system)
+    if idr_tune:
         if not target_ff.has_feature("idr"):
             LOGGER.warning('Improved IDR potentials are not implemented '
                            'for this force field',
@@ -1003,7 +996,6 @@ def entry():
         mappings=known_mappings,
         to_ff=known_force_fields[args.to_ff],
         delete_unknown=True,
-        idrs=args.idr_tune,
         disordered_regions=args.water_idrs
     )
     if 'bondedtypes' in known_force_fields[args.to_ff].variables:

--- a/doc/source/tutorials/water_biasing.rst
+++ b/doc/source/tutorials/water_biasing.rst
@@ -18,7 +18,6 @@ The documentation describes these features::
     -id-regions WATER_IDRS [WATER_IDRS ...]
                           Intrinsically disordered regions specified by resid.These parts are biased differently when applying a water bias.format:
                           <chain>-<start_resid_1>:<end_resid_1> <chain>-<start_resid_2>:<end_resid_2>... (default: [])
-    -idr-tune             Tune the idr regions with specific bonded potentials. (default: False)
 
 These flags can be specified in conjunction with the Go model.
 
@@ -60,7 +59,7 @@ known to be disordered:
 Ideally, as the paper describes, these should have their water bias and bonded parameters fixed too.
 This can be done by combining the above command with the ones previously described about water biasing:
 
-``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions A-1:10 B-65:92 -idr-tune -water-bias -water-bias-eps idr:0.5``
+``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions A-1:10 B-65:92 -water-bias -water-bias-eps idr:0.5``
 
 Here, ``-idr-tune`` makes sure that the additional bonded parameters are applied to the region specified by ``-id-regions``,
 while ``-water-bias`` and ``-water-bias-eps idr:0.5`` ensures that for the idr region defined, an additional nonbonded parameter
@@ -69,7 +68,7 @@ with water is written to the nonbond_params.itp file.
 For a single chain, or a homomultimer containing identical disordered regions, the chain specifier on the ``-id-regions`` flag is
 not necessary. The command:
 
-``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions 50:75 -idr-tune -water-bias -water-bias-eps idr:0.5``
+``martinize2 -f protein.pdb -o topol.top -x cg_protein.pdb -dssp -id-regions 50:75 -water-bias -water-bias-eps idr:0.5``
 
 will apply disordered parameters and biasing to residues 50:75 of all chains in the system.
 

--- a/vermouth/tests/data/integration_tests/tier-1/hst5/martinize2/command
+++ b/vermouth/tests/data/integration_tests/tier-1/hst5/martinize2/command
@@ -7,5 +7,4 @@ martinize2
 -water-bias
 -water-bias-eps idr:0.5
 -id-regions 1:24
--idr-tune
 -noscfix


### PR DESCRIPTION
If `-id-regions` is given, use id features automatically. This cleans things up a bit and makes sure that a small missing flag doesn't generate wrong parameters. 