### PR TITLE
set default args RB processor from Ff file

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -477,21 +477,21 @@ def entry():
         "-ef",
         dest="rb_force_constant",
         type=float,
-        default=700,
+        default=None,
         help="Elastic bond force constant Fc in kJ/mol/nm^2",
     )
     rb_group.add_argument(
         "-el",
         dest="rb_lower_bound",
         type=float,
-        default=0,
+        default=None,
         help="Elastic bond lower cutoff: F = Fc if rij < lo",
     )
     rb_group.add_argument(
         "-eu",
         dest="rb_upper_bound",
         type=float,
-        default=0.9,
+        default=None,
         help="Elastic bond upper cutoff: F = 0  if rij > up",
     )
     rb_group.add_argument(
@@ -508,21 +508,21 @@ def entry():
         "-ea",
         dest="rb_decay_factor",
         type=float,
-        default=0,
+        default=None,
         help="Elastic bond decay factor a",
     )
     rb_group.add_argument(
         "-ep",
         dest="rb_decay_power",
         type=float,
-        default=1,
+        default=None,
         help="Elastic bond decay power p",
     )
     rb_group.add_argument(
         "-em",
         dest="rb_minimum_force",
         type=float,
-        default=0,
+        default=None,
         help="Remove elastic bonds with force constant lower than this",
     )
     rb_group.add_argument(
@@ -1117,6 +1117,7 @@ def entry():
             selector = functools.partial(selectors.select_backbone,
                                          bb_atomname=system.force_field.variables['bb_atomname'])
         rubber_band_processor = vermouth.ApplyRubberBand(
+            force_field=system.force_field,
             lower_bound=args.rb_lower_bound,
             upper_bound=args.rb_upper_bound,
             decay_factor=args.rb_decay_factor,

--- a/vermouth/processors/apply_rubber_band.py
+++ b/vermouth/processors/apply_rubber_band.py
@@ -15,6 +15,7 @@
 Provides a processor that adds a rubber band elastic network.
 """
 import itertools
+import inspect 
 
 import numpy as np
 import networkx as nx
@@ -27,11 +28,14 @@ from ..log_helpers import StyleAdapter, get_logger
 
 LOGGER = StyleAdapter(get_logger(__name__))
 
-# the bond type of the RB
-DEFAULT_BOND_TYPE = 6
-# the minimum distance between the resids
-# of two beads to have an RB
-DEFAULT_RMD = 2
+DEFAULTS = {"ApplyRubberBand:bond_type": 6,
+            "ApplyRubberBand:res_min_dist": 2,
+            "ApplyRubberBand:minimum_force": 0,
+            "ApplyRubberBand:lower_bound": 0,
+            "ApplyRubberBand:upper_bound": 0.9,
+            "ApplyRubberBand:decay_factor": 0,
+            "ApplyRubberBand:base_constant": 700,
+            "ApplyRubberBand:decay_power": 1,}
 
 def self_distance_matrix(coordinates):
     """
@@ -492,46 +496,32 @@ class ApplyRubberBand(Processor):
     --------
     :func:`apply_rubber_band`
     """
-    def __init__(self, lower_bound, upper_bound, decay_factor, decay_power,
-                 base_constant, minimum_force,
+    def __init__(self,
+                 force_field,
+                 lower_bound=None,
+                 upper_bound=None,
+                 decay_factor=None,
+                 decay_power=None,
+                 base_constant=None,
+                 minimum_force=None,
                  res_min_dist=None,
                  bond_type=None,
                  selector=selectors.select_backbone,
-                 bond_type_variable='elastic_network_bond_type',
-                 res_min_dist_variable='elastic_network_res_min_dist',
                  domain_criterion=always_true):
         super().__init__()
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.decay_factor = decay_factor
-        self.decay_power = decay_power
-        self.base_constant = base_constant
-        self.minimum_force = minimum_force
-        self.bond_type = bond_type
-        self.selector = selector
-        self.bond_type_variable = bond_type_variable
-        self.domain_criterion = domain_criterion
-        self.res_min_dist = res_min_dist
-        self.res_min_dist_variable = res_min_dist_variable
+        # populates the class variables by first checking if they are 
+        # defined as input arguments; if not we check if they are defined
+        # in the force field variables. If neither they are taken from 
+        # the processors defaults
+        for argname in inspect.signature(self.__init__).parameters.keys():
+            value = locals()[argname]
+            if value is None:
+                argkey  = f"ApplyRubberBand:{argname}"
+                value = force_field.variables.get(argkey,
+                                                  DEFAULTS[argkey])
+            setattr(self, argname, value)
 
     def run_molecule(self, molecule):
-        # Choose the bond type. From high to low, the priority order is:
-        # * what is set as an argument to the processor
-        # * what is written in the force field variables
-        #   under the key `self.bond_type_variable`
-        # * the default value set in DEFAULT_BOND_TYPE
-        bond_type = self.bond_type
-        if self.bond_type is None:
-            bond_type = molecule.force_field.variables.get(self.bond_type_variable,
-                                                           DEFAULT_BOND_TYPE)
-
-        # Same procedure for res_min_dist the minimum distance between
-        # the resids of two beads for them to have a RB
-        res_min_dist = self.res_min_dist
-        if self.res_min_dist is None:
-            res_min_dist = molecule.force_field.variables.get(self.res_min_dist_variable,
-                                                              DEFAULT_RMD)
-
         apply_rubber_band(molecule, self.selector,
                           lower_bound=self.lower_bound,
                           upper_bound=self.upper_bound,
@@ -539,7 +529,7 @@ class ApplyRubberBand(Processor):
                           decay_power=self.decay_power,
                           base_constant=self.base_constant,
                           minimum_force=self.minimum_force,
-                          bond_type=bond_type,
+                          bond_type=self.bond_type,
                           domain_criterion=self.domain_criterion,
-                          res_min_dist=res_min_dist)
+                          res_min_dist=self.res_min_dist)
         return molecule


### PR DESCRIPTION
In this PR I've modified the RubberBand processor in a way that it accepts all input arguments from the force field file unless they are specified on the CLI or the defaults dict. This could be a general approach to more flexibility with these definitions. The idea is that the `[variable]` section can be populated with `ProcessorName:Argument value` statements, which get picked up by the processor when it is created. CLI overrides these definitions and defaults are taken from a dict, which could be globally defined or with each processor.  

@Lp0lp requested this feature. 

@pckroon what do you think?