### PR TITLE
Warning for id-regions

### DIFF
--- a/vermouth/bin/martinize2.py
+++ b/vermouth/bin/martinize2.py
@@ -1026,20 +1026,50 @@ def entry():
         disordered_regions=args.id_regions
     )
 
-    print("DEBUG id_regions:", args.id_regions)
+    # Check that all requested residues to be treated as IDR are actually present in the structure, and warn if not.
     if any(args.id_regions):
-        annotated = any(
-            mol.nodes[n].get("cgidr")
+
+        # Rebuild requested_resids from args.id_regions
+        requested_resids = set()
+        for region in args.id_regions:
+            if ":" in region:
+                a, b = region.split(":")
+                start, end = int(a), int(b)
+            else:
+                start = end = int(region)
+            lo, hi = sorted((start, end))
+            requested_resids.update(range(lo, hi + 1))
+
+        # Collect annotated residues using TRUE PDB numbering
+        annotated_resids = {
+            mol.nodes[n]['stash']['resid']
             for mol in system.molecules
             for n in mol.nodes
-        )
-        if not annotated:
+            if mol.nodes[n].get("cgidr")
+        }
+
+        # Collect ALL PDB residues present in the structure
+        present_resids = {
+            mol.nodes[n]['stash']['resid']
+            for mol in system.molecules
+            for n in mol.nodes
+        }
+        min_pdb = min(present_resids)
+        max_pdb = max(present_resids)
+
+        # Find missing requested residues
+        missing = sorted(requested_resids - annotated_resids)
+
+        if missing:
+            # show only first 10 missing residues
+            missing_preview = missing[:10]
+
             LOGGER.warning(
-                "No residues were annotated as IDR. "
-                "Check that the resids in -id-regions match your input structure.",
+                f"Requested residues in -id-regions do not exist in the input structure. "
+                f"Some missing residues: {missing_preview} ... "
+                f"Please select residues within the PDB range {min_pdb}–{max_pdb}.",
                 type="missing-flag",
             )
-        
 
     if 'bondedtypes' in known_force_fields[args.to_ff].variables:
         LOGGER.info("Generating implicit interactions for RTP force field", type='step')

--- a/vermouth/bin/martinize2.py
+++ b/vermouth/bin/martinize2.py
@@ -1027,21 +1027,37 @@ def entry():
     )
 
     # Check if any residues were annotated as IDR, if IDR regions were specified.
+    # if any(args.id_regions):
+    #     for region in args.id_regions:
+    #         # check if any molecule node was actually annotated
+    #         annotated = any(
+    #             mol.nodes[n].get("idr")
+    #             for mol in system.molecules
+    #             for n in mol.nodes
+    #         )
+    #         if not annotated:
+    #             LOGGER.warning(
+    #                 "No residues were annotated as IDR. "
+    #                 "Check that the resids in -id-regions match your input structure.",
+    #                 type="missing-feature",
+    #             )
+    #             break
+    
+
+
     if any(args.id_regions):
-        for region in args.id_regions:
-            # check if any molecule node was actually annotated
-            annotated = any(
-                mol.nodes[n].get("idr")
-                for mol in system.molecules
-                for n in mol.nodes
+        annotated = any(
+            mol.nodes[n].get("idr")
+            for mol in system.molecules
+            for n in mol.nodes
+        )
+        if not annotated:
+            LOGGER.warning(
+                "No residues were annotated as IDR. "
+                "Check that the resids in -id-regions match your input structure.",
+                type="missing-flag",
             )
-            if not annotated:
-                LOGGER.warning(
-                    "No residues were annotated as IDR. "
-                    "Check that the resids in -id-regions match your input structure.",
-                    type="missing-feature",
-                )
-                break
+        
 
     if 'bondedtypes' in known_force_fields[args.to_ff].variables:
         LOGGER.info("Generating implicit interactions for RTP force field", type='step')

--- a/vermouth/bin/martinize2.py
+++ b/vermouth/bin/martinize2.py
@@ -1047,7 +1047,7 @@ def entry():
 
     if any(args.id_regions):
         annotated = any(
-            mol.nodes[n].get("idr")
+            mol.nodes[n].get("cgidr")
             for mol in system.molecules
             for n in mol.nodes
         )

--- a/vermouth/bin/martinize2.py
+++ b/vermouth/bin/martinize2.py
@@ -1025,6 +1025,24 @@ def entry():
         delete_unknown=True,
         disordered_regions=args.id_regions
     )
+
+    # Check if any residues were annotated as IDR, if IDR regions were specified.
+    if any(args.id_regions):
+        for region in args.id_regions:
+            # check if any molecule node was actually annotated
+            annotated = any(
+                mol.nodes[n].get("idr")
+                for mol in system.molecules
+                for n in mol.nodes
+            )
+            if not annotated:
+                LOGGER.warning(
+                    "No residues were annotated as IDR. "
+                    "Check that the resids in -id-regions match your input structure.",
+                    type="missing-feature",
+                )
+                break
+
     if 'bondedtypes' in known_force_fields[args.to_ff].variables:
         LOGGER.info("Generating implicit interactions for RTP force field", type='step')
         vermouth.RTPPolisher().run_system(system)

--- a/vermouth/bin/martinize2.py
+++ b/vermouth/bin/martinize2.py
@@ -1026,25 +1026,7 @@ def entry():
         disordered_regions=args.id_regions
     )
 
-    # Check if any residues were annotated as IDR, if IDR regions were specified.
-    # if any(args.id_regions):
-    #     for region in args.id_regions:
-    #         # check if any molecule node was actually annotated
-    #         annotated = any(
-    #             mol.nodes[n].get("idr")
-    #             for mol in system.molecules
-    #             for n in mol.nodes
-    #         )
-    #         if not annotated:
-    #             LOGGER.warning(
-    #                 "No residues were annotated as IDR. "
-    #                 "Check that the resids in -id-regions match your input structure.",
-    #                 type="missing-feature",
-    #             )
-    #             break
-    
-
-
+    print("DEBUG id_regions:", args.id_regions)
     if any(args.id_regions):
         annotated = any(
             mol.nodes[n].get("cgidr")

--- a/vermouth/bin/martinize2.py
+++ b/vermouth/bin/martinize2.py
@@ -1025,52 +1025,6 @@ def entry():
         delete_unknown=True,
         disordered_regions=args.id_regions
     )
-
-    # Check that all requested residues to be treated as IDR are actually present in the structure, and warn if not.
-    if any(args.id_regions):
-
-        # Rebuild requested_resids from args.id_regions
-        requested_resids = set()
-        for region in args.id_regions:
-            if ":" in region:
-                a, b = region.split(":")
-                start, end = int(a), int(b)
-            else:
-                start = end = int(region)
-            lo, hi = sorted((start, end))
-            requested_resids.update(range(lo, hi + 1))
-
-        # Collect annotated residues using TRUE PDB numbering
-        annotated_resids = {
-            mol.nodes[n]['stash']['resid']
-            for mol in system.molecules
-            for n in mol.nodes
-            if mol.nodes[n].get("cgidr")
-        }
-
-        # Collect ALL PDB residues present in the structure
-        present_resids = {
-            mol.nodes[n]['stash']['resid']
-            for mol in system.molecules
-            for n in mol.nodes
-        }
-        min_pdb = min(present_resids)
-        max_pdb = max(present_resids)
-
-        # Find missing requested residues
-        missing = sorted(requested_resids - annotated_resids)
-
-        if missing:
-            # show only first 10 missing residues
-            missing_preview = missing[:10]
-
-            LOGGER.warning(
-                f"Requested residues in -id-regions do not exist in the input structure. "
-                f"Some missing residues: {missing_preview} ... "
-                f"Please select residues within the PDB range {min_pdb}–{max_pdb}.",
-                type="missing-flag",
-            )
-
     if 'bondedtypes' in known_force_fields[args.to_ff].variables:
         LOGGER.info("Generating implicit interactions for RTP force field", type='step')
         vermouth.RTPPolisher().run_system(system)

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -138,7 +138,6 @@ def _check_missing_idr_residues(system, id_regions):
             "structure. {} residues are missing. Some missing residues: {} ... "
             "Please select residues within the PDB range {}–{}.",
             len(missing), missing_preview, min_pdb, max_pdb,
-            type="missing-flag",
         )
 
     # Inform the user when a region has no chain specifier, since it will
@@ -190,6 +189,12 @@ class AnnotateIDRs(Processor):
         system: :class:`vermouth.system.System`
         """
         if not self.id_regions:
+            LOGGER.warning(
+                "No IDR regions specified. The -id-regions flag was given "
+                "but no regions were provided, so no residues will be "
+                "annotated as disordered. This means no IDR-specific "
+                "parameters will be applied to the system.",
+            )
             return system
         LOGGER.info("Annotating disordered regions.", type="step")
         super().run_system(system)

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -83,6 +83,55 @@ def annotate_disorder(molecule, id_regions, annotation="cgidr"):
                     molecule.nodes[key][annotation] = False
 
 
+def _check_missing_idr_residues(system, id_regions):
+    """
+    Check that all requested residues to be treated as IDR are actually
+    present in the structure, and warn if not.
+
+    Parameters
+    ----------
+    system: :class:`vermouth.system.System`
+        The system to check.
+    id_regions: list[dict]
+        Parsed IDR regions, as stored in :attr:`AnnotateIDRs.id_regions`.
+    """
+    # Rebuild requested_resids from id_regions
+    requested_resids = set()
+    for region in id_regions:
+        for start, end in region['resids']:
+            lo, hi = sorted((start, end))
+            requested_resids.update(range(lo, hi + 1))
+
+    # Collect annotated residues using TRUE PDB numbering
+    annotated_resids = {
+        mol.nodes[n]['stash']['resid']
+        for mol in system.molecules
+        for n in mol.nodes
+        if mol.nodes[n].get("cgidr")
+    }
+
+    # Collect ALL PDB residues present in the structure
+    present_resids = {
+        mol.nodes[n]['stash']['resid']
+        for mol in system.molecules
+        for n in mol.nodes
+    }
+    min_pdb = min(present_resids)
+    max_pdb = max(present_resids)
+
+    # Find missing requested residues
+    missing = sorted(requested_resids - annotated_resids)
+
+    if missing:
+        # show only first 10 missing residues
+        missing_preview = missing[:10]
+        LOGGER.warning(
+            "Requested residues in -id-regions do not exist in the input "
+            "structure. {} residues are missing. Some missing residues: {} ... "
+            "Please select residues within the PDB range {}–{}.",
+            len(missing), missing_preview, min_pdb, max_pdb,
+            type="missing-flag",
+        )
 
 
 class AnnotateIDRs(Processor):
@@ -127,6 +176,7 @@ class AnnotateIDRs(Processor):
             return system
         LOGGER.info("Annotating disordered regions.", type="step")
         super().run_system(system)
+        _check_missing_idr_residues(system, self.id_regions)
 
         if any([molecule.meta.get('modified_cgsecstruct', False) for molecule in system.molecules]):
             supplementary_ss_seq = list(

--- a/vermouth/processors/annotate_idrs.py
+++ b/vermouth/processors/annotate_idrs.py
@@ -95,20 +95,28 @@ def _check_missing_idr_residues(system, id_regions):
     id_regions: list[dict]
         Parsed IDR regions, as stored in :attr:`AnnotateIDRs.id_regions`.
     """
-    # Rebuild requested_resids from id_regions
+    # A region without a chain specifier matches any chain.
     requested_resids = set()
     for region in id_regions:
+        chain = region.get('chain')
         for start, end in region['resids']:
             lo, hi = sorted((start, end))
-            requested_resids.update(range(lo, hi + 1))
+            requested_resids.update((chain, resid) for resid in range(lo, hi + 1))
 
-    # Collect annotated residues using TRUE PDB numbering
+    # Collect annotated residues using TRUE PDB numbering, as (chain, resid) pairs
     annotated_resids = {
-        mol.nodes[n]['stash']['resid']
+        (mol.nodes[n].get('chain'), mol.nodes[n]['stash']['resid'])
         for mol in system.molecules
         for n in mol.nodes
         if mol.nodes[n].get("cgidr")
     }
+
+    # A requested residue with no chain specifier matches any chain, so
+    # consider it found if the resid is annotated in any chain.
+    if any(chain is None for chain, _ in requested_resids):
+        annotated_resids |= {
+            (None, resid) for _, resid in annotated_resids
+        }
 
     # Collect ALL PDB residues present in the structure
     present_resids = {
@@ -131,6 +139,15 @@ def _check_missing_idr_residues(system, id_regions):
             "Please select residues within the PDB range {}–{}.",
             len(missing), missing_preview, min_pdb, max_pdb,
             type="missing-flag",
+        )
+
+    # Inform the user when a region has no chain specifier, since it will
+    # be applied to all chains in the structure.
+    if any(region.get('chain') is None for region in id_regions):
+        LOGGER.info(
+            "No chain specified in -id-regions. The regions will be applied "
+            "to all chains in the structure.",
+            type="general",
         )
 
 

--- a/vermouth/tests/test_annotate_idrs.py
+++ b/vermouth/tests/test_annotate_idrs.py
@@ -15,9 +15,15 @@
 """
 Test for the tune idp bonds processor.
 """
+import logging
+
 import pytest
 from vermouth.dssp import dssp
+from vermouth.forcefield import ForceField
+from vermouth.molecule import Molecule
 from vermouth.processors.annotate_idrs import AnnotateIDRs, parse_residues
+from vermouth.system import System
+from vermouth.tests.datafiles import FF_UNIVERSAL_TEST
 from vermouth.tests.helper_functions import create_sys_all_attrs, test_molecule
 
 @pytest.mark.parametrize('idr_regions, expected', [
@@ -172,3 +178,39 @@ def test_parse_disorder_resspec(resspec, expected):
         for key in i.keys():
             assert i[key] == j[key]
 
+def _make_idr_system():
+    """Build a minimal system with resids 1-4 in chain A."""
+    system = System(force_field=ForceField(FF_UNIVERSAL_TEST))
+    mol = Molecule(force_field=ForceField(FF_UNIVERSAL_TEST))
+    nodes = [
+        {'chain': 'A', 'resid': 1, 'stash': {'resid': 1}},
+        {'chain': 'A', 'resid': 2, 'stash': {'resid': 2}},
+        {'chain': 'A', 'resid': 3, 'stash': {'resid': 3}},
+        {'chain': 'A', 'resid': 4, 'stash': {'resid': 4}},
+    ]
+    mol.add_nodes_from(enumerate(nodes))
+    system.add_molecule(mol)
+    return system
+
+
+def test_missing_idr_regions_warn(caplog):
+    system = _make_idr_system()
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        AnnotateIDRs(id_regions=["9:11"]).run_system(system)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == 'WARNING'
+    assert 'missing' in caplog.records[0].getMessage().lower()
+    assert '3' in caplog.records[0].getMessage()
+
+
+def test_idr_regions_within_structure_no_warning(caplog):
+    system = _make_idr_system()
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        AnnotateIDRs(id_regions=["1:4"]).run_system(system)
+
+    assert caplog.records == []

--- a/vermouth/tests/test_annotate_idrs.py
+++ b/vermouth/tests/test_annotate_idrs.py
@@ -181,16 +181,23 @@ def test_parse_disorder_resspec(resspec, expected):
 def _make_idr_system():
     """
     Build a minimal system with resids 1-4 in chain A and resids 1-2 in chain B.
+
+    The stashed resids differ from the current resids to mimic a structure
+    that has been renumbered, so the tests exercise the use of the TRUE PDB 
+    numbering from the stash.
+
+    Chain A has a gap in the stashed numbering (10, 11, 14, 15) to mimic a
+    PDB structure with missing residues (12, 13).
     """
     system = System(force_field=ForceField(FF_UNIVERSAL_TEST))
     mol = Molecule(force_field=ForceField(FF_UNIVERSAL_TEST))
     nodes = [
-        {'chain': 'A', 'resid': 1, 'stash': {'resid': 1}},
-        {'chain': 'A', 'resid': 2, 'stash': {'resid': 2}},
-        {'chain': 'A', 'resid': 3, 'stash': {'resid': 3}},
-        {'chain': 'A', 'resid': 4, 'stash': {'resid': 4}},
-        {'chain': 'B', 'resid': 1, 'stash': {'resid': 1}},
-        {'chain': 'B', 'resid': 2, 'stash': {'resid': 2}},
+        {'chain': 'A', 'resid': 1, 'stash': {'resid': 10}},
+        {'chain': 'A', 'resid': 2, 'stash': {'resid': 11}},
+        {'chain': 'A', 'resid': 3, 'stash': {'resid': 14}},
+        {'chain': 'A', 'resid': 4, 'stash': {'resid': 15}},
+        {'chain': 'B', 'resid': 1, 'stash': {'resid': 20}},
+        {'chain': 'B', 'resid': 2, 'stash': {'resid': 21}},
     ]
     mol.add_nodes_from(enumerate(nodes))
     system.add_molecule(mol)
@@ -200,23 +207,23 @@ def _make_idr_system():
 @pytest.mark.parametrize('id_regions, expected_cgidr', [
     # All residues requested are present in the structure. A region without
     # a chain specifier annotates all chains.
-    (["1:4"], {('A', 1): True, ('A', 2): True, ('A', 3): True, ('A', 4): True,
-               ('B', 1): True, ('B', 2): True}),
+    (["10:11"], {('A', 10): True, ('A', 11): True, ('A', 14): False, ('A', 15): False,
+                 ('B', 20): False, ('B', 21): False}),
     # Only a subset of the requested residues is present.
-    (["3:9"], {('A', 1): False, ('A', 2): False, ('A', 3): True, ('A', 4): True,
-               ('B', 1): False, ('B', 2): False}),
+    (["10:15"], {('A', 10): True, ('A', 11): True, ('A', 14): True, ('A', 15): True,
+                 ('B', 20): False, ('B', 21): False}),
     # None of the requested residues are present.
-    (["9:11"], {('A', 1): False, ('A', 2): False, ('A', 3): False, ('A', 4): False,
-                ('B', 1): False, ('B', 2): False}),
+    (["30:32"], {('A', 10): False, ('A', 11): False, ('A', 14): False, ('A', 15): False,
+                 ('B', 20): False, ('B', 21): False}),
     # Multiple regions, one fully present and one fully absent.
-    (["1:2", "9:11"], {('A', 1): True, ('A', 2): True, ('A', 3): False, ('A', 4): False,
-                       ('B', 1): True, ('B', 2): True}),
+    (["10:11", "30:32"], {('A', 10): True, ('A', 11): True, ('A', 14): False, ('A', 15): False,
+                          ('B', 20): False, ('B', 21): False}),
     # Chain-specific region: only chain A is annotated.
-    (["A-1:4"], {('A', 1): True, ('A', 2): True, ('A', 3): True, ('A', 4): True,
-                 ('B', 1): False, ('B', 2): False}),
+    (["A-10:15"], {('A', 10): True, ('A', 11): True, ('A', 14): True, ('A', 15): True,
+                   ('B', 20): False, ('B', 21): False}),
     # Chain-specific region: only chain B is annotated.
-    (["B-1:2"], {('A', 1): False, ('A', 2): False, ('A', 3): False, ('A', 4): False,
-                 ('B', 1): True, ('B', 2): True}),
+    (["B-20:21"], {('A', 10): False, ('A', 11): False, ('A', 14): False, ('A', 15): False,
+                   ('B', 20): True, ('B', 21): True}),
 ])
 def test_annotate_idr_regions(id_regions, expected_cgidr):
     """
@@ -228,36 +235,37 @@ def test_annotate_idr_regions(id_regions, expected_cgidr):
     AnnotateIDRs(id_regions=id_regions).run_system(system)
 
     for node, (chain, resid) in enumerate(
-            [('A', 1), ('A', 2), ('A', 3), ('A', 4), ('B', 1), ('B', 2)]):
+            [('A', 10), ('A', 11), ('A', 14), ('A', 15), ('B', 20), ('B', 21)]):
         assert system.molecules[0].nodes[node].get('cgidr') == expected_cgidr[(chain, resid)]
 
 
 @pytest.mark.parametrize('id_regions, expected', [
     # All residues requested are present in the structure.
-    (["1:4"], False),
-    # Only a subset of the requested residues is present.
-    (["3:9"], True),
+    (["10:11"], False),
+    # Requested region spans the gap (12-13 missing).
+    (["10:15"], True),
     # None of the requested residues are present.
-    (["9:11"], True),
+    (["1:4"], True),
     # Multiple regions, one fully present and one fully absent.
-    (["1:2", "9:11"], True),
+    (["10:11", "30:32"], True),
+    # Multiple regions, all fully present.
+    (["10:11", "14:15"], False),
+    # Chain-specific multiple regions, all fully present.
+    (["A-10:11", "B-20:21"], False),
     # Chain-specific region that exists in the structure.
-    (["A-1:4"], False),
+    (["A-10:15"], True),
     # Chain-specific region that does not exist in the structure.
-    (["C-1:4"], True),
-    # Chain-specific region on chain B, which only has resids 1-2.
-    (["B-1:4"], True),
+    (["C-10:15"], True),
+    # Chain-specific region on chain B, which only has resids 20-21.
+    (["B-10:15"], True),
 ])
 def test_missing_idr_regions_warn(caplog, id_regions, expected):
     """
     Tests that a warning is logged when -id-regions requests residues
     that are not present in the input structure.
-
-    The structure contains resids 1-4 in chain A and resids 1-2 in chain B.
     """
     system = _make_idr_system()
 
-    caplog.clear()
     with caplog.at_level(logging.WARNING):
         AnnotateIDRs(id_regions=id_regions).run_system(system)
 
@@ -269,13 +277,26 @@ def test_missing_idr_regions_warn(caplog, id_regions, expected):
         assert caplog.records == []
 
 
+def test_empty_id_regions_warns(caplog):
+    """
+    Tests that a warning is logged when -id-regions is given but no
+    regions are provided, since no residues will be annotated.
+    """
+    system = _make_idr_system()
+
+    with caplog.at_level(logging.WARNING):
+        AnnotateIDRs(id_regions=[]).run_system(system)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == 'WARNING'
+
 @pytest.mark.parametrize('id_regions, expected', [
     # No chain specified: an info message is logged.
-    (["1:4"], True),
+    (["10:11"], True),
     # Chain specified: no info message.
-    (["A-1:4"], False),
+    (["A-10:15"], False),
     # Mixed: at least one region without a chain.
-    (["A-1:2", "3:4"], True),
+    (["A-10:11", "14:15"], True),
 ])
 def test_no_chain_specifier_info(caplog, id_regions, expected):
     """
@@ -284,7 +305,6 @@ def test_no_chain_specifier_info(caplog, id_regions, expected):
     """
     system = _make_idr_system()
 
-    caplog.clear()
     with caplog.at_level(logging.INFO):
         AnnotateIDRs(id_regions=id_regions).run_system(system)
 

--- a/vermouth/tests/test_annotate_idrs.py
+++ b/vermouth/tests/test_annotate_idrs.py
@@ -179,7 +179,9 @@ def test_parse_disorder_resspec(resspec, expected):
             assert i[key] == j[key]
 
 def _make_idr_system():
-    """Build a minimal system with resids 1-4 in chain A."""
+    """
+    Build a minimal system with resids 1-4 in chain A.
+    """
     system = System(force_field=ForceField(FF_UNIVERSAL_TEST))
     mol = Molecule(force_field=ForceField(FF_UNIVERSAL_TEST))
     nodes = [
@@ -194,6 +196,14 @@ def _make_idr_system():
 
 
 def test_missing_idr_regions_warn(caplog):
+    """
+    Tests that a warning is logged when -id-regions requests residues
+    that are not present in the input structure.
+
+    The structure only contains resids 1-4, so requesting 9:11 should
+    trigger exactly one WARNING that mentions how many residues are
+    missing (3).
+    """
     system = _make_idr_system()
 
     caplog.clear()
@@ -207,6 +217,13 @@ def test_missing_idr_regions_warn(caplog):
 
 
 def test_idr_regions_within_structure_no_warning(caplog):
+    """
+    Tests that no warning is logged when -id-regions requests residues
+    that are all present in the input structure.
+
+    The structure contains resids 1-4, so requesting 1:4 should not
+    trigger any warning.
+    """
     system = _make_idr_system()
 
     caplog.clear()

--- a/vermouth/tests/test_annotate_idrs.py
+++ b/vermouth/tests/test_annotate_idrs.py
@@ -180,7 +180,7 @@ def test_parse_disorder_resspec(resspec, expected):
 
 def _make_idr_system():
     """
-    Build a minimal system with resids 1-4 in chain A.
+    Build a minimal system with resids 1-4 in chain A and resids 1-2 in chain B.
     """
     system = System(force_field=ForceField(FF_UNIVERSAL_TEST))
     mol = Molecule(force_field=ForceField(FF_UNIVERSAL_TEST))
@@ -189,45 +189,107 @@ def _make_idr_system():
         {'chain': 'A', 'resid': 2, 'stash': {'resid': 2}},
         {'chain': 'A', 'resid': 3, 'stash': {'resid': 3}},
         {'chain': 'A', 'resid': 4, 'stash': {'resid': 4}},
+        {'chain': 'B', 'resid': 1, 'stash': {'resid': 1}},
+        {'chain': 'B', 'resid': 2, 'stash': {'resid': 2}},
     ]
     mol.add_nodes_from(enumerate(nodes))
     system.add_molecule(mol)
     return system
 
 
-def test_missing_idr_regions_warn(caplog):
+@pytest.mark.parametrize('id_regions, expected_cgidr', [
+    # All residues requested are present in the structure. A region without
+    # a chain specifier annotates all chains.
+    (["1:4"], {('A', 1): True, ('A', 2): True, ('A', 3): True, ('A', 4): True,
+               ('B', 1): True, ('B', 2): True}),
+    # Only a subset of the requested residues is present.
+    (["3:9"], {('A', 1): False, ('A', 2): False, ('A', 3): True, ('A', 4): True,
+               ('B', 1): False, ('B', 2): False}),
+    # None of the requested residues are present.
+    (["9:11"], {('A', 1): False, ('A', 2): False, ('A', 3): False, ('A', 4): False,
+                ('B', 1): False, ('B', 2): False}),
+    # Multiple regions, one fully present and one fully absent.
+    (["1:2", "9:11"], {('A', 1): True, ('A', 2): True, ('A', 3): False, ('A', 4): False,
+                       ('B', 1): True, ('B', 2): True}),
+    # Chain-specific region: only chain A is annotated.
+    (["A-1:4"], {('A', 1): True, ('A', 2): True, ('A', 3): True, ('A', 4): True,
+                 ('B', 1): False, ('B', 2): False}),
+    # Chain-specific region: only chain B is annotated.
+    (["B-1:2"], {('A', 1): False, ('A', 2): False, ('A', 3): False, ('A', 4): False,
+                 ('B', 1): True, ('B', 2): True}),
+])
+def test_annotate_idr_regions(id_regions, expected_cgidr):
+    """
+    Tests that the cgidr annotation is set on the residues that are
+    present in the structure and requested via -id-regions.
+    """
+    system = _make_idr_system()
+
+    AnnotateIDRs(id_regions=id_regions).run_system(system)
+
+    for node, (chain, resid) in enumerate(
+            [('A', 1), ('A', 2), ('A', 3), ('A', 4), ('B', 1), ('B', 2)]):
+        assert system.molecules[0].nodes[node].get('cgidr') == expected_cgidr[(chain, resid)]
+
+
+@pytest.mark.parametrize('id_regions, expected', [
+    # All residues requested are present in the structure.
+    (["1:4"], False),
+    # Only a subset of the requested residues is present.
+    (["3:9"], True),
+    # None of the requested residues are present.
+    (["9:11"], True),
+    # Multiple regions, one fully present and one fully absent.
+    (["1:2", "9:11"], True),
+    # Chain-specific region that exists in the structure.
+    (["A-1:4"], False),
+    # Chain-specific region that does not exist in the structure.
+    (["C-1:4"], True),
+    # Chain-specific region on chain B, which only has resids 1-2.
+    (["B-1:4"], True),
+])
+def test_missing_idr_regions_warn(caplog, id_regions, expected):
     """
     Tests that a warning is logged when -id-regions requests residues
     that are not present in the input structure.
 
-    The structure only contains resids 1-4, so requesting 9:11 should
-    trigger exactly one WARNING that mentions how many residues are
-    missing (3).
+    The structure contains resids 1-4 in chain A and resids 1-2 in chain B.
     """
     system = _make_idr_system()
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        AnnotateIDRs(id_regions=["9:11"]).run_system(system)
+        AnnotateIDRs(id_regions=id_regions).run_system(system)
 
-    assert len(caplog.records) == 1
-    assert caplog.records[0].levelname == 'WARNING'
-    assert 'missing' in caplog.records[0].getMessage().lower()
-    assert '3' in caplog.records[0].getMessage()
+    if expected:
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'WARNING'
+        assert 'missing' in caplog.records[0].getMessage().lower()
+    else:
+        assert caplog.records == []
 
 
-def test_idr_regions_within_structure_no_warning(caplog):
+@pytest.mark.parametrize('id_regions, expected', [
+    # No chain specified: an info message is logged.
+    (["1:4"], True),
+    # Chain specified: no info message.
+    (["A-1:4"], False),
+    # Mixed: at least one region without a chain.
+    (["A-1:2", "3:4"], True),
+])
+def test_no_chain_specifier_info(caplog, id_regions, expected):
     """
-    Tests that no warning is logged when -id-regions requests residues
-    that are all present in the input structure.
-
-    The structure contains resids 1-4, so requesting 1:4 should not
-    trigger any warning.
+    Tests that an info message is logged when a region has no chain
+    specifier, since it will be applied to all chains.
     """
     system = _make_idr_system()
 
     caplog.clear()
-    with caplog.at_level(logging.WARNING):
-        AnnotateIDRs(id_regions=["1:4"]).run_system(system)
+    with caplog.at_level(logging.INFO):
+        AnnotateIDRs(id_regions=id_regions).run_system(system)
 
-    assert caplog.records == []
+    info_records = [rec for rec in caplog.records if rec.levelname == 'INFO']
+    if expected:
+        assert any('all chains' in rec.getMessage() for rec in info_records)
+    else:
+        assert not any('all chains' in rec.getMessage() for rec in info_records)


### PR DESCRIPTION
According to #770, I'm including a warning that will tell users when they are trying to use parameters for an IDP/IDR region that it's not present in the input pdb.