### PR TITLE
Files created with martinize should follow umask

### DIFF
--- a/vermouth/file_writer.py
+++ b/vermouth/file_writer.py
@@ -171,8 +171,17 @@ class DeferredFileWriter(metaclass=Singleton):
                 LOGGER.info('Backing up {} to {}.', final_path, free_path, type='general')
                 shutil.move(str(final_path), str(free_path))
             LOGGER.debug('Writing output to {}.', final_path, type='general')
-            shutil.copyfile(tmp_path, str(final_path))
-            os.remove(tmp_path)
+            try:
+                success = True
+                shutil.copyfile(tmp_path, str(final_path))
+            except Exception as error:
+                success = False
+                LOGGER.exception("An error occurred when moving your output from {tmp_path} to {final_path}: {error}", tmp_path=tmp_path, final_path=final_path, error=error)
+            if success:
+                try:
+                    os.remove(tmp_path)
+                except OSError as error:
+                    LOGGER.warning("An error occurred removing temporary file {tmp_path}: {error}", tmp_path=tmp_path, error=error)
 
     @staticmethod
     def _append_file(tmp_path, final_path, mode='a'):

--- a/vermouth/file_writer.py
+++ b/vermouth/file_writer.py
@@ -150,10 +150,17 @@ class DeferredFileWriter(metaclass=Singleton):
         Existing file destinations will be backed up according to the Gromacs
         scheme.
         """
+        # get a temp path
+        handle, perm_source = tempfile.mkstemp()
+        os.close(handle)
+        os.remove(perm_source)
+        # create an empty file with default permissions based on env
+        open(perm_source, "x").close()
+
         while self.open_files:
             tmp_path, final_path, mode = self.open_files.popleft()
             if 'w' in mode or '+' in mode:  # write
-                self._write_file(tmp_path, final_path)
+                self._write_file(tmp_path, final_path, perm_source)
             elif 'r' in mode:  # read = error
                 raise AssertionError("Files opened with mode 'r' should not be "
                                      "treated special")
@@ -162,7 +169,9 @@ class DeferredFileWriter(metaclass=Singleton):
             else:
                 raise KeyError('Unknown file mode')
 
-    def _write_file(self, tmp_path, final_path):
+        os.remove(perm_source)
+
+    def _write_file(self, tmp_path, final_path, perm_source):
         # There is no way to move a file and make it error if the destination
         # already exists, so use a lock instead.
         with lock:
@@ -172,6 +181,7 @@ class DeferredFileWriter(metaclass=Singleton):
                 shutil.move(str(final_path), str(free_path))
             LOGGER.debug('Writing output to {}.', final_path, type='general')
             shutil.move(tmp_path, str(final_path))
+            shutil.copymode(perm_source, str(final_path))
 
     @staticmethod
     def _append_file(tmp_path, final_path, mode='a'):

--- a/vermouth/file_writer.py
+++ b/vermouth/file_writer.py
@@ -150,17 +150,10 @@ class DeferredFileWriter(metaclass=Singleton):
         Existing file destinations will be backed up according to the Gromacs
         scheme.
         """
-        # get a temp path
-        handle, perm_source = tempfile.mkstemp()
-        os.close(handle)
-        os.remove(perm_source)
-        # create an empty file with default permissions based on env
-        open(perm_source, "x").close()
-
         while self.open_files:
             tmp_path, final_path, mode = self.open_files.popleft()
             if 'w' in mode or '+' in mode:  # write
-                self._write_file(tmp_path, final_path, perm_source)
+                self._write_file(tmp_path, final_path)
             elif 'r' in mode:  # read = error
                 raise AssertionError("Files opened with mode 'r' should not be "
                                      "treated special")
@@ -169,9 +162,7 @@ class DeferredFileWriter(metaclass=Singleton):
             else:
                 raise KeyError('Unknown file mode')
 
-        os.remove(perm_source)
-
-    def _write_file(self, tmp_path, final_path, perm_source):
+    def _write_file(self, tmp_path, final_path):
         # There is no way to move a file and make it error if the destination
         # already exists, so use a lock instead.
         with lock:
@@ -180,8 +171,8 @@ class DeferredFileWriter(metaclass=Singleton):
                 LOGGER.info('Backing up {} to {}.', final_path, free_path, type='general')
                 shutil.move(str(final_path), str(free_path))
             LOGGER.debug('Writing output to {}.', final_path, type='general')
-            shutil.move(tmp_path, str(final_path))
-            shutil.copymode(perm_source, str(final_path))
+            shutil.copyfile(tmp_path, str(final_path))
+            os.remove(tmp_path)
 
     @staticmethod
     def _append_file(tmp_path, final_path, mode='a'):


### PR DESCRIPTION
Make a temporary file using open() to create it with default permissions. Copy permissions for all files from this source.

Based on discussion in #771, fixes #771 and #762
