### PR TITLE
Parser Utils extra exception info

### DIFF
--- a/vermouth/citation_parser.py
+++ b/vermouth/citation_parser.py
@@ -140,7 +140,7 @@ class BibTexDirector():
         str, str
             the field type, the field content
         """
-        for field, value in re.findall("(.*?)=(.*?)\}", entry_string):
+        for field, value in re.findall(r"(.*?)=(.*?)\}", entry_string):
             yield field.strip(",").strip(" "), value.strip("{").strip("}")
 
     def parse_entry(self, entry_string):

--- a/vermouth/dssp/dssp.py
+++ b/vermouth/dssp/dssp.py
@@ -282,7 +282,7 @@ def run_dssp(system, executable='dssp', savedir=None, defer_writing=True):
     except FileNotFoundError:
         raise DSSPError("DSSP executable not found. Perhaps MDTraj was not installed in the environment?")
 
-    match = re.search('\d+\.\d+\.\d+', process.stdout.decode('UTF8'))
+    match = re.search(r'\d+\.\d+\.\d+', process.stdout.decode('UTF8'))
     version = match[0] if match else None
     if not version:
         raise DSSPError('Failed to get DSSP version information.')

--- a/vermouth/parser_utils.py
+++ b/vermouth/parser_utils.py
@@ -223,7 +223,9 @@ class SectionLineParser(LineParser, metaclass=SectionParser):
         Parameters
         ----------
         line: str
+            The line content, before macro substitution.
         lineno: int
+            The line number, used to display accurate error messages.
 
         Returns
         -------
@@ -238,9 +240,12 @@ class SectionLineParser(LineParser, metaclass=SectionParser):
             method, kwargs = self.METH_DICT[tuple(self.section)]
             return method(self, line, lineno, **kwargs)
         except Exception as error:
-            raise IOError("Problems parsing line {}. I think it should be a "
-                          "'{}' line, but I can't parse it as such."
-                          "".format(lineno, self.section)) from error
+            raise IOError(
+                f"Problems parsing line {lineno} "
+                f"in section {self.section}:\n"
+                f"{line}\n"
+                f"{repr(error)}"
+            ) from error
 
     def parse_header(self, line, lineno=0):
         """
@@ -251,7 +256,7 @@ class SectionLineParser(LineParser, metaclass=SectionParser):
         Parameters
         ----------
         line: str
-        lineno: str
+        lineno: int
 
         Returns
         -------
@@ -310,6 +315,7 @@ class SectionLineParser(LineParser, metaclass=SectionParser):
         Parameters
         ----------
         line: str
+        lineno: int
         """
         line = deque(_tokenize(line))
         _parse_macro(line, self.macros)


### PR DESCRIPTION
Also see #776

This current PR so far was made with the intention to avoid breaking changes, it so far adds whatever info is readily available to parse error messages (I figured this already partly fixes the issue without the breaking change of adding paths to function signatures).

I also changed two regexes to raw strings, since there were warnings printed while using the martinize2 script (I hope this is ok)