### PR TITLE
Add bb_atomname flexibility to elastic network selectors too

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -1109,7 +1109,8 @@ def entry():
                 values=args.rb_selection,
             )
         else:
-            selector = selectors.select_backbone
+            selector = functools.partial(selectors.select_backbone,
+                                         bb_atomname=system.force_field.variables['bb_atomname'])
         rubber_band_processor = vermouth.ApplyRubberBand(
             lower_bound=args.rb_lower_bound,
             upper_bound=args.rb_upper_bound,

--- a/vermouth/data/force_fields/martini30b32/general.ff
+++ b/vermouth/data/force_fields/martini30b32/general.ff
@@ -1,0 +1,16 @@
+; Copyright 2020 University of Groningen
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[ variables ]
+bb_atomname "BB"

--- a/vermouth/data/force_fields/martini30dev/general.ff
+++ b/vermouth/data/force_fields/martini30dev/general.ff
@@ -1,0 +1,16 @@
+; Copyright 2020 University of Groningen
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[ variables ]
+bb_atomname "BB"


### PR DESCRIPTION
in #671 we added flexibility for backbone selection so we could change where the virtual go bead is placed. The equivalent for the elastic network was missed, which we implement here. The extra general.ff file is needed for one of the integration tests