### PR TITLE
Add vebose output to test deploy

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -151,3 +151,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        verbose: true


### PR DESCRIPTION
The deployment to test.pypi.org keeps failing, so let's enable verbose output